### PR TITLE
src/confd: add the ability to change MotD in cli

### DIFF
--- a/package/sysrepo-plugin-system/sysrepo-plugin-system.mk
+++ b/package/sysrepo-plugin-system/sysrepo-plugin-system.mk
@@ -22,6 +22,8 @@ define SYSREPO_PLUGIN_SYSTEM_INSTALL_YANG_MODELS
                 $(TARGET_DIR)/usr/share/yang/modules/sysrepo-plugin-system/iana-crypt-hash@2014-08-06.yang
 	$(INSTALL) -D -m 0644 $(@D)/yang/ietf-system@2014-08-06.yang \
                 $(TARGET_DIR)/usr/share/yang/modules/sysrepo-plugin-system/ietf-system@2014-08-06.yang
+	$(INSTALL) -D -m 0644 $(@D)/yang/infix-system@2014-08-06.yang \
+                $(TARGET_DIR)/usr/share/yang/modules/sysrepo-plugin-system/infix-system@2014-08-06.yang
 endef
 SYSREPO_PLUGIN_SYSTEM_POST_INSTALL_TARGET_HOOKS += SYSREPO_PLUGIN_SYSTEM_INSTALL_YANG_MODELS
 

--- a/src/confd/yang/infix-system@2014-08-06.yang
+++ b/src/confd/yang/infix-system@2014-08-06.yang
@@ -1,0 +1,20 @@
+module infix-system {
+	prefix "infix-sys";
+	yang-version 1.1;
+	namespace "urn:infix:params:xml:ns:yang:infix-system";
+
+	import ietf-system {
+		prefix "sys";
+	}
+
+	revision 2014-08-06 {
+		description "Initial revision.";
+	}
+
+	augment "/sys:system" {
+		leaf motd {
+			type string;
+			description "Set the MotD (Message of the Day), which is shown after login";
+		}
+	}
+}


### PR DESCRIPTION
# Pull Request
Not sure if this is even something we want? I did it mainly to learn and to test the work flow.
If this is indeed something we want then I intent to fix the duplication of the default value (in skel /etc/motd and in the confd C code).
I might also hook it into the `aug` framework, even tho it should never fail (TM) and "abort" seems to work as intended?

# Commit message
Add the ability to set and delete system MotD (Message Of The Day) using the cli.

So there's no staging concept (aug), if user issues "leave" the change takes immediate effect.

The default value is hard coded in two places, confd and the rootfs file /etc/motd. The intention is to fix this in upcoming patches.

Introduces:
exec> configure> set system motd STRING
exec> configure> delete system motd