### PR TITLE
Add basic user authentication to ietf system

### DIFF
--- a/src/confd/src/Makefile.am
+++ b/src/confd/src/Makefile.am
@@ -8,4 +8,4 @@ confd_plugin_la_CFLAGS  = $(augeas_CFLAGS) $(libite_CFLAGS) $(sysrepo_CFLAGS) $(
 confd_plugin_la_LIBADD  = $(augeas_LIBS)   $(libite_LIBS)   $(sysrepo_LIBS)
 confd_plugin_la_LDFLAGS = -module -avoid-version -shared
 confd_plugin_la_SOURCES = core.c core.h helpers.c helpers.h srx_module.c srx_module.h srx_val.c srx_val.h \
-			  ietf-system.c ietf-interfaces.c systemv.c
+			  ietf-system.c ietf-interfaces.c systemv.c systemv.h

--- a/src/confd/src/core.h
+++ b/src/confd/src/core.h
@@ -21,6 +21,7 @@
 #include <sysrepo/xpath.h>
 
 #include "helpers.h"
+#include "systemv.h"
 
 #ifndef HAVE_VASPRINTF
 int vasprintf(char **strp, const char *fmt, va_list ap);

--- a/src/confd/src/systemv.c
+++ b/src/confd/src/systemv.c
@@ -12,7 +12,7 @@
 /**
  * Reimplementation of system() without /bin/sh intermediary
  */
-int fsystemv(char **args, FILE *in, FILE *out, FILE *err)
+static int fsystemv(char **args, FILE *in, FILE *out, FILE *err)
 {
 	struct sigaction sa = { .sa_handler = SIG_IGN };
 	sigset_t oldmask;

--- a/src/confd/src/systemv.h
+++ b/src/confd/src/systemv.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef CONFD_SYSTEMV_H_
+#define CONFD_SYSTEMV_H_
+
+int systemv(char **args);
+int systemv_silent(char **args);
+
+#endif /* CONFD_SYSTEMV_H_ */


### PR DESCRIPTION
This PR introduces the ability to:
* Create or delete a UNIX user.
* Set or delete a UNIX user password.

The password needs to be hashed and in a UNIX shadow format, such as
`$ALG$SALT$HASH`. We want to avoid the handling of clear text
passwords as much as possible. In the meanwhile, passwords
can be generated in the infix shell using `mkpasswd`.

### CLI Examples

#### Add a user:
`configure> set system authentication user foo`

#### Delete a user:
`configure> delete system authentication user foo`

#### Set a user password:
`configure> set system authentication user foo password ...`

### "systemv" functions
This PR also exposes and uses existing "systemv" functions.