### PR TITLE
cli: rpc commands for reboot/poweroff and set datetime

### DIFF
--- a/src/klinfix/xml/infix.xml
+++ b/src/klinfix/xml/infix.xml
@@ -34,6 +34,10 @@
     <ACTION sym="STRING"/>
   </PTYPE>
 
+  <PTYPE name="GETSTR">
+    <ACTION sym="STRING"/>
+  </PTYPE>
+
   <PTYPE name="PLINE_SET">
     <COMPL>
       <ACTION sym="srp_compl@sysrepo"/>
@@ -121,7 +125,17 @@
       <ACTION sym="klix_copy@klinfix"/>
     </COMMAND>
 
+    <COMMAND name="set" help="Set" mode="switch">
+      <COMMAND name="datetime" help="Set current date and time">
+	<PARAM name="current-datetime" ptype="/GETSTR" help="yyyy-mm-ddThh:mm:ss(Z|+/-hh:mm)"/>
+	<ACTION sym="klix_rpc@klinfix">/ietf-system:set-current-datetime</ACTION>
+      </COMMAND>
+    </COMMAND>
+
     <COMMAND name="show" help="Show" mode="switch">
+      <COMMAND name="datetime" help="Show current date and time">
+	<ACTION sym="script">date -Isec</ACTION>
+      </COMMAND>
       <COMMAND name="running-config" help="Show running-config">
 	<ACTION sym="srp_show_running@sysrepo"/>
       </COMMAND>

--- a/src/klinfix/xml/infix.xml
+++ b/src/klinfix/xml/infix.xml
@@ -93,11 +93,11 @@
     </PROMPT>
 
     <COMMAND name="poweroff" help="Poweroff system (system policy may yield reboot)">
-      <ACTION sym="script">poweroff</ACTION>
+      <ACTION sym="klix_rpc@klinfix" ptype="STRING">/ietf-system:system-shutdown</ACTION>
     </COMMAND>
 
     <COMMAND name="reboot" help="Reboot system">
-      <ACTION sym="script">reboot</ACTION>
+      <ACTION sym="klix_rpc@klinfix" ptype="STRING">/ietf-system:system-restart</ACTION>
     </COMMAND>
 
     <COMMAND name="shell" help="Enter system shell">


### PR DESCRIPTION
This patch set adds RPC commands to the CLI.  A generic function for RPCs is added, along with commands for reboot and poweroff, that replace the existing ones.  A `set datetime` command is also added, along with a `show datetime` that display output in the same format as the `set` command requires.

