### PR TITLE
Export qemu.sh and qemu/Config.in to release tarball

### DIFF
--- a/board/common/post-image.sh
+++ b/board/common/post-image.sh
@@ -52,3 +52,7 @@ fi
 
 # For use outside of the build system, e.g., Qeneth
 ln -sf rootfs.squashfs "$BINARIES_DIR/$NAME$(ver).img"
+
+# Create the necessary files to run Qemu from a build
+grep QEMU_ "$BR2_CONFIG" | sed 's/"images[\/]*/"/g' > "/$BINARIES_DIR/qemu.cfg"
+cp "$BR2_EXTERNAL_INFIX_PATH/qemu/qemu.sh" "/$BINARIES_DIR/"

--- a/board/common/post-image.sh
+++ b/board/common/post-image.sh
@@ -55,4 +55,6 @@ ln -sf rootfs.squashfs "$BINARIES_DIR/$NAME$(ver).img"
 
 # Create the necessary files to run Qemu from a build
 grep QEMU_ "$BR2_CONFIG" | sed 's/"images[\/]*/"/g' > "/$BINARIES_DIR/qemu.cfg"
+sed 's/"images[\/]*/"/g
+     s/comment "System setup"/mainmenu "Qemu Settings"/g' < "$BR2_EXTERNAL_INFIX_PATH/qemu/Config.in" > "/$BINARIES_DIR/Config.in"
 cp "$BR2_EXTERNAL_INFIX_PATH/qemu/qemu.sh" "/$BINARIES_DIR/"

--- a/qemu/qemu.sh
+++ b/qemu/qemu.sh
@@ -184,7 +184,13 @@ if [ "$1" ]; then
     cd $1
 fi
 
-load_qemucfg .config
+if [ -f .config ]; then
+    # 'make run' from output/ or build directory
+    load_qemucfg .config
+else
+    # ./qemu.sh from output/images/ or release tarball
+    load_qemucfg qemu.cfg
+fi
 
 echo "Starting Qemu  ::  Ctrl-a x -- exit | Ctrl-a c -- toggle console/monitor"
 line=$(stty -g)


### PR DESCRIPTION
This changeset makes it possible for a user to easily test their Infix build in Qemu.

The qemu.sh script has been extended with a `-c` flag to start the kconfig-frontends tool `kconfig-mconf` with a slightly modified qemu/Config.in 

To test: 

     sudo apt install kconfig-frontends

