### PR TITLE
cli: use pwgen secure and increase password length

### DIFF
--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -159,7 +159,7 @@
 
 <COMMAND name="password" help="Password tools" mode="switch">
   <COMMAND name="generate" help="Generate random passwords using pwgen">
-    <ACTION sym="script">pwgen -c -n -B -C</ACTION>
+    <ACTION sym="script">pwgen -C -s 13 20</ACTION>
   </COMMAND>
 
   <COMMAND name="encrypt" help="Encrypt a password string">


### PR DESCRIPTION
Adhere to our recommendations and avoid pseudorandom passwords which are "easy to remember". Also increase password length to 13 chars.

Side notes:
Knowing that a password contains at least one char, one number and so on, lowers the number of possible passwords to test when brute forcing.

The entropy for the pwgen "easy to remember" passwords isn't good (naturally).