### PR TITLE
confd: fix memory leak in lydx_new_path()

### DIFF
--- a/src/confd/src/confd/ietf-system.c
+++ b/src/confd/src/confd/ietf-system.c
@@ -138,7 +138,6 @@ static int clock_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *modu
 	const struct ly_ctx *ctx;
 	char curtime[64];
 	time_t now, boot;
-	int first = 1;
 	int rc;
 
 	ctx = sr_acquire_context(sr_session_get_connection(session));
@@ -153,9 +152,9 @@ static int clock_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *modu
 	}
 	fmtime(now, curtime, sizeof(curtime));
 
-	if ((rc = lydx_new_path(ctx, parent, &first, CLOCK_PATH_, "boot-datetime", boottime)))
+	if ((rc = lydx_new_path(ctx, parent, CLOCK_PATH_, "boot-datetime", boottime)))
 		goto fail;
-	if ((rc = lydx_new_path(ctx, parent, &first, CLOCK_PATH_, "current-datetime", curtime)))
+	if ((rc = lydx_new_path(ctx, parent, CLOCK_PATH_, "current-datetime", curtime)))
 		goto fail;
 
 	if (rc) {
@@ -173,18 +172,17 @@ static int platform_cb(sr_session_ctx_t *session, uint32_t sub_id, const char *m
 		       struct lyd_node **parent, void *priv)
 {
 	const struct ly_ctx *ctx;
-	int first = 1;
 	int rc;
 
 	ctx = sr_acquire_context(sr_session_get_connection(session));
 
-	if ((rc = lydx_new_path(ctx, parent, &first, PLATFORM_PATH_, "os-name", os)))
+	if ((rc = lydx_new_path(ctx, parent, PLATFORM_PATH_, "os-name", os)))
 		goto fail;
-	if ((rc = lydx_new_path(ctx, parent, &first, PLATFORM_PATH_, "os-release", rel)))
+	if ((rc = lydx_new_path(ctx, parent, PLATFORM_PATH_, "os-release", rel)))
 		goto fail;
-	if ((rc = lydx_new_path(ctx, parent, &first, PLATFORM_PATH_, "os-version", ver)))
+	if ((rc = lydx_new_path(ctx, parent, PLATFORM_PATH_, "os-version", ver)))
 		goto fail;
-	if ((rc = lydx_new_path(ctx, parent, &first, PLATFORM_PATH_, "machine", sys)))
+	if ((rc = lydx_new_path(ctx, parent, PLATFORM_PATH_, "machine", sys)))
 		goto fail;
 
 	if (rc) {

--- a/src/confd/src/lib/lyx.c
+++ b/src/confd/src/lib/lyx.c
@@ -176,7 +176,7 @@ const char *lydx_get_attrf(struct lyd_node *sibling, const char *namefmt, ...)
 	return val;
 }
 
-int lydx_new_path(const struct ly_ctx *ctx, struct lyd_node **parent, int *first,
+int lydx_new_path(const struct ly_ctx *ctx, struct lyd_node **parent,
 		  char *xpath_base, char *node, const char *fmt, ...)
 {
 	char xpath[strlen(xpath_base) + strlen(node) + 2];
@@ -198,14 +198,9 @@ int lydx_new_path(const struct ly_ctx *ctx, struct lyd_node **parent, int *first
 	vsnprintf(val, len, fmt, ap);
 	va_end(ap);
 
-	DEBUG("Setting first:%d xpath %s to %s", *first, xpath, val);
+	DEBUG("Setting xpath %s to %s", xpath, val);
 
-	if (*first)
-		rc = lyd_new_path(NULL, ctx, xpath, val, 0, parent);
-	else
-		rc = lyd_new_path(*parent, NULL, xpath, val, 0, NULL);
-
-	*first = 0;
+	rc = lyd_new_path(*parent, NULL, xpath, val, 0, NULL);
 	if (rc)
 		ERROR("Failed building data tree, xpath %s, libyang error %d: %s",
 		      xpath, rc, ly_errmsg(ctx));

--- a/src/confd/src/lib/lyx.h
+++ b/src/confd/src/lib/lyx.h
@@ -45,9 +45,9 @@ const char *lydx_get_vattrf(struct lyd_node *sibling, const char *namefmt, va_li
 const char *lydx_get_attrf(struct lyd_node *sibling, const char *namefmt, ...)
 	__attribute__ ((format (printf, 2, 3)));
 
-int lydx_new_path(const struct ly_ctx *ctx, struct lyd_node **parent, int *first, char *xpath_base,
+int lydx_new_path(const struct ly_ctx *ctx, struct lyd_node **parent, char *xpath_base,
 		  char *node, const char *fmt, ...)
-	__attribute__ ((format (printf, 6, 7)));
+	__attribute__ ((format (printf, 5, 6)));
 
 static inline int lydx_is_enabled(struct lyd_node *parent, const char *name)
 {

--- a/src/confd/src/statd/core.c
+++ b/src/confd/src/statd/core.c
@@ -51,7 +51,7 @@ static json_t *get_ip_link_json(char *ifname)
 }
 
 static int add_ip_link_data(const struct ly_ctx *ctx, struct lyd_node **parent,
-			    char *xpath, json_t *iface, int *first)
+			    char *xpath, json_t *iface)
 {
 	json_t *j_val;
 	char *val;
@@ -63,7 +63,7 @@ static int add_ip_link_data(const struct ly_ctx *ctx, struct lyd_node **parent,
 		return SR_ERR_SYS;
 	}
 
-	err = lydx_new_path(ctx, parent, first, xpath, "if-index", "%lld",
+	err = lydx_new_path(ctx, parent, xpath, "if-index", "%lld",
 			    json_integer_value(j_val));
 	if (err) {
 		ERROR("Error adding 'if-index' to data tree, libyang error %d", err);
@@ -82,7 +82,7 @@ static int add_ip_link_data(const struct ly_ctx *ctx, struct lyd_node **parent,
 
 	to_lowercase(val);
 
-	err = lydx_new_path(ctx, parent, first, xpath, "oper-status", val);
+	err = lydx_new_path(ctx, parent, xpath, "oper-status", val);
 	if (err) {
 		ERROR("Error adding 'oper-status' to data tree, libyang error %d", err);
 		free(val);
@@ -98,7 +98,6 @@ static int add_ip_link(const struct ly_ctx *ctx, struct lyd_node **parent, char 
 	char xpath[XPATH_MAX] = {};
 	json_t *j_root;
 	json_t *j_iface;
-	int first = 1;
 	int err;
 
 	j_root = get_ip_link_json(ifname);
@@ -117,7 +116,7 @@ static int add_ip_link(const struct ly_ctx *ctx, struct lyd_node **parent, char 
 	snprintf(xpath, sizeof(xpath), "%s/interface[name='%s']",
 		 XPATH_IFACE_BASE, ifname);
 
-	err = add_ip_link_data(ctx, parent, xpath, j_iface, &first);
+	err = add_ip_link_data(ctx, parent, xpath, j_iface);
 	if (err) {
 		ERROR("Error adding ip-link info for %s", ifname);
 		json_decref(j_root);


### PR DESCRIPTION
# Disclaimer 
This might break something. **Please test your use case**.
I didn't find any need for the "first" concept at all. I have tested to query the operational status for both ietf-system (confd) and ietf-interfaces (statd). Sysrepo is still able to report operational status in the same manner as before and the memory leak is fixed.

Here's what I used to test this:
```sysrepocfg -X -d operational -m ietf-system```
```sysrepocfg -X -d operational -m ietf-interfaces```

# Patch
Prior to this patch, every new call to lydx_new_path() where "first" was set to 1 resulted in a memory leak of 72 bytes. Typically at least once for each sysrepo query.

The memory was allocated deep down in the lyd library, but as the parent node wasn't set (NULL) it wasn't found by sysrepo when cleaning up.

**In this patch we mitigate this by simply removing the "first" concept, as it doesn't appear to be needed.**