### PR TITLE
cli: handle missing oper-status

### DIFF
--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -95,8 +95,8 @@ class Iface:
 
     def pr_proto_eth(self):
         row = f"{'ethernet':<{Pad.proto}}"
-        dec = Decore.green if self.data['oper-status'] == "up" else Decore.red
-        row += dec(f"{self.data['oper-status'].upper():<{Pad.state}}")
+        dec = Decore.green if self.oper_status == "up" else Decore.red
+        row += dec(f"{self.oper_status.upper():<{Pad.state}}")
         row += f"{self.data['phys-address']:<{Pad.data}}"
         print(row)
 

--- a/test/case/cli_pretty/json/bloated.json
+++ b/test/case/cli_pretty/json/bloated.json
@@ -322,9 +322,9 @@
         }
       },
       {
+        "TEST-DESCR": "VLAN without operstatus",
         "name": "vlan20",
         "type": "infix-if-type:vlan",
-        "oper-status": "up",
         "if-index": 4,
         "phys-address": "02:00:00:00:00:00",
         "statistics": {


### PR DESCRIPTION
Use known data from .self to avoid crashing if the oper-status is missing for a interface.

Fixes #162 