### PR TITLE
Add admin user to factory config

### DIFF
--- a/board/common/rootfs/lib/infix/cfg-bootstrap
+++ b/board/common/rootfs/lib/infix/cfg-bootstrap
@@ -10,7 +10,8 @@ PATH=/lib/infix/factory:$PATH
 gen-hostname   >$FACTORY_D/20-auto-hostname.json
 gen-interfaces >$FACTORY_D/20-auto-interfaces.json
 
-jq -s add $(find $FACTORY_D -name '*.json') >$CFG_D/auto-factory-config.cfg
+jq -s 'reduce .[] as $item ({}; . * $item)' $(find $FACTORY_D -name '*.json') \
+    >$CFG_D/auto-factory-config.cfg
 
 # TODO: Look for statically defined factory-config, based on the
 # system's product ID.

--- a/board/netconf/rootfs/etc/auto-factory.d/10-authentication.json
+++ b/board/netconf/rootfs/etc/auto-factory.d/10-authentication.json
@@ -1,0 +1,12 @@
+{
+  "ietf-system:system": {
+    "authentication": {
+      "user": [
+        {
+          "name": "admin",
+          "password": "$6$bKPp6xu45L1cmp70$fcwDhGZct4q8LxwPASf9iVHyWqnklcdjeYi/SupLo1K9nb.aAQUz48.3qTcW38XL6gQzfHyGoyeDG2orjPUwm1"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add a user `admin` with password `admin` to the generated factory config.

This is a work in progress. A user can login using these credentials but there's still some work needed for NETCONF functionality. In the meantime, developers can continue using `root`.

The goal here is to disable the password for `root`, thus disallowing "root" login and make root own all system processes. 