### PR TITLE
confd: add global event hook support

### DIFF
--- a/src/confd/src/core.c
+++ b/src/confd/src/core.c
@@ -5,6 +5,10 @@
 
 static struct confd confd;
 
+static uint32_t hook_prio = CB_PRIO_PASSIVE;
+static int num_changes;
+static int cur_change;
+
 static int startup_save_hook(sr_session_ctx_t *session, uint32_t sub_id, const char *module,
 	const char *xpath, sr_event_t event, unsigned request_id, void *priv)
 {
@@ -14,14 +18,41 @@ static int startup_save_hook(sr_session_ctx_t *session, uint32_t sub_id, const c
 	return SR_ERR_OK;
 }
 
-static int commit_done_hook(sr_session_ctx_t *session, uint32_t sub_id, const char *module,
+uint32_t core_hook_prio(void)
+{
+	return hook_prio--;
+}
+
+/*
+ * Run on UPDATE to see how many modules have changes in the inbound changeset
+ * Run on DONE, after the last module callback has run, to activate changes.
+ * For details, see https://github.com/sysrepo/sysrepo/issues/2188
+ */
+int core_commit_done(sr_session_ctx_t *session, uint32_t sub_id, const char *module,
 	const char *xpath, sr_event_t event, unsigned request_id, void *priv)
 {
-	/* No need to reload if the system is still bootstrapping. */
-	if (system("runlevel >/dev/null"))
+	switch (event) {
+	case SR_EV_UPDATE:
+		num_changes++;
+		return SR_ERR_OK;
+	case SR_EV_DONE:
+		cur_change++;
+		if (cur_change == num_changes)
+			break;
+		return SR_ERR_OK;
+	default:
+		ERROR("core_commit_done() should not be called with event %d", event);
+		return SR_ERR_SYS;
+	}
+
+	/* reset for next changeset */
+	num_changes = cur_change = 0;
+
+	/* skip reload in bootstrap, implicit reload in runlevel change */
+	if (systemf("runlevel >/dev/null 2>&1"))
 		return SR_ERR_OK;
 
-	if (system("initctl -nbq reload"))
+	if (systemf("initctl -nbq reload"))
 		return SR_ERR_SYS;
 
 	return SR_ERR_OK;
@@ -62,27 +93,13 @@ int sr_plugin_init_cb(sr_session_ctx_t *session, void **priv)
 
 	/* YOUR_INIT GOES HERE */
 
-	/* Set up hook to save startup-config to persisten backend store */
+	/* Set up hook to save startup-config to persistent backend store */
 	rc = sr_session_start(confd.conn, SR_DS_STARTUP, &startup);
 	if (rc)
 		goto err;
 
 	rc = sr_module_change_subscribe(startup, "ietf-system", "/ietf-system:system//.",
-					startup_save_hook, NULL, 0, SR_SUBSCR_PASSIVE | SR_SUBSCR_DONE_ONLY, &confd.sub);
-	if (rc) {
-		ERROR("failed setting up startup-config hook: %s", sr_strerror(rc));
-		goto err;
-	}
-
-	rc = sr_module_change_subscribe(session, "ietf-system", "/ietf-system:system//.",
-					commit_done_hook, NULL, 0, SR_SUBSCR_PASSIVE | SR_SUBSCR_DONE_ONLY, &confd.sub);
-	if (rc) {
-		ERROR("failed setting up startup-config hook: %s", sr_strerror(rc));
-		goto err;
-	}
-
-	rc = sr_module_change_subscribe(session, "ietf-interfaces", "/ietf-interfaces:interfaces//.",
-					commit_done_hook, NULL, 0, SR_SUBSCR_PASSIVE | SR_SUBSCR_DONE_ONLY, &confd.sub);
+		startup_save_hook, NULL, CB_PRIO_PASSIVE, SR_SUBSCR_PASSIVE | SR_SUBSCR_DONE_ONLY, &confd.sub);
 	if (rc) {
 		ERROR("failed setting up startup-config hook: %s", sr_strerror(rc));
 		goto err;

--- a/src/confd/src/core.h
+++ b/src/confd/src/core.h
@@ -78,7 +78,6 @@ int      core_startup_save (sr_session_ctx_t *, uint32_t, const char *, const ch
 static inline int register_change(sr_session_ctx_t *session, const char *module, const char *xpath,
 	int flags, sr_module_change_cb cb, void *arg, sr_subscription_ctx_t **sub)
 {
-	int hook_flags = SR_SUBSCR_UPDATE | SR_SUBSCR_DONE_ONLY | SR_SUBSCR_PASSIVE;
 	struct confd *confd = (struct confd *)arg;
 	int rc;
 
@@ -98,9 +97,9 @@ static inline int register_change(sr_session_ctx_t *session, const char *module,
 	 */
 	if (!flags) {
 		sr_module_change_subscribe(confd->session, module, xpath, core_commit_done, NULL,
-				core_hook_prio(), hook_flags, sub);
+				core_hook_prio(), SR_SUBSCR_PASSIVE, sub);
 		sr_module_change_subscribe(confd->startup, module, xpath, core_startup_save, NULL,
-				core_hook_prio(), hook_flags, sub);
+				core_hook_prio(), SR_SUBSCR_PASSIVE, sub);
 	}
 
 	return 0;

--- a/src/confd/src/core.h
+++ b/src/confd/src/core.h
@@ -57,8 +57,8 @@ static inline void print_val(sr_val_t *val)
 	if ((rc = register_oper(s, m, x, c, a, f, u)))		\
 		goto fail
 
-#define REGISTER_RPC(s,x,c,a,u)				\
-	if ((rc = register_rpc(s, x, c, a, u)))		\
+#define REGISTER_RPC(s,x,c,a,u)					\
+	if ((rc = register_rpc(s, x, c, a, u)))			\
 		goto fail
 
 struct confd {
@@ -76,21 +76,24 @@ int core_commit_done(sr_session_ctx_t *session, uint32_t sub_id, const char *mod
 	const char *xpath, sr_event_t event, unsigned request_id, void *priv);
 
 static inline int register_change(sr_session_ctx_t *session, const char *module, const char *xpath,
-			int flags, sr_module_change_cb cb, void *arg, sr_subscription_ctx_t **sub)
+	int flags, sr_module_change_cb cb, void *arg, sr_subscription_ctx_t **sub)
 {
-	int rc = sr_module_change_subscribe(session, module, xpath, cb, arg, CB_PRIO_PRIMARY, flags | SR_SUBSCR_DEFAULT, sub);
+	int hook_flags = SR_SUBSCR_UPDATE | SR_SUBSCR_DONE_ONLY | SR_SUBSCR_PASSIVE;
+	int rc = sr_module_change_subscribe(session, module, xpath, cb, arg,
+				CB_PRIO_PRIMARY, flags | SR_SUBSCR_DEFAULT, sub);
 	if (rc)
 		ERROR("failed subscribing to changes of %s: %s", xpath, sr_strerror(rc));
 	else if (!flags)
-		sr_module_change_subscribe(session, module, xpath, core_commit_done, NULL, core_hook_prio(),
-				SR_SUBSCR_UPDATE | SR_SUBSCR_DONE_ONLY | SR_SUBSCR_PASSIVE, sub);
+		sr_module_change_subscribe(session, module, xpath, core_commit_done, NULL,
+				core_hook_prio(), hook_flags, sub);
 	return rc;
 }
 
 static inline int register_oper(sr_session_ctx_t *session, const char *module, const char *xpath,
-			sr_oper_get_items_cb cb, void *arg, int flags, sr_subscription_ctx_t **sub)
+	sr_oper_get_items_cb cb, void *arg, int flags, sr_subscription_ctx_t **sub)
 {
-	int rc = sr_oper_get_subscribe(session, module, xpath, cb, arg, flags | SR_SUBSCR_DEFAULT, sub);
+	int rc = sr_oper_get_subscribe(session, module, xpath, cb, arg,
+				flags | SR_SUBSCR_DEFAULT, sub);
 	if (rc)
 		ERROR("failed subscribing to %s oper: %s", xpath, sr_strerror(rc));
 	return rc;


### PR DESCRIPTION
Refactor `register_change()` wrapper, for `sr_module_change_subscribe()`, with an additional twist of setting up a commit DONE event catcher.

This creates a global event hook that ensures we call `initctl reload` after all module callbacks have completed, regardless of the xpath and without having to have "shadow" subscriptions to all new modules being added to confd.

Based on on ideas from https://github.com/sysrepo/sysrepo/issues/2188