### PR TITLE
Add deviations for MTU configuration (IPv4/IPv6) in ietf-ip.yang

### DIFF
--- a/src/confd/yang/infix-ip@2023-09-14.yang
+++ b/src/confd/yang/infix-ip@2023-09-14.yang
@@ -50,11 +50,19 @@ module infix-ip {
     }
   }
 
+  deviation "/if:interfaces/if:interface/ip:ipv4/ip:mtu" {
+    deviate not-supported;
+  }
+
   deviation "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask" {
     deviate not-supported;
   }
   
   deviation "/if:interfaces/if:interface/ip:ipv4/ip:neighbor" {
+    deviate not-supported;
+  }
+
+  deviation "/if:interfaces/if:interface/ip:ipv6/ip:mtu" {
     deviate not-supported;
   }
 


### PR DESCRIPTION
MTU configuration/status not yet implemented in Infix, thus deviations added.