### PR TITLE
Add CLI interface statistics

### DIFF
--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -39,6 +39,13 @@ class Iface:
         self.oper_status = data.get('oper-status', None)
         self.phys_address = data.get('phys-address', None)
 
+        if data.get('statistics', None):
+            self.in_octets = data.get('statistics').get('in-octets', None)
+            self.out_octets = data.get('statistics').get('out-octets', None)
+        else:
+            self.in_octets = None
+            self.out_octets = None
+
         self.parent = data.get('ietf-if-extensions:parent-interface', None)
 
         if self.data.get('ietf-ip:ipv4'):
@@ -142,6 +149,11 @@ class Iface:
                 first = False
         else:
                 print(f"{'ipv4 addresses':<{20}}:")
+
+        if self.in_octets and self.out_octets:
+            print(f"{'in-octets':<{20}}: {self.in_octets}")
+            print(f"{'out-octets':<{20}}: {self.out_octets}")
+
 
 def find_iface(_ifaces, name):
     for _iface in [Iface(data) for data in _ifaces]:

--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -135,11 +135,13 @@ class Iface:
 
         if self.ipv4_addr:
             first = True
-            print("")
             for addr in self.ipv4_addr:
                 key = 'ipv4 addresses' if first else ''
-                print(f"{key:<{20}}: {addr['ip']}/{addr['prefix-length']}")
+                colon = ':' if first else ' '
+                print(f"{key:<{20}}{colon} {addr['ip']}/{addr['prefix-length']}")
                 first = False
+        else:
+                print(f"{'ipv4 addresses':<{20}}:")
 
 def find_iface(_ifaces, name):
     for _iface in [Iface(data) for data in _ifaces]:

--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -35,30 +35,30 @@ class Iface:
     def __init__(self, data):
         self.data = data
         self.name = data.get('name', '')
-        self.index = data.get('if-index', None)
-        self.oper_status = data.get('oper-status', None)
-        self.phys_address = data.get('phys-address', None)
+        self.index = data.get('if-index', '')
+        self.oper_status = data.get('oper-status', '')
+        self.phys_address = data.get('phys-address', '')
 
-        if data.get('statistics', None):
-            self.in_octets = data.get('statistics').get('in-octets', None)
-            self.out_octets = data.get('statistics').get('out-octets', None)
+        if data.get('statistics'):
+            self.in_octets = data.get('statistics').get('in-octets', '')
+            self.out_octets = data.get('statistics').get('out-octets', '')
         else:
-            self.in_octets = None
-            self.out_octets = None
+            self.in_octets = ''
+            self.out_octets = ''
 
         self.parent = data.get('ietf-if-extensions:parent-interface', None)
 
         if self.data.get('ietf-ip:ipv4'):
-            self.mtu = self.data.get('ietf-ip:ipv4').get('mtu', None)
-            self.ipv4_addr = self.data.get('ietf-ip:ipv4').get('address', None)
+            self.mtu = self.data.get('ietf-ip:ipv4').get('mtu', '')
+            self.ipv4_addr = self.data.get('ietf-ip:ipv4').get('address', '')
         else:
-            self.mtu = None
+            self.mtu = ''
             self.ipv4_addr = []
 
         if self.data.get('infix-interfaces:bridge-port'):
             self.bridge = self.data.get('infix-interfaces:bridge-port').get('bridge', None)
         else:
-            self.bridge = None
+            self.bridge = ''
 
     def is_vlan(self):
         return self.data['type'] == "iana-if-type:l2vlan"
@@ -131,8 +131,7 @@ class Iface:
 
     def pr_iface(self):
         print(f"{'name':<{20}}: {self.name}")
-        if self.index:
-            print(f"{'index':<{20}}: {self.index}")
+        print(f"{'index':<{20}}: {self.index}")
         if self.mtu:
             print(f"{'mtu':<{20}}: {self.mtu}")
         if self.oper_status:


### PR DESCRIPTION
Re-add statistics to the detailed show interface view.

Also, print empty columns for some values that the user adds/remove, such as ipv4 address.
This make it easier to spot if a interface has no ip set.