### PR TITLE
Add autoneg status to op datastore

### DIFF
--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -35,7 +35,7 @@ class Iface:
     def get_json_data(self, default, *args):
         data = self.data
         for arg in args:
-            if data.get(arg):
+            if arg in data:
                 data = data.get(arg)
             else:
                 return default
@@ -47,6 +47,8 @@ class Iface:
         self.name = data.get('name', '')
         self.index = data.get('if-index', '')
         self.oper_status = data.get('oper-status', '')
+        self.autoneg = self.get_json_data('unknown', 'ieee802-ethernet-interface:ethernet',
+                                          'auto-negotiation', 'enable')
         self.phys_address = data.get('phys-address', '')
 
         if data.get('statistics'):
@@ -161,6 +163,11 @@ class Iface:
             print(f"{'mtu':<{20}}: {self.mtu}")
         if self.oper_status:
             print(f"{'operational status':<{20}}: {self.oper_status}")
+
+        if self.autoneg != 'unknown':
+            val = "on" if self.autoneg else "off"
+            print(f"{'auto-negotiation':<{20}}: {val}")
+
         if self.phys_address:
             print(f"{'physical address':<{20}}: {self.phys_address}")
 

--- a/board/netconf/rootfs/lib/infix/ethtool-to-json
+++ b/board/netconf/rootfs/lib/infix/ethtool-to-json
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import json
+
+def get_ethtool_output(interface):
+    try:
+        output = subprocess.check_output(['ethtool', interface], stderr=subprocess.DEVNULL, text=True)
+        return output.splitlines()
+    except subprocess.CalledProcessError:
+        print("Error: Failed to run ethtool on interface", interface)
+        sys.exit(1)
+
+def parse_ethtool_output(lines, keys):
+    result = {}
+    for line in lines:
+        line = line.strip()
+        key = line.split(':', 1)[0].strip()
+        if key in keys:
+            key, value = line.split(':', 1)
+            result[key.strip()] = value.strip()
+    return result
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} INTERFACE")
+        sys.exit(1)
+
+    interface = sys.argv[1]
+    keys = ["Duplex", "Auto-negotiation"]
+
+    lines = get_ethtool_output(interface)
+    parsed_data = parse_ethtool_output(lines, keys)
+
+    print(json.dumps(parsed_data, indent=4))

--- a/test/case/cli_pretty/json/bloated.json
+++ b/test/case/cli_pretty/json/bloated.json
@@ -32,6 +32,11 @@
           "in-octets": "0",
           "out-octets": "21286"
         },
+        "ieee802-ethernet-interface:ethernet": {
+          "auto-negotiation": {
+            "enable": false
+          }
+        },
         "ietf-ip:ipv4": {
           "mtu": 1500,
           "address": [
@@ -80,7 +85,7 @@
       },
       {
         "TEST-DESCR": "Bridge interface without IP",
-        "name": "e1",
+        "name": "e2",
         "type": "infix-if-type:ethernet",
         "oper-status": "up",
         "if-index": 4,
@@ -88,6 +93,11 @@
         "statistics": {
           "in-octets": "0",
           "out-octets": "21286"
+        },
+        "ieee802-ethernet-interface:ethernet": {
+          "auto-negotiation": {
+            "enable": "invalid-data"
+          }
         },
         "ietf-ip:ipv4": {
           "mtu": 1500


### PR DESCRIPTION
## Changes
* Add the status of autoneg to the operational datastore.
* Print it in the detauled interface CLI view

##  Examples
Sysrepo data:
```
"ieee802-ethernet-interface:ethernet": {                                     
   "auto-negotiation": {                                                      
     "enable": false                                                          
    }                                                                          
},   
```

CLI:
```
root@infix:/> show interfaces name p1
name                : p1
index               : 4
mtu                 : 1500
operational status  : up
auto-negotiation    : on
```

