### PR TITLE
test: add functional example of how to test CLI auth

### DIFF
--- a/test/9pm-lab/cfg/run.yaml
+++ b/test/9pm-lab/cfg/run.yaml
@@ -1,0 +1,8 @@
+# Your computers prompt goes here
+prompt: "foobar"
+
+infix:
+  prompt: "infix"
+  hostname: "192.168.122.76"
+  username: "admin"
+  password: "admin"

--- a/test/9pm-lab/lib/infix.tcl
+++ b/test/9pm-lab/lib/infix.tcl
@@ -1,0 +1,56 @@
+namespace eval ::infix::cli {
+    proc exp_prompt { prompt } {
+        expect {
+            -re {Error: [^\r\n]+} {
+                9pm::output::fail "$expect_out(0,string)"
+                exp_continue -continue_timer
+            }
+            $prompt { }
+            default { 9pm::fatal 9pm::output::fail "Error, expecting prompt ($prompt)" }
+        }
+    }
+    proc start { node } {
+        9pm::cmd::start "cli"
+        expect {
+            "[dict get $node "prompt"]:exec>" { 9pm::output::debug "Infix CLI started" }
+            default { 9pm::fatal 9pm::output::fail "Error, starting Infix CLI" }
+        }
+
+    }
+    proc config { node } {
+        send "configure\r"
+        exp_prompt "[dict get $node "prompt"]:configure>"
+        9pm::output::debug "CLI entered configure mode"
+    }
+    proc leave { node } {
+        send "leave\r"
+        exp_prompt "[dict get $node "prompt"]:exec>"
+        9pm::output::debug "CLI left configure mode"
+    }
+    proc exit { node } {
+        send "exit\r"
+        9pm::cmd::finish
+        9pm::output::debug "CLI closed"
+    }
+    proc run { node cmd } {
+        expect *
+        send "$cmd\r"
+        expect {
+            -re {Error: [^\r\n]+} {
+                9pm::output::fail "$expect_out(0,string)"
+                exp_continue -continue_timer
+            }
+            {[Edit]} { }
+            default { 9pm::fatal 9pm::output::fail "Error, running $cmd" }
+        }
+        exp_prompt "[dict get $node "prompt"]:configure>"
+    }
+    proc run_code { node code} {
+        infix::cli::start $node
+        infix::cli::config $node
+        uplevel 1 $code
+        infix::cli::leave $node
+        9pm::output::debug "Code successfully executed in CLI"
+        infix::cli::exit $node
+    }
+}

--- a/test/9pm-lab/src/auth.tcl
+++ b/test/9pm-lab/src/auth.tcl
@@ -1,0 +1,79 @@
+#!/usr/bin/env tclsh
+
+package require 9pm
+source "[9pm::misc::get::script_path]/../lib/infix.tcl"
+
+9pm::output::plan 8
+
+set CNT 20
+set infix [dict get $9pm::conf::data "infix"]
+
+9pm::shell::open "target"
+9pm::ssh::connect $infix
+9pm::output::info "Connected to Infix"
+
+# TODO: Remove once admin is admin.
+send "su -l root\n"
+expect {
+    "root@[dict get $infix "prompt"]" {}
+    default { 9pm::fatal ::9pm::output::fail "Unable to su root" }
+}
+
+9pm::output::info "Creating $CNT users without password"
+infix::cli::run_code $infix {
+    for {set i 0} {$i < $CNT} {incr i} {
+        infix::cli::run $infix "set system authentication user user$i"
+    }
+}
+9pm::output::ok "Created $CNT new users"
+
+9pm::output::info "Checking that all $CNT users are in shadow"
+for {set i 0} {$i < $CNT} {incr i} {
+    9pm::cmd::execute "grep 'user$i:!:' /etc/shadow" 0
+}
+9pm::output::ok "All $CNT users are passwordless in shadow"
+
+9pm::output::info "Setting password for all $CNT users"
+infix::cli::run_code $infix {
+    for {set i 0} {$i < $CNT} {incr i} {
+        infix::cli::run $infix \
+            "set system authentication user user$i password \$1\$AxkhipBg\$fxSMhuY.3EQyrfJlKmEDN1"
+    }
+}
+9pm::output::ok "All $CNT users now have password"
+
+9pm::output::info "Checking that all $CNT users has password in shadow"
+for {set i 0} {$i < $CNT} {incr i} {
+    9pm::cmd::execute "grep 'user$i:\$1\$AxkhipBg\$fxSMhuY.3EQyrfJlKmEDN1:' /etc/shadow" 0
+}
+9pm::output::ok "All $CNT users has a password in shadow"
+
+9pm::output::info "Removing password for $CNT users"
+infix::cli::run_code $infix {
+    for {set i 0} {$i < $CNT} {incr i} {
+        infix::cli::run $infix \
+            "delete system authentication user user$i password"
+    }
+}
+9pm::output::ok "All $CNT users now lack password"
+
+9pm::output::info "Checking that all $CNT users passwords are gone in shadow"
+for {set i 0} {$i < $CNT} {incr i} {
+    9pm::cmd::execute "grep 'user$i:!:' /etc/shadow" 0
+}
+9pm::output::ok "All $CNT users are passwordless in shadow"
+
+9pm::output::info "Removing $CNT users"
+infix::cli::run_code $infix {
+    for {set i 0} {$i < $CNT} {incr i} {
+        infix::cli::run $infix \
+            "delete system authentication user user$i"
+    }
+}
+9pm::output::ok "All $CNT users now lack password"
+
+9pm::output::info "Checking that all users are removed from shadow"
+for {set i 0} {$i < $CNT} {incr i} {
+    9pm::cmd::execute "grep 'user$i:' /etc/shadow" 1
+}
+9pm::output::ok "All $CNT users are removed from shadow"


### PR DESCRIPTION
This test is based on the 9pm framework, which supports execution of test-cases written in any language. This test is written in tcl/expect with help from the 9pm expect library. It's what I used to test during development of the Infix basic authentication support.

The aim of this patch is to serve as an example of how the interactiveness of the 9pm-expect library can be used.

9pm framework code is here:
https://github.com/rical/9pm