### PR TITLE
Add IPv6 operational data

### DIFF
--- a/board/common/rootfs/etc/avahi/avahi-autoipd.action
+++ b/board/common/rootfs/etc/avahi/avahi-autoipd.action
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+# This file is part of avahi.
+#
+# avahi is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# avahi is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+# License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with avahi; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# USA.
+
+set -e
+
+# Command line arguments:
+#   $1 event that happened:
+#          BIND:     Successfully claimed address
+#          CONFLICT: An IP address conflict happened
+#          UNBIND:   The IP address is no longer needed
+#          STOP:     The daemon is terminating
+#   $2 interface name
+#   $3 IP adddress
+
+PATH="$PATH:/usr/bin:/usr/sbin:/bin:/sbin"
+
+# Use a different metric for each interface, so that we can set
+# identical routes to multiple interfaces.
+
+METRIC=$((1000 + `cat "/sys/class/net/$2/ifindex" 2>/dev/null || echo 0`))
+
+if [ -x /bin/ip -o -x /sbin/ip ] ; then
+
+    # We have the Linux ip tool from the iproute package
+
+    case "$1" in
+        BIND)
+            ip addr flush dev "$2" label "$2:avahi"
+            ip addr add "$3"/16 brd 169.254.255.255 label "$2:avahi" scope link dev "$2"
+            ip route add default dev "$2" metric "$METRIC" scope link ||:
+            ;;
+
+        CONFLICT|UNBIND|STOP)
+            ip route del default dev "$2" metric "$METRIC" scope link ||:
+            ip addr del "$3"/16 brd 169.254.255.255 label "$2:avahi" scope link dev "$2"
+            ;;
+
+        *)
+            echo "Unknown event $1" >&2
+            exit 1
+            ;;
+    esac
+
+elif [ -x /bin/ifconfig -o -x /sbin/ifconfig ] ; then
+
+    # We have the old ifconfig tool
+
+    case "$1" in
+        BIND)
+            ifconfig "$2:avahi" inet "$3" netmask 255.255.0.0 broadcast 169.254.255.255 up
+            route add default dev "$2:avahi" metric "$METRIC" ||:
+            ;;
+
+        CONFLICT|STOP|UNBIND)
+            route del default dev "$2:avahi" metric "$METRIC" ||:
+            ifconfig "$2:avahi" down
+            ;;
+
+        *)
+            echo "Unknown event $1" >&2
+            exit 1
+            ;;
+    esac
+
+else
+
+    echo "No network configuration tool found." >&2
+    exit 1
+
+fi
+
+exit 0

--- a/board/common/rootfs/etc/avahi/avahi-autoipd.action
+++ b/board/common/rootfs/etc/avahi/avahi-autoipd.action
@@ -42,7 +42,7 @@ if [ -x /bin/ip -o -x /sbin/ip ] ; then
     case "$1" in
         BIND)
             ip addr flush dev "$2" label "$2:avahi"
-            ip addr add "$3"/16 brd 169.254.255.255 label "$2:avahi" scope link dev "$2"
+            ip addr add "$3"/16 brd 169.254.255.255 label "$2:avahi" scope link dev "$2" proto 6
             ip route add default dev "$2" metric "$METRIC" scope link ||:
             ;;
 

--- a/board/common/rootfs/etc/iproute2/rt_addrprotos
+++ b/board/common/rootfs/etc/iproute2/rt_addrprotos
@@ -1,2 +1,3 @@
 4 static
 5 dhcp
+6 random

--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -157,9 +157,12 @@ class Iface:
         if self.ipv4_addr:
             first = True
             for addr in self.ipv4_addr:
+                origin = f"({addr['origin']})" if addr.get('origin') else ""
                 key = 'ipv4 addresses' if first else ''
                 colon = ':' if first else ' '
-                print(f"{key:<{20}}{colon} {addr['ip']}/{addr['prefix-length']}")
+                row = f"{key:<{20}}{colon} "
+                row += f"{addr['ip']}/{addr['prefix-length']} {origin}"
+                print(row)
                 first = False
         else:
                 print(f"{'ipv4 addresses':<{20}}:")
@@ -167,9 +170,12 @@ class Iface:
         if self.ipv6_addr:
             first = True
             for addr in self.ipv6_addr:
+                origin = f"({addr['origin']})" if addr.get('origin') else ""
                 key = 'ipv6 addresses' if first else ''
                 colon = ':' if first else ' '
-                print(f"{key:<{20}}{colon} {addr['ip']}/{addr['prefix-length']}")
+                row = f"{key:<{20}}{colon} "
+                row += f"{addr['ip']}/{addr['prefix-length']} {origin}"
+                print(row)
                 first = False
         else:
                 print(f"{'ipv6 addresses':<{20}}:")

--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -9,10 +9,10 @@ parser.add_argument("-n", "--name", help="Focus on specific name")
 args = parser.parse_args()
 
 class Pad:
-    iface = 15 + 2 # + 2 is ASCII tree for nesting
-    proto = 18
-    state = 15
-    data = 30
+    iface = 16
+    proto = 11
+    state = 12
+    data = 41
 
 class Decore():
     @staticmethod
@@ -55,6 +55,11 @@ class Iface:
             self.mtu = ''
             self.ipv4_addr = []
 
+        if self.data.get('ietf-ip:ipv6'):
+            self.ipv6_addr = self.data.get('ietf-ip:ipv6').get('address', '')
+        else:
+            self.ipv6_addr = []
+
         if self.data.get('infix-interfaces:bridge-port'):
             self.bridge = self.data.get('infix-interfaces:bridge-port').get('bridge', None)
         else:
@@ -82,6 +87,15 @@ class Iface:
             row += f"{'':<{Pad.state}}{addr['ip']}/{addr['prefix-length']} {origin}"
             print(row)
 
+    def pr_proto_ipv6(self, pipe=''):
+        for addr in self.ipv6_addr:
+            origin = f"({addr['origin']})" if addr.get('origin') else ""
+
+            row =  f"{pipe:<{Pad.iface}}"
+            row += f"{'ipv6':<{Pad.proto}}"
+            row += f"{'':<{Pad.state}}{addr['ip']}/{addr['prefix-length']} {origin}"
+            print(row)
+
     def pr_proto_eth(self):
         row = f"{'ethernet':<{Pad.proto}}"
         dec = Decore.green if self.data['oper-status'] == "up" else Decore.red
@@ -101,8 +115,10 @@ class Iface:
 
         if lowers:
             self.pr_proto_ipv4(pipe='│')
+            self.pr_proto_ipv6(pipe='│')
         else:
             self.pr_proto_ipv4()
+            self.pr_proto_ipv6()
 
         for i, lower in enumerate(lowers):
             pipe = '└ ' if (i == len(lowers) -1)  else '├ '
@@ -115,8 +131,10 @@ class Iface:
 
         if self.parent:
             self.pr_proto_ipv4(pipe='│')
+            self.pr_proto_ipv6(pipe='│')
         else:
             self.pr_proto_ipv4()
+            self.pr_proto_ipv6()
             return
 
         parent = find_iface(_ifaces, self.parent)
@@ -145,6 +163,16 @@ class Iface:
                 first = False
         else:
                 print(f"{'ipv4 addresses':<{20}}:")
+
+        if self.ipv6_addr:
+            first = True
+            for addr in self.ipv6_addr:
+                key = 'ipv6 addresses' if first else ''
+                colon = ':' if first else ' '
+                print(f"{key:<{20}}{colon} {addr['ip']}/{addr['prefix-length']}")
+                first = False
+        else:
+                print(f"{'ipv6 addresses':<{20}}:")
 
         if self.in_octets and self.out_octets:
             print(f"{'in-octets':<{20}}: {self.in_octets}")
@@ -187,6 +215,7 @@ def pr_interface_list(json):
         iface.pr_name()
         iface.pr_proto_eth()
         iface.pr_proto_ipv4()
+        iface.pr_proto_ipv6()
 
 def ietf_interfaces(json, name):
     if not json or not json.get("ietf-interfaces:interfaces"):

--- a/src/statd/statd.c
+++ b/src/statd/statd.c
@@ -169,6 +169,7 @@ static const char *get_yang_origin(const char *protocol)
 		{"kernel_ll",	"link-layer"},
 		{"static",	"static"},
 		{"dhcp",	"dhcp"},
+		{"random",	"random"},
 	};
 
 	for (i = 0; i < sizeof(map) / sizeof(map[0]); i++) {

--- a/test/case/cli_pretty/json/bloated.json
+++ b/test/case/cli_pretty/json/bloated.json
@@ -41,6 +41,21 @@
             }
           ]
         },
+        "ietf-ip:ipv6": {
+          "mtu": 1500,
+          "address": [
+            {
+              "ip": "fe80::beff:407a:d738:abb4",
+              "prefix-length": 64,
+              "origin": "link-layer"
+            },
+            {
+              "ip": "fe80::beff:aaaa:d738:abb4",
+              "prefix-length": 64,
+              "origin": "random"
+            }
+          ]
+        },
         "infix-interfaces:bridge-port": {
           "bridge": "br0"
         }
@@ -114,6 +129,21 @@
               "ip": "192.168.5.1",
               "prefix-length": 24,
               "origin" : "static"
+            }
+          ]
+        },
+        "ietf-ip:ipv6": {
+          "mtu": 1500,
+          "address": [
+            {
+              "ip": "fe80::beff:407a:d738:abb4",
+              "prefix-length": 64,
+              "origin": "link-layer"
+            },
+            {
+              "ip": "fe80::beff:aaaa:d738:abb4",
+              "prefix-length": 64,
+              "origin": "random"
             }
           ]
         }


### PR DESCRIPTION
This PR adds basic IPv6 info to the operational datastore.
It also adds YANG origin for avahi IPv4 link-local addresses.

**CLI Example with avahi IPv4-LL and eui64 generated IPv6-LL**
```
INTERFACE       PROTOCOL   STATE       DATA                                     
e0              ethernet   UP          02:00:00:00:00:00                        
                ipv4                   169.254.1.3/16 (random)
                ipv4                   192.168.1.1/24 (static)
                ipv6                   fe80::ff:fe00:0/64 (link-layer)
lo              ethernet   UP          00:00:00:00:00:00                        
                ipv4                   127.0.0.1/8 (static)
                ipv6                   ::1/128 (static)

```

**CLI Example with avahi IPv4-LL and random/secure generated IPv6-LL**
```
INTERFACE       PROTOCOL   STATE       DATA                                     
e0              ethernet   UP          02:00:00:00:00:00                        
                ipv4                   169.254.1.3/16 (random)
                ipv4                   192.168.1.1/24 (static)
                ipv6                   fe80::1d81:3434:61ad:e76a/64 (random)
lo              ethernet   UP          00:00:00:00:00:00                        
                ipv4                   127.0.0.1/8 (static)
                ipv6                   ::1/128 (static)

```