### PR TITLE
Bridge vlan forwarding

### DIFF
--- a/board/common/qemu/qemu.sh
+++ b/board/common/qemu/qemu.sh
@@ -251,7 +251,7 @@ generate_dot()
 
     hostports="<qtap0> qtap0"
     targetports="<e0> e0"
-    edges="host:qtap0 -- target:e0;"
+    edges="host:qtap0 -- target:e0 [kind=mgmt];"
     for tap in $(seq 1 $(($CONFIG_QEMU_NET_TAP_N - 1))); do
 	hostports="$hostports | <qtap$tap> qtap$tap "
 	targetports="$targetports | <e$tap> e$tap "

--- a/test/case/infix_interfaces/all.yaml
+++ b/test/case/infix_interfaces/all.yaml
@@ -4,4 +4,6 @@
 - case: dual_bridge.py
 - case: bridge_vlan.py
 - case: ipv4_autoconf.py
-
+- case: bridge_fwd_sgl_dut.py
+- case: bridge_fwd_dual_dut.py
+- case: bridge_vlan_separation.py

--- a/test/case/infix_interfaces/bridge_fwd_dual_dut.py
+++ b/test/case/infix_interfaces/bridge_fwd_dual_dut.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+#    ,-------------------------------------,       ,-------------------------------------,       
+#    |                          dut1:data2 |       | dut2:data2                          | 
+#    |                      br0  ----------|-------|---------  br0                       |  
+#    |                     /   \           |       |          /   \                      | 
+#    |dut1:mgmt  dut1:data0     dut1:data1 |       | dut2:data0    dut2:data1  dut2:mgmt | 
+#    '-------------------------------------'       '-------------------------------------'
+#        |                |     |                            |     |                 | 
+#        |                |     |                            |     |                 |
+# ,-----------------------------------------------------------------------------------------,
+# |  host:mgmt0  host:data0     host:data1          host:data2     host:data3   host:mgmt1  |
+# |                             [10.0.0.2]          [10.0.0.3]     [10.0.0.4]               |
+# |                               (ns11)              (ns20)         (ns21)                 |
+# |                                                                                         |
+# |                                        [ HOST ]                                         |
+# '-----------------------------------------------------------------------------------------'
+
+import infamy
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("2x4"))
+        dut1 = env.attach("dut1", "mgmt")
+        dut2 = env.attach("dut2", "mgmt")
+
+    with test.step("Configure a bridge with triple physical port"):
+        _, tport10 = env.ltop.xlate("dut1", "data0")
+        _, tport11 = env.ltop.xlate("dut1", "data1")
+        _, tport12 = env.ltop.xlate("dut1", "data2")
+        _, tport20 = env.ltop.xlate("dut2", "data0")
+        _, tport21 = env.ltop.xlate("dut2", "data1")
+        _, tport22 = env.ltop.xlate("dut2", "data2")
+
+        dut1.put_config_dict("ietf-interfaces", {
+            "interfaces": {
+                "interface": [
+                    {
+                        "name": "br0",
+                        "type": "iana-if-type:bridge",
+                        "enabled": True,
+                        "bridge": {
+                            "vlans": {
+                                "vlan": [
+                                    {
+                                        "vid": 10,
+                                        "untagged": [ tport10, tport11 ],
+                                        "tagged":   [ "br0", tport12 ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": tport10,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 10,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport11,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 10,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport12,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "bridge": "br0",
+                        }
+                    }
+                ]
+            }
+        })
+
+        dut2.put_config_dict("ietf-interfaces", {
+            "interfaces": {
+                "interface": [
+                    {
+                        "name": "br0",
+                        "type": "iana-if-type:bridge",
+                        "enabled": True,
+                        "bridge": {
+                            "vlans": {
+                                "vlan": [
+                                    {
+                                        "vid": 10,
+                                        "untagged": [ tport20, tport21 ],
+                                        "tagged":   [ "br0", tport22 ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": tport20,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 10,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport21,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 10,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport22,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "bridge": "br0",
+                        }
+                    }
+                ]
+            }
+        })
+
+    with test.step("Ping host:data20 [10.0.0.3] and host:data21 [10.0.0.4]"\
+                   "from host:data11 [10.0.0.2]"):
+        
+        _, hport11 = env.ltop.xlate("host", "data11")
+        _, hport20 = env.ltop.xlate("host", "data20")
+        _, hport21 = env.ltop.xlate("host", "data21")
+
+        with infamy.IsolatedMacVlan(hport11) as ns11, \
+             infamy.IsolatedMacVlan(hport20) as ns20, \
+             infamy.IsolatedMacVlan(hport21) as ns21:
+
+            ns11.addip("10.0.0.2")
+            ns20.addip("10.0.0.3")
+            ns21.addip("10.0.0.4")
+
+            ns11.must_reach("10.0.0.3")
+            ns11.must_reach("10.0.0.4")
+                    
+    test.succeed()

--- a/test/case/infix_interfaces/bridge_fwd_sgl_dut.py
+++ b/test/case/infix_interfaces/bridge_fwd_sgl_dut.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# ,-----------------------------------------,       
+# |                                         | 
+# |                          br0            |  
+# |                         /   \           | 
+# | target:mgmt    tgt:data0     tgt:data1  | 
+# '-----------------------------------------'
+#         |                |     |            
+#         |                |     |           
+# ,------------------------------------------,
+# |   host:mgmt   host:data0     host:data1  |
+# |               [10.0.0.1]     [10.0.0.2]  |
+# |                  (ns0)         (ns1)     |
+# |                                          |
+# |                 [ HOST ]                 |
+# '------------------------------------------'
+
+import infamy
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("1x3"))
+        target = env.attach("target", "mgmt")
+
+    with test.step("Configure a bridge with dual physical port"):
+        _, tport0 = env.ltop.xlate("target", "data0")
+        _, tport1 = env.ltop.xlate("target", "data1")
+
+        target.put_config_dict("ietf-interfaces", {
+            "interfaces": {
+                "interface": [
+                    {
+                        "name": "br0",
+                        "type": "iana-if-type:bridge",
+                        "enabled": True,
+                    },
+                    {
+                        "name": tport0,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport1,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "bridge": "br0"
+                        }
+                    }
+                ]
+            }
+        })
+
+    with test.step("Ping host:data1 [10.0.0.2] from host:data0 [10.0.0.1]"):
+        _, hport0 = env.ltop.xlate("host", "data0")
+        _, hport1 = env.ltop.xlate("host", "data1")
+
+        with infamy.IsolatedMacVlan(hport0) as ns0, \
+             infamy.IsolatedMacVlan(hport1) as ns1 :
+            
+            ns1.addip("10.0.0.2")
+            ns0.addip("10.0.0.1")
+
+            ns0.must_reach("10.0.0.2") 
+            
+    test.succeed()

--- a/test/case/infix_interfaces/bridge_vlan_separation.py
+++ b/test/case/infix_interfaces/bridge_vlan_separation.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+#    ,-------------------------------------,       ,-------------------------------------,       
+#    |                          dut1:data2 |       | dut2:data2                          | 
+#    |                      br0  ----------|-------|---------  br0                       |  
+#    |                     /   \           |       |          /   \                      | 
+#    |dut1:mgmt  dut1:data0     dut1:data1 |       | dut2:data0    dut2:data1  dut2:mgmt | 
+#    '-------------------------------------'       '-------------------------------------'
+#        |                |     |                            |     |                 | 
+#        |                |     |                            |     |                 |
+# ,-----------------------------------------------------------------------------------------,
+# |  host:mgmt0  host:data0     host:data1          host:data2     host:data3   host:mgmt1  |
+# |              [10.0.0.1]     [10.0.0.2]          [10.0.0.3]     [10.0.0.4]               |
+# |                (ns10)         (ns11)              (ns20)         (ns21)                 |
+# |                                                                                         |
+# |                                        [ HOST ]                                         |
+# '-----------------------------------------------------------------------------------------'          
+
+import infamy
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("2x4"))
+        dut1 = env.attach("dut1", "mgmt")
+        dut2 = env.attach("dut2", "mgmt")
+
+    with test.step("Configure a bridge with triple physical port"):
+        _, tport10 = env.ltop.xlate("dut1", "data0")
+        _, tport11 = env.ltop.xlate("dut1", "data1")
+        _, tport12 = env.ltop.xlate("dut1", "data2")
+        _, tport20 = env.ltop.xlate("dut2", "data0")
+        _, tport21 = env.ltop.xlate("dut2", "data1")
+        _, tport22 = env.ltop.xlate("dut2", "data2")
+
+        dut1.put_config_dict("ietf-interfaces", {
+            "interfaces": {
+                "interface": [
+                    {
+                        "name": "br0",
+                        "type": "iana-if-type:bridge",
+                        "enabled": True,
+                        "bridge": {
+                            "vlans": {
+                                "vlan": [
+                                    {
+                                        "vid": 10,
+                                        "untagged": [ tport10 ],
+                                        "tagged":   [ "br0", tport12 ]
+                                    },
+                                    {
+                                        "vid": 20,
+                                        "untagged": [ tport11 ],
+                                        "tagged":   [ "br0", tport12 ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": tport10,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 10,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport11,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 20,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport12,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "bridge": "br0",
+                        }
+                    }
+                ]
+            }
+        })
+
+        dut2.put_config_dict("ietf-interfaces", {
+            "interfaces": {
+                "interface": [
+                    {
+                        "name": "br0",
+                        "type": "iana-if-type:bridge",
+                        "enabled": True,
+                        "bridge": {
+                            "vlans": {
+                                "vlan": [
+                                    {
+                                        "vid": 10,
+                                        "untagged": [ tport20 ],
+                                        "tagged":   [ "br0", tport22 ]
+                                    },
+                                    {
+                                        "vid": 20,
+                                        "untagged": [ tport21 ],
+                                        "tagged":   [ "br0", tport22 ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "name": tport20,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 10,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport21,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "pvid": 20,
+                            "bridge": "br0"
+                        }
+                    },
+                    {
+                        "name": tport22,
+                        "type": "iana-if-type:ethernetCsmacd",
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "bridge": "br0",
+                        }
+                    }
+                ]
+            }
+        })
+
+    with test.step("Ping host:data20 [10.0.0.3] from host:data10 [10.0.0.1] through <bridge-vlan-10>" \
+                   " and host:data21 [10.0.0.4] from host:data11 [10.0.0.2] through <bridge-vlan-20>"):
+        
+        _, hport10 = env.ltop.xlate("host", "data10")
+        _, hport11 = env.ltop.xlate("host", "data11")
+        _, hport20 = env.ltop.xlate("host", "data20")
+        _, hport21 = env.ltop.xlate("host", "data21")
+
+        with infamy.IsolatedMacVlan(hport10) as ns10, \
+             infamy.IsolatedMacVlan(hport11) as ns11, \
+             infamy.IsolatedMacVlan(hport20) as ns20, \
+             infamy.IsolatedMacVlan(hport21) as ns21:
+
+            ns10.addip("10.0.0.1")
+            ns11.addip("10.0.0.2")
+            ns20.addip("10.0.0.3")
+            ns21.addip("10.0.0.4")
+
+            ns10.must_reach("10.0.0.3")
+            ns11.must_reach("10.0.0.4")
+
+            ns10.must_not_reach("10.0.0.4")
+            ns11.must_not_reach("10.0.0.3")
+            ns10.must_not_reach("10.0.0.2")
+            ns11.must_not_reach("10.0.0.1")
+                    
+    test.succeed()

--- a/test/infamy/topologies/1x1.dot
+++ b/test/infamy/topologies/1x1.dot
@@ -19,5 +19,5 @@ graph "1x1" {
 	    kind="infix",
 	];
 
-	host:tgt -- target:mgmt
+	host:tgt -- target:mgmt [kind=mgmt]
 }

--- a/test/infamy/topologies/1x2.dot
+++ b/test/infamy/topologies/1x2.dot
@@ -19,6 +19,6 @@ graph "1x2" {
 	    kind="infix",
 	];
 
-	host:tgt -- target:mgmt
+	host:tgt -- target:mgmt [kind=mgmt]
 	host:data -- target:data
 }

--- a/test/infamy/topologies/1x3.dot
+++ b/test/infamy/topologies/1x3.dot
@@ -1,0 +1,25 @@
+graph "1x3" {
+	layout="neato";
+	overlap="false";
+	esep="+20";
+
+        node [shape=record, fontname="monospace"];
+	edge [color="cornflowerblue", penwidth="2"];
+
+	host [
+	    label="host | { <tgt> tgt | <data0> data0 | <data1>  data1 }",
+	    pos="0,12!",
+	    kind="controller",
+	];
+
+        target [
+	    label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 } | target",
+	    pos="10,12!",
+
+	    kind="infix",
+	];
+
+	host:tgt -- target:mgmt [kind=mgmt]
+	host:data0 -- target:data0
+	host:data1 -- target:data1
+}

--- a/test/infamy/topologies/2x4.dot
+++ b/test/infamy/topologies/2x4.dot
@@ -1,0 +1,38 @@
+graph "2x4" {
+	layout="neato";
+	overlap="false";
+	esep="+20";
+
+        node [shape=record, fontname="monospace"];
+	edge [color="cornflowerblue", penwidth="2"];
+
+	host [
+	    label="host | { <mgmt1> mgmt1 | <data10> data10 | <data11>  data11 | <mgmt2> mgmt2 | <data20> data20 | <data21>  data21 }",
+	    pos="0,15!",
+	    kind="controller",
+	];
+
+        dut1 [
+	    label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 } | dut1 | { <data2> data2 }",
+	    pos="10,18!",
+
+	    kind="infix",
+	];
+
+        dut2 [
+		label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 } | dut2 | { <data2> data2 }",
+	    pos="10,12!",
+
+	    kind="infix",
+	];
+
+	host:mgmt1 -- dut1:mgmt [kind=mgmt]
+	host:data10 -- dut1:data0
+	host:data11 -- dut1:data1
+
+	host:mgmt2 -- dut2:mgmt [kind=mgmt]
+	host:data20 -- dut2:data0
+	host:data21 -- dut2:data1
+
+	dut1:data2 -- dut2:data2
+}

--- a/test/virt/dual/topology.dot.in
+++ b/test/virt/dual/topology.dot.in
@@ -11,28 +11,31 @@ graph "dual" {
 	qn_append="quiet";
 
         host [
-	    label="host | { <d1a> d1a | <d1b> d1b | <d2a> d2a | <d2b> d2b }",
+	    label="host | { <d1a> d1a | <d1b> d1b | <d1c> d1c | <d2a> d2a | <d2b> d2b | <d2c> d2c }",
 	    color="grey",fontcolor="grey",pos="0,15!",
 	    kind="controller",
 	];
 
         dut1 [
-	    label="{ <eth0> eth0 | <eth1> eth1 } | dut1 | { <eth2> eth2 | <eth3> eth3 }",
+	    label="{ <eth0> eth0 | <eth1> eth1 | <eth2> eth2 } | dut1 | { <eth3> eth3 | <eth4> eth4 | <eth5> eth5 }",
 	    pos="10,18!",
 	    kind="infix",
 	];
         dut2 [
-	    label="{ <eth0> eth0 | <eth1> eth1 } | dut2 | { <eth2> eth2 | <eth3> eth3 }",
+	    label="{ <eth0> eth0 | <eth1> eth1 | <eth2> eth2 } | dut2 | { <eth3> eth3 | <eth4> eth4 | <eth5> eth5 }",
 	    pos="10,12!",
 	    kind="infix",
 	];
 
-	host:d1a -- dut1:eth0
+	host:d1a -- dut1:eth0 [kind=mgmt]
 	host:d1b -- dut1:eth1
+	host:d1c -- dut1:eth2
 
-	host:d2a -- dut2:eth0
+	host:d2a -- dut2:eth0 [kind=mgmt]
 	host:d2b -- dut2:eth1
+	host:d2c -- dut2:eth2
 
-	dut1:eth2 -- dut2:eth3
-	dut2:eth2 -- dut1:eth3
+	dut1:eth3 -- dut2:eth5
+	dut1:eth4 -- dut2:eth4
+	dut1:eth5 -- dut2:eth3
 }


### PR DESCRIPTION
Edge(port) type parameter added to the topology files (**test/infamy** commit) in order to avoid false mgmt port selection.

There is a possibility for a test program to try to configure (set) a management port of a node to the one already allocated to a bridge in the previous test case. To avoid this, port mapping process in topology.py matches the edge type in the physical and the logical topology prior to the mapping of the other ports (bridge ports in this case)  