### PR TITLE
linux: add loopback carrier for operstate up

### DIFF
--- a/src/confd/src/confd/ietf-interfaces.c
+++ b/src/confd/src/confd/ietf-interfaces.c
@@ -1021,7 +1021,7 @@ static sr_error_t netdag_gen_iface(struct dagger *net,
 	/* Bring interface back up, if enabled */
 	attr = lydx_get_cattr(cif, "enabled");
 	if (!attr || !strcmp(attr, "true"))
-		fprintf(ip, "link set dev %s up\n", ifname);
+		fprintf(ip, "link set dev %s up state up\n", ifname);
 
 	err = err ? : netdag_gen_sysctl(net, dif);
 


### PR DESCRIPTION
This is a proposal to fix the issue of loopback having operstate UNKNOWN, which otherwise propagates over NETCONF as well.

See separate discussion thread in Projects.