### PR TITLE
confd: fix IPv6 autoconf support

### DIFF
--- a/src/confd/confd-bootstrap.sh
+++ b/src/confd/confd-bootstrap.sh
@@ -56,6 +56,7 @@ sysrepoctl -s $SEARCH							\
 	   -i ietf-interfaces@2018-02-20.yang   -g wheel -p 0660	\
 		-e if-mib						\
 	   -i ietf-ip@2018-02-22.yang		-g wheel -p 0660	\
+		-e ipv6-privacy-autoconf				\
 	   -i ietf-network-instance@2019-01-21.yang -g wheel -p 0660	\
 	   -i ietf-netconf-monitoring@2010-10-04.yang -g wheel -p 0660	\
 	   -i ietf-netconf-nmda@2019-01-07.yang -g wheel -p 0660	\


### PR DESCRIPTION
 - Enable privacy feature, allows true random address instead of EUI64
 - Allow global addresses to use router prefix

Fixes #136