### PR TITLE
Bridge VLAN filtering fixes

### DIFF
--- a/src/confd/yang/infix-if-bridge@2023-11-08.yang
+++ b/src/confd/yang/infix-if-bridge@2023-11-08.yang
@@ -18,6 +18,12 @@ submodule infix-if-bridge {
   contact      "kernelkit@googlegroups.com";
   description  "Linux bridge extension for ietf-interfaces.";
 
+  revision 2023-11-08 {
+    description "Dropped support for configuring bridge pvid.
+                 Bridge ports need explicit VLAN assignment.";
+    reference "internal";
+  }
+
   revision 2023-08-21 {
     description "Minor, lint ordering and add missing description.";
     reference "internal";
@@ -96,12 +102,6 @@ submodule infix-if-bridge {
 	  type dot1q-types:dot1q-tag-type;
 	  default dot1q-types:c-vlan;
 	  description "Standard (1Q/c-vlan) or provider (1ad/s-vlan) bridge.";
-	}
-
-	leaf pvid {
-	  type dot1q-types:vlanid;
-	  default 1;
-	  description "Default primary VID for untagged frames, default: 1.";
 	}
 
         list vlan {


### PR DESCRIPTION
First, drop bridge vlans pvid from YANG model.  This enforces explicit port VLAN assignment, by setting `vlan_default_pvid = 0`.  Hence, untagged frames on tagged ports are now dropped by default.

Finally, fix VLAN filtering detection.  Until now the filtering was always enabled, but worked fine in tests because `vlan_default_pvid` defaulted to 1, because of the YANG model's `pvid` default value.  Instead we now check if the bridge has any VLANs configured, while there are none the bridge will be VLAN agnostic, when there is at least one we enable VLAN filtering and all bridge ports that are not a tagged or untagged member will have all its frames dropped on ingress.

