### PR TITLE
Add NETCONF support for Linux bridge native VLANs

### DIFF
--- a/src/confd/src/confd/dagger.h
+++ b/src/confd/src/confd/dagger.h
@@ -3,8 +3,11 @@
 
 #include <limits.h>
 #include <stdio.h>
+#include "core.h"
 
 struct dagger {
+	sr_session_ctx_t *session;
+
 	int current, next;
 	FILE *next_fp;
 

--- a/src/confd/yang/infix-if-bridge@2023-05-31.yang
+++ b/src/confd/yang/infix-if-bridge@2023-05-31.yang
@@ -87,6 +87,18 @@ submodule infix-if-bridge {
         if-feature "vlan-filtering";
         description "A VLAN filtering bridge has at least one VLAN.";
 
+	leaf proto {
+	  type dot1q-types:dot1q-tag-type;
+	  default dot1q-types:c-vlan;
+	  description "Standard (1Q/c-vlan) or provider (1ad/s-vlan) bridge.";
+	}
+
+	leaf pvid {
+	  type dot1q-types:vlanid;
+	  default 1;
+	  description "Default primary VID for untagged frames, default: 1.";
+	}
+
         list vlan {
           key "vid";
           description "List of VLANs associated with the Bridge.";

--- a/src/confd/yang/infix-if-bridge@2023-05-31.yang
+++ b/src/confd/yang/infix-if-bridge@2023-05-31.yang
@@ -96,12 +96,15 @@ submodule infix-if-bridge {
             description "The VLAN identifier to which this entry applies.";
           }
 
-          leaf-list untagged-ports {
+          leaf-list untagged {
             type if:interface-ref;
             description "The set of ports in the untagged set for VLAN.";
           }
 
-          leaf-list tagged-ports {
+          leaf-list tagged {
+	    must "not(../untagged[contains(., current())])" {
+	      error-message "Cannot be an untagged port at the same time.";
+	    }
             type if:interface-ref;
             description "The set of ports in the tagged set for VLAN.";
           }

--- a/test/case/infix_interfaces/all.yaml
+++ b/test/case/infix_interfaces/all.yaml
@@ -2,3 +2,4 @@
 - case: bridge_basic.py
 - case: bridge_veth.py
 - case: dual_bridge.py
+- case: bridge_vlan.py

--- a/test/case/infix_interfaces/bridge_vlan.py
+++ b/test/case/infix_interfaces/bridge_vlan.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+#
+#                vlan10 IP:10.0.0.2
+#                /
+# PING -->     br0  <-- VLAN filtering enabled
+#             /
+#   PC ---- e0
+#
+
+import infamy
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("1x2"))
+        target = env.attach("target", "mgmt")
+
+    with test.step("Configure single vlan-filtering bridge with vlan10 subinterface @ IP 10.0.0.2"):
+        _, tport = env.ltop.xlate("target", "data")
+
+        target.put_config_dict("ietf-interfaces", {
+            "interfaces": {
+                "interface": [
+                    {
+                        "name": "br0",
+                        "type": "iana-if-type:bridge",
+                        "enabled": True,
+                        "bridge": {
+                            "vlans": {
+                                "pvid": 4094,
+                                "vlan": [
+                                    {
+                                        "vid": 10,
+                                        "untagged": [ tport ],
+                                        "tagged":   [ "br0" ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": "vlan10",
+                        "type": "iana-if-type:l2vlan",
+                        "enabled": True,
+                        "parent-interface": "br0",
+                        "encapsulation": {
+                            "dot1q-vlan": {
+                                "outer-tag": {
+                                    "tag-type": "ieee802-dot1q-types:c-vlan",
+                                    "vlan-id": 10,
+                                }
+                            }
+                        },
+                        "ipv4": {
+                            "address": [
+                                {
+                                    "ip": "10.0.0.2",
+                                    "prefix-length": 24,
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": tport,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 10,
+                            "bridge": "br0"
+                        }
+                    },
+                ]
+            }
+        })
+
+    with test.step("Ping vlan10 subinterface 10.0.0.2 from host:data with IP 10.0.0.1"):
+        _, hport = env.ltop.xlate("host", "data")
+
+        with infamy.IsolatedMacVlan(hport) as ns:
+            pingtest = ns.runsh("""
+            set -ex
+
+            ip link set iface up
+            ip addr add 10.0.0.1/24 dev iface
+
+            ping -c1 -w5 10.0.0.2 || exit 1
+            """)
+
+        if pingtest.returncode:
+            print(pingtest.stdout)
+            test.fail()
+
+    test.succeed()


### PR DESCRIPTION

Example:

```
  interface br0 {
    type bridge;
    enabled true;
    bridge {
      vlans {
        pvid 4094;
        vlan 10 {
          untagged e2;
          tagged br0;
        }
      }
    }
  }
```