### PR TITLE
Fixing broken urls in document docs

### DIFF
--- a/doc/container.md
+++ b/doc/container.md
@@ -57,7 +57,7 @@ inside the container will always be: `eth0`, `eth1`, etc.
 
 A common setup is to use a VETH pair, with one end in the container and
 the other end routed, or bridged, to the rest of the world.  The Infix
-[CLI Guide](cli.md) provides examples of both.  In either case you need
+[CLI Guide](cli/introduction.md) provides examples of both.  In either case you need
 to create a matching CNI profile for one end of the VETH pair before
 starting the container, here we use two network profiles, the default
 podman bridge and the VETH profile:

--- a/doc/developers-guide.md
+++ b/doc/developers-guide.md
@@ -66,8 +66,8 @@ see also [Infix in Virtual Environments](virtual.md).
 
 The Infix automated test suite is built around Qemu and [Qeneth][2], see:
 
- * [Testing](doc/testing.md)
- * [Docker Image](test/docker/README.md)
+ * [Testing](testing.md)
+ * [Docker Image](../test/docker/README.md)
 
 
 Contributing

--- a/doc/virtual.md
+++ b/doc/virtual.md
@@ -33,8 +33,8 @@ from a pre-built Infix release tarball, using <kbd>./qemu.sh -c</kbd>
 
 The Infix test suite is built around Qemu and [Qeneth][qeth], see:
 
- * [Testing](doc/testing.md)
- * [Docker Image](test/docker/README.md)
+ * [Testing](testing.md)
+ * [Docker Image](../test/docker/README.md)
 
 
 GNS3
@@ -52,6 +52,6 @@ an end device.
 [Qemu]: https://www.qemu.org/
 [GNS3]: https://gns3.com/
 [virt]: https://virt-manager.org/
-[rels]; https://github.com/kernelkit/infix/releases
+[rels]: https://github.com/kernelkit/infix/releases
 [qeth]: https://github.com/wkz/qeneth
 [APPL]: https://docs.gns3.com/docs/using-gns3/beginners/import-gns3-appliance/


### PR DESCRIPTION
Fixing some broken links.
Regarding the url to the CLI guide in container.md, changing it to cli/README.md
(rather than cli/introduction.md) is perhaps better.  Or to "cli/"!

I have a problem to display https://github.com/jovatn/infix-jovatn/tree/main/doc/cli/README.md
but with https://github.com/jovatn/infix-jovatn/tree/main/doc/cli it works good