### PR TITLE
Lock down actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,13 @@ name: Bob the Builder
 #    branches:
 #      - '*'
 on:
-  pull_request:
+  pull_request_review:
+    types: [submitted]
   workflow_dispatch:
 
 jobs:
   build:
+    if: github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch'
     name: Build ${{ matrix.platform }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           path: output/${{ steps.vars.outputs.tgz }}
   release:
+    if: github.repository == 'kernelkit/infix' && github.ref == 'refs/heads/main'
     name: Upload Latest Build
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since complete builds currently take over 2h to complete, we cannot start the existing build workflow on any event.

This PR locks down our current GitHub action in two ways:

 - Only allow (or attempt) upload of [latest build](https://github.com/kernelkit/infix/releases/tag/latest) from main repo and main branch
 - Start _Bob the Builder_ automatically on manual start (`workflow_dispatch`) or when a PR to main has been approved

> Separate workflows for validating YANG models and running unit tests to be added later.