### PR TITLE
cli: speedup detailed interface view

### DIFF
--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -248,18 +248,20 @@ def pr_interface_list(json):
         iface.pr_proto_ipv6()
 
 def ietf_interfaces(json, name):
-    if not json or not json.get("ietf-interfaces:interfaces"):
-        print(f"Error, top level \"ietf-interfaces:interfaces\" missing")
-        sys.exit(1)
-
-    if not name:
-        return pr_interface_list(json)
-
-    iface = find_iface(json["ietf-interfaces:interfaces"]["interface"], name)
-    if not iface:
-        print(f"Interface {name} not found")
-        sys.exit(1)
-    return iface.pr_iface()
+    if name:
+        if not json.get("ietf-interfaces:interfaces"):
+            print(f"No interface data found for \"{name}\"")
+            sys.exit(1)
+        iface = find_iface(json["ietf-interfaces:interfaces"]["interface"], name)
+        if not iface:
+            print(f"Interface \"{name}\" not found")
+            sys.exit(1)
+        iface.pr_iface()
+    else:
+        if not json.get("ietf-interfaces:interfaces"):
+            print(f"Error, top level \"ietf-interfaces:interfaces\" missing")
+            sys.exit(1)
+        pr_interface_list(json)
 
 def main():
     try:

--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -240,7 +240,8 @@
     </SWITCH>
     <ACTION sym="script" interactive="false">
       if [ -n "$KLISH_PARAM_name" ]; then
-      sysrepocfg -f json -X -d operational -m ietf-interfaces | \
+        sysrepocfg -f json -X -d operational -x \
+        "/ietf-interfaces:interfaces/interface[name='$KLISH_PARAM_name']" | \
         /lib/infix/cli-pretty "ietf-interfaces" -n "$KLISH_PARAM_name"
       else
       sysrepocfg -f json -X -d operational -m ietf-interfaces | \


### PR DESCRIPTION
This affects CLI command such as:
> show interface name p1

Prior to this patch, this took roughly ~1200ms on hardware and with the patch it takes roughly 50ms.