### PR TITLE
Set buildroot branch name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "buildroot"]
 	path = buildroot
 	url = https://github.com/buildroot/buildroot.git
+	branch = 2023.02.x


### PR DESCRIPTION
allows "submodule update --remote" to refresh to current version