### PR TITLE
Regen factory on every boot

### DIFF
--- a/package/confd/tmpfiles.conf
+++ b/package/confd/tmpfiles.conf
@@ -1,2 +1,3 @@
+d  /run/confd/factory.d		- - -
+d  /run/confd/failure.d		- - -
 d  /run/resolvconf/interfaces	- - -
-

--- a/src/confd/bin/.confdrc
+++ b/src/confd/bin/.confdrc
@@ -1,20 +1,26 @@
 # Defaults for testing bootstrap script                       -*-conf-*-
+#set -x
+
 TESTING=true
 
 PATH=.:$PATH
 INIT_DATA=/etc/sysrepo/factory-default.json
 SEARCH=/usr/share/yang/modules/confd:/usr/share/yang/modules/libnetconf2:/usr/share/yang/modules/libyang:/usr/share/yang/modules/netopeer2:/usr/share/yang/modules/sysrepo
 
-CFG_PATH_=/tmp/confd
+CFG_PATH_=/tmp/confd/cfg
+RUN_PATH_=/tmp/confd/run
 
 FACTORY_DEFAULTS_D=../share/factory.d
 FAILURE_DEFAULTS_D=../share/failure.d
 
-FACTORY_D=$CFG_PATH_/factory.d
-FAILURE_D=$CFG_PATH_/failure.d
+FACTORY_D=$RUN_PATH_/factory.d
+FAILURE_D=$RUN_PATH_/failure.d
 
-FACTORY_CFG=$CFG_PATH_/factory-config.cfg
-FAILURE_CFG=$CFG_PATH_/failure-config.cfg
+FACTORY_GEN=$RUN_PATH_/factory-config.gen
+FAILURE_GEN=$RUN_PATH_/failure-config.gen
+
+FACTORY_CFG=$RUN_PATH_/factory-config.cfg
+FAILURE_CFG=$RUN_PATH_/failure-config.cfg
 STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 
 # Uncomment this line in to create a bridge (br0) with all (classified
@@ -26,3 +32,6 @@ STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 # Default hostname in Fail Secure mode, plus last three octets in the base
 # MAC address, e.g. "failed-c0-ff-ee".
 FAIL_HOSTNAME="failed"
+
+# Only needed for testing
+mkdir -p "$CFG_PATH_" "$RUN_PATH_" "$FACTORY_D" "$FAILURE_D"

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -1,14 +1,14 @@
 #!/bin/sh
-# Bootstrap sysrepo db with all modules required by confd
+# Bootstrap system factory-config, failure-config and sysrepo db.
 #
-# 1. Load all yang models with /cfg/factory-config
-# 2. [ if /cfg/startup-config is missing :: copy {factory} -> /cfg/startup-config ]
-# 3. Import /cfg/startup -> {startup} ]
-# 4. Clear running-config :: import NULL -> {running}
-# 5. Start sysrepo-plugind
-# 6. Activate startup-config by :: copy {startup} -> {running}
+# The system factory-config and failure-config are derived from default
+# settings snippets, from /usr/share/confd/factory.d, and some generated
+# snippets, e.g., device unique password, hostname (based on base MAC
+# address), and number of interfaces.
 #
-# It's all really simple ... this script takes care of 1-4
+# The resulting factory-config is used to create the syrepo db (below)
+# {factory} datastore.  Hence, the factory-config file must match the
+# the YANG models of the active image.
 #
 
 # /etc/confdrc controls the behavior or most of the gen-scripts,
@@ -27,17 +27,30 @@ fi
 # shellcheck disable=SC1090
 . "$RC"
 
-FACTORY_GEN="$(dirname "$FACTORY_CFG")/$(basename "$FACTORY_CFG" .cfg).gen"
-FAILURE_GEN="$(dirname "$FAILURE_CFG")/$(basename "$FAILURE_CFG" .cfg).gen"
+# shellcheck disable=SC2046,SC2086
+collate()
+{
+    gen=$1; shift
+    cfg=$1; shift
+    dir=$*
 
-# Generate device's factory-config at first boot or on override
-if [ ! -f "$FACTORY_GEN" ] || [ "$FACTORY_OVERRIDE" = "true" ]; then
-    mkdir -p "$FACTORY_D"
+    rm -f "$gen"
+    jq -s 'reduce .[] as $item ({}; . * $item)' $(find $dir -name '*.json' | sort) >"$gen"
+    chmod 444 "$gen"
 
-    # Save the original templates (from the original image) used to create factory-config
-    for file in $(find "$FACTORY_DEFAULTS_D" -type f); do
-	cp "$file" "$FACTORY_D"
-    done
+    if [ ! -f "$cfg" ]; then
+	cp "$gen" "$cfg"
+    fi
+}
+
+# TODO: Look for statically defined factory-config, based on the
+#       system's product ID, or just custom site-specific factory.
+#
+# If we haven't found a more specific, better match, settle for
+# factory-config.gen as the system's factory-config.
+factory()
+{
+    gen=$1
 
     # Create an overlay for /etc/hostname to change the default in an br2-external
     gen-hostname                                            >"$FACTORY_D/20-hostname.json"
@@ -52,26 +65,17 @@ if [ ! -f "$FACTORY_GEN" ] || [ "$FACTORY_OVERRIDE" = "true" ]; then
 
     rm -f "$FACTORY_GEN"
     # shellcheck disable=SC2046
-    jq -s 'reduce .[] as $item ({}; . * $item)'	\
-       $(find "$FACTORY_D" -name '*.json' | sort) >"$FACTORY_GEN"
+    jq -s 'reduce .[] as $item ({}; . * $item)' \
+       $(find "$FACTORY_DEFAULTS_D" "$FACTORY_D" -name '*.json' | sort) \
+       >"$FACTORY_GEN"
     chmod 444 "$FACTORY_GEN"
 
-    # TODO: Look for statically defined factory-config, based on the
-    #       system's product ID, or just custom site-specific factory.
+    collate "$FACTORY_GEN" "$FACTORY_CFG" "$FACTORY_DEFAULTS_D" "$FACTORY_D"
+}
 
-    # If we haven't found a more specific, better match, settle for
-    # factory-config.gen as the system's factory-config.
-    [ -h "$FACTORY_CFG" ] || ln -sf "$(basename "$FACTORY_GEN")" "$FACTORY_CFG"
-fi
-
-# Generate device's failure-config at first boot
-if [ ! -f "$FAILURE_GEN" ] || [ "$FAILURE_OVERRIDE" = "true" ]; then
-    mkdir -p "$FAILURE_D"
-
-    # Save the original templates (from the original image) used to create failure-config
-    for file in $(find "$FAILURE_DEFAULTS_D" -type f); do
-	cp "$file" "$FAILURE_D"
-    done
+failure()
+{
+    gen=$1
 
     gen-hostname   "$FAIL_HOSTNAME"                         >"$FAILURE_D/20-hostname.json"
     gen-interfaces                                          >"$FAILURE_D/20-interfaces.json"
@@ -81,14 +85,11 @@ if [ ! -f "$FAILURE_GEN" ] || [ "$FAILURE_OVERRIDE" = "true" ]; then
     # Optional failure/error config to generate (or override) for br2-externals
     [ -x "$(command -v gen-err-custom)" ] && gen-err-custom >"$FAILURE_D/30-error.json"
 
-    rm -f "$FAILURE_GEN"
-    # shellcheck disable=SC2046
-    jq -s 'reduce .[] as $item ({}; . * $item)'	\
-       $(find "$FAILURE_D" -name '*.json' | sort) >"$FAILURE_GEN"
-    chmod 444 "$FAILURE_GEN"
+    collate "$FAILURE_GEN" "$FAILURE_CFG" "$FAILURE_DEFAULTS_D" "$FAILURE_D"
+}
 
-    [ -h "$FAILURE_CFG" ] || ln -sf "$(basename "$FAILURE_GEN")" "$FAILURE_CFG"
-fi
+factory "$FACTORY_GEN"
+failure "$FAILURE_GEN"
 
 if [ -n "$TESTING" ]; then
 	echo "Done."

--- a/src/confd/bin/gen-interfaces
+++ b/src/confd/bin/gen-interfaces
@@ -85,13 +85,13 @@ phys_ifaces=$(ip -d -j link show | jq -r '
 	 select(.link_type == "ether") |
 	 select(.group != "internal")  |
 	 select(has("parentbus")) |
-	 .ifname')
+	 .ifname' | sort -V)
 ports=$(ip -d -j link show group port | jq -r '
 	 .[] |
 	 select(.link_type == "ether") |
 	 select(.group != "internal")  |
 	 select(has("parentbus")) |
-	 .ifname')
+	 .ifname' | sort -V)
 ifaces=""
 for phy in $phys_ifaces; do
     found=""

--- a/src/confd/bin/load
+++ b/src/confd/bin/load
@@ -15,15 +15,21 @@ if [ "$1" = "-b" ]; then
 else
     bootstrap=false
 fi
+
 config=$1
-fn=/cfg/${config}.cfg
+if [ -f "$config" ]; then
+    fn="$config"
+else
+    if [ -f "/cfg/${config}.cfg" ]; then
+	fn="/cfg/${config}.cfg"
+    else
+	fn="/run/confd/${config}.cfg"
+    fi
+fi
 
 if [ ! -f "$fn" ]; then
-    if [ ! -f "$config" ]; then
-	logger -sik -p user.error "No such file, $fn, aborting!"
-	exit 1
-    fi
-    fn=$config
+    logger -sik -p user.error "No such file, $fn, aborting!"
+    exit 1
 fi
 
 if ! sysrepocfg -v3 -I"$fn" -f json; then

--- a/src/confd/confdrc
+++ b/src/confd/confdrc
@@ -6,15 +6,24 @@ INIT_DATA=/etc/sysrepo/factory-default.json
 SEARCH=/usr/share/yang/modules/confd:/usr/share/yang/modules/libnetconf2:/usr/share/yang/modules/libyang:/usr/share/yang/modules/netopeer2:/usr/share/yang/modules/sysrepo
 
 CFG_PATH_=/cfg
+RUN_PATH_=/run/confd
 
+# Static defaults, base Infix and any br2-external derivative.
 FACTORY_DEFAULTS_D=/usr/share/confd/factory.d
 FAILURE_DEFAULTS_D=/usr/share/confd/failure.d
 
-FACTORY_D=$CFG_PATH_/factory.d
-FAILURE_D=$CFG_PATH_/failure.d
+# Generated config snippets, e.g., hostname, password, and interfaces.
+FACTORY_D=$RUN_PATH_/factory.d
+FAILURE_D=$RUN_PATH_/failure.d
 
-FACTORY_CFG=$CFG_PATH_/factory-config.cfg
-FAILURE_CFG=$CFG_PATH_/failure-config.cfg
+# The default config snippets and generated snippets are collated into
+# RAM-only name-config.gen , which are candidates for name-config.cfg
+FACTORY_GEN=$RUN_PATH_/factory-config.gen
+FAILURE_GEN=$RUN_PATH_/failure-config.gen
+
+# The resulting .cfg files can be peristent (factory-config) or not.
+FACTORY_CFG=$RUN_PATH_/factory-config.cfg
+FAILURE_CFG=$RUN_PATH_/failure-config.cfg
 STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 
 # Uncomment this line in to create a bridge (br0) with all (classified
@@ -26,9 +35,3 @@ STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 # Default hostname in Fail Secure mode, plus last three octets in the base
 # MAC address, e.g. "failed-c0-ff-ee".
 FAIL_HOSTNAME="failed"
-
-# Uncomment to regenerate factory-config (except hostkeys) on each boot.
-#FACTORY_OVERRIDE=true
-
-# Uncomment to regenerate failure-config (except hostkeys) on each boot.
-#FAILURE_OVERRIDE=true


### PR DESCRIPTION
This PR fixes the annoying "RMA" issue we've seen over the past week or so.  Instead of saving `factory-config` and `failure-config` to `/cfg`, we now regenerate them on each boot to match our YANG models.  The files are stored in `/run/confd/`, except for `startup-config` that remains in `/cfg`.

It also address the "unsorted interfaces" issue we found in customer bridge created by `gen-interfaces` today.