### PR TITLE
Add support for reading routing operational data for IPv4

### DIFF
--- a/board/netconf/rootfs/lib/infix/cli-pretty
+++ b/board/netconf/rootfs/lib/infix/cli-pretty
@@ -14,6 +14,12 @@ class Pad:
     state = 12
     data = 41
 
+class PadRoute:
+    prefix = 30
+    protocol = 10
+    next_hop = 30
+    metric = 10
+
 class Decore():
     @staticmethod
     def decorate(sgr, txt, restore="0"):
@@ -31,27 +37,53 @@ class Decore():
     def green(txt):
         return Decore.decorate("32", txt, "39")
 
+def get_json_data(default, indata, *args):
+    data = indata
+    for arg in args:
+        if arg in data:
+            data = data.get(arg)
+        else:
+            return default
+
+    return data
+
+class Route:
+    def __init__(self,data):
+        self.data = data
+        self.prefix = data.get('ietf-ipv4-unicast-routing:destination-prefix', '')
+        self.protocol = data.get('source-protocol','')[14:]
+        self.metric = data.get('route-preference','')
+
+        interface = get_json_data(None, self.data, 'next-hop', 'outgoing-interface')
+        address = get_json_data(None, self.data, 'next-hop', 'ietf-ipv4-unicast-routing:next-hop-address')
+        special = get_json_data(None, self.data, 'next-hop', 'special-next-hop')
+        if interface:
+            self.next_hop = interface
+        elif address:
+            self.next_hop = address
+        elif special:
+            self.next_hop = special
+        else:
+            self.next_hop = "unspecified"
+
+    def print(self):
+          row  = f"{self.prefix:<{PadRoute.prefix}}"
+          row += f"{self.next_hop:<{PadRoute.next_hop}}"
+          row += f"{self.metric:<{PadRoute.metric}}"
+          row += f"{self.protocol:<{PadRoute.protocol}}"
+          print(row)
+
 class Iface:
-    def get_json_data(self, default, *args):
-        data = self.data
-        for arg in args:
-            if arg in data:
-                data = data.get(arg)
-            else:
-                return default
-
-        return data
-
     def __init__(self, data):
         self.data = data
         self.name = data.get('name', '')
         self.type = data.get('type', '')
         self.index = data.get('if-index', '')
         self.oper_status = data.get('oper-status', '')
-        self.autoneg = self.get_json_data('unknown', 'ieee802-ethernet-interface:ethernet',
+        self.autoneg = get_json_data('unknown', self.data, 'ieee802-ethernet-interface:ethernet',
                                           'auto-negotiation', 'enable')
-        self.duplex = self.get_json_data('', 'ieee802-ethernet-interface:ethernet', 'duplex')
-        self.speed = self.get_json_data('', 'ieee802-ethernet-interface:ethernet', 'speed')
+        self.duplex = get_json_data('', self.data,'ieee802-ethernet-interface:ethernet','duplex')
+        self.speed = get_json_data('', self.data, 'ieee802-ethernet-interface:ethernet', 'speed')
         self.phys_address = data.get('phys-address', '')
 
         if data.get('statistics'):
@@ -231,8 +263,8 @@ class Iface:
             print(f"{'in-octets':<{20}}: {self.in_octets}")
             print(f"{'out-octets':<{20}}: {self.out_octets}")
 
-        frame = self.get_json_data([], 'ieee802-ethernet-interface:ethernet',
-                                   'statistics', 'frame')
+        frame = get_json_data([], self.data,'ieee802-ethernet-interface:ethernet',
+                              'statistics', 'frame')
         if frame:
             print(f"")
             for key, val in frame.items():
@@ -297,6 +329,25 @@ def ietf_interfaces(json, name):
             sys.exit(1)
         pr_interface_list(json)
 
+def ietf_routing(json, protocol="ipv4"):
+    if not json.get("ietf-routing:routing"):
+        print(f"Error, top level \"ietf-routing:routing\" missing")
+        sys.exit(1)
+    routes = get_json_data({}, json, 'ietf-routing:routing','ribs', 'rib')[0]
+    routes = get_json_data(None, routes, "routes", "route")
+
+    hdr = (f"{'PREFIX':<{PadRoute.prefix}}"
+           f"{'NEXT-HOP':<{PadRoute.next_hop}}"
+           f"{'METRIC':<{PadRoute.metric}}"
+           f"{'PROTOCOL':<{PadRoute.protocol}}")
+
+    print(Decore.invert(hdr))
+
+    if routes:
+        for r in routes:
+            route = Route(r)
+            route.print()
+
 def main():
     try:
         json_data = json.load(sys.stdin)
@@ -309,6 +360,8 @@ def main():
 
     if args.module == "ietf-interfaces":
         sys.exit(ietf_interfaces(json_data, args.name))
+    if args.module == "ietf-routing":
+        sys.exit(ietf_routing(json_data, args.name))
     else:
         print(f"Error, unknown module {args.module}")
         sys.exit(1)

--- a/board/netconf/rootfs/lib/infix/yanger
+++ b/board/netconf/rootfs/lib/infix/yanger
@@ -116,6 +116,40 @@ def iface_is_dsa(iface_in):
         return False
     return True
 
+def add_ipv4_route(routes):
+    cmd = ['ip', '-4', '-s', '-d', '-j', 'route']
+    data = run_json_cmd(cmd)
+    out={}
+    out["route"] = []
+
+    for d in data:
+        new = {}
+        next_hop = {}
+        if(d['dst'] == "default"):
+            d['dst'] = "0.0.0.0/0"
+        if(d['dst'].find('/') == -1):
+            d['dst'] = d['dst']+"/32"
+        new['ietf-ipv4-unicast-routing:destination-prefix'] = d['dst']
+        new['source-protocol'] = "infix-routing:"+d['protocol']
+        if d.get("metric"):
+            new['route-preference'] = d['metric']
+
+        if d['type'] == "blackhole":
+            next_hop['special-next-hop'] = "blackhole"
+        if d['type'] == "unreachable":
+            next_hop['special-next-hop'] = "unreachable"
+
+        if d['type'] == "unicast":
+            if(d.get("gateway")):
+                next_hop['ietf-ipv4-unicast-routing:next-hop-address'] = d['gateway']
+            elif(d.get("dev")):
+                next_hop['outgoing-interface'] = d['dev']
+
+        new['next-hop'] = next_hop
+
+        out['route'].append(new)
+    insert(routes, 'routes', out)
+
 def add_ip_link(ifname, iface_out):
     cmd = ['ip', '-s', '-d', '-j', 'link', 'show', 'dev', ifname]
 
@@ -125,7 +159,6 @@ def add_ip_link(ifname, iface_out):
         sys,exit(1)
 
     iface_in = data[0]
-    iface_out = yang_data['ietf-interfaces:interfaces']['interface'][0]
 
     if 'ifname' in iface_in:
         iface_out['name'] = iface_in['ifname']
@@ -323,25 +356,48 @@ def add_ethtool_std(ifname, iface_out):
             insert(iface_out, "ieee802-ethernet-interface:ethernet", "speed", str(num))
 
 if __name__ == "__main__":
-    yang_data = {
-        "ietf-interfaces:interfaces": {
-            "interface": [{}]
-        }
-    }
-
-    # For now, we handle each interface separately, as this is how it's
-    # currently implemented in sysrepo. I.e sysrepo will subscribe to
-    # each individual interface and query it for YANG data.
-    if len(sys.argv) != 2:
-        print(f"usage: yanger IFNAME", file=sys.stderr)
+    if len(sys.argv) < 2:
+        print(f"usage: yanger <model> [params]", file=sys.stderr)
         sys.exit(1)
 
-    ifname = sys.argv[1]
-    iface_out = yang_data['ietf-interfaces:interfaces']['interface'][0]
+    model = sys.argv[1]
+    if(model == 'ietf-interfaces'):
+        # For now, we handle each interface separately, as this is how it's
+        # currently implemented in sysrepo. I.e sysrepo will subscribe to
+        # each individual interface and query it for YANG data.
 
-    add_ip_link(ifname, iface_out)
-    add_ip_addr(ifname, iface_out)
-    add_ethtool_groups(ifname, iface_out)
-    add_ethtool_std(ifname, iface_out)
+        if len(sys.argv) != 3:
+            print(f"usage: yanger ietf-interfaces IFNAME", file=sys.stderr)
+            sys.exit(1)
 
+        yang_data = {
+            "ietf-interfaces:interfaces": {
+                "interface": [{}]
+            }
+        }
+
+        ifname = sys.argv[2]
+        iface_out = yang_data['ietf-interfaces:interfaces']['interface'][0]
+
+        add_ip_link(ifname, iface_out)
+        add_ip_addr(ifname, iface_out)
+        add_ethtool_groups(ifname, iface_out)
+        add_ethtool_std(ifname, iface_out)
+    elif(model == 'ietf-routing'):
+        yang_data = {
+            "ietf-routing:routing": {
+                "ribs":  {
+                    "rib": [{
+                        "name": "ipv4",
+                        "address-family": "ipv4",
+                    }]
+                }
+            }
+        }
+
+        ipv4routes = yang_data['ietf-routing:routing']['ribs']['rib'][0]
+        add_ipv4_route(ipv4routes);
+    else:
+        print(f"Unsupported model {model}", file=sys.stderr)
+        sys.exit(1)
     print(json.dumps(yang_data, indent=2))

--- a/external.mk
+++ b/external.mk
@@ -17,3 +17,10 @@ run:
 run-menuconfig: $(BUILD_DIR)/buildroot-config/mconf
 	CONFIG_="CONFIG_" BR2_CONFIG="$(BINARIES_DIR)/.config" \
 		$(BUILD_DIR)/buildroot-config/mconf $(BINARIES_DIR)/Config.in
+
+define FRR_POST_BUILD_HOOK
+	mkdir -p $(TARGET_DIR)/etc/iproute2/
+	cp -r $(@D)/tools/etc/iproute2/rt_protos.d/ $(TARGET_DIR)/etc/iproute2/
+endef
+
+FRR_POST_BUILD_HOOKS += FRR_POST_BUILD_HOOK

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -711,6 +711,6 @@ UseTab: Always
 # Infix overrides
 #
 ColumnLimit: 0
-ForEachMacros: ['LYX_LIST_FOR_EACH', 'TAILQ_FOREACH', 'LY_LIST_FOR']
+ForEachMacros: ['LYX_LIST_FOR_EACH', 'TAILQ_FOREACH', 'LY_LIST_FOR', 'json_array_foreach']
 UseTab: AlignWithSpaces
 ...

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -170,7 +170,7 @@ sysrepoctl -s $SEARCH							\
 	   -i ieee802-dot1q-types@2022-10-29.yang -g wheel -p 0660	\
 	   -i infix-ip@2023-09-14.yang		-g wheel -p 0660	\
 	   -i infix-if-type@2023-08-21.yang	-g wheel -p 0660	\
-	   -i infix-routing@2013-10-27.yang     -g wheel -p 0660        \
+	   -i infix-routing@2023-11-23.yang     -g wheel -p 0660        \
 	   -i infix-interfaces@2023-09-19.yang	-g wheel -p 0660	\
 		-e vlan-filtering					\
 	   -i ieee802-dot1ab-lldp@2022-03-15.yang -g wheel -p 0660	\

--- a/src/confd/yang/infix-routing@2013-10-27.yang
+++ b/src/confd/yang/infix-routing@2013-10-27.yang
@@ -43,10 +43,37 @@ module infix-routing {
       }
     }
 
+    identity infix-source-protocol {
+      description "Infix naming of source protocols";
+    }
+    identity kernel {
+      description "Kernel added route";
+      base infix-source-protocol;
+    }
+    identity static {
+      description "Static added route";
+      base infix-source-protocol;
+    }
+    identity ospf {
+      description "OSPF added route";
+      base infix-source-protocol;
+    }
+    identity dhcp {
+      description "DHCP added route";
+      base infix-source-protocol;
+    }
     deviation "/ietf-r:routing/ietf-r:control-plane-protocols/ietf-r:control-plane-protocol/ietf-r:name" {
       description "Limitation: Only one routing instance per protocol.";
       deviate replace {
 	type infix-control-plane-name;
+      }
+    }
+    deviation "/ietf-r:routing/ietf-r:ribs/ietf-r:rib/ietf-r:routes/ietf-r:route/ietf-r:source-protocol" {
+      description "Use type names from iproute2";
+      deviate replace {
+	type identityref {
+	  base infix-source-protocol;
+	}
       }
     }
     /* Static routes */
@@ -61,6 +88,9 @@ module infix-routing {
       deviate not-supported;
     }
     deviation "/ietf-r:routing/ietf-r:ribs/ietf-r:rib/ietf-r:active-route" {
+      deviate not-supported;
+    }
+    deviation "/ietf-r:routing/ietf-r:ribs/ietf-r:rib/ietf-r:routes/ietf-r:route/ietf-r:next-hop/ietf-r:next-hop-options/ietf-r:next-hop-list" {
       deviate not-supported;
     }
 

--- a/src/confd/yang/infix-routing@2023-11-23.yang
+++ b/src/confd/yang/infix-routing@2023-11-23.yang
@@ -17,7 +17,13 @@ module infix-routing {
       prefix ospf;
     }
     */
-    revision 2013-10-27 {
+    revision 2023-11-23 {
+      description "Limit to one instance per control plane protocol,
+	and change to infix (iproute2) specific source protocol names
+	for routes";
+      reference "internal";
+    }
+    revision 2023-10-27 {
       description "Initial revision.";
       reference "internal";
     }

--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -230,6 +230,12 @@
     </SWITCH>
   </COMMAND>
 
+  <COMMAND name="routes" help="Show routing table">
+    <ACTION sym="script">
+      sysrepocfg -f json -X -d operational -m ietf-routing | \
+      /lib/infix/cli-pretty "ietf-routing"
+    </ACTION>
+  </COMMAND>
   <!-- https://www.cisco.com/c/en/us/td/docs/wireless/access_point/mob_exp/83/cmd-ref/me_cr_book/me_ports_and_interfaces_cli.html -->
   <COMMAND name="interfaces" help="Show interface info">
     <SWITCH name="optional" min="0" max="1">

--- a/test/case/cli_pretty/all.yaml
+++ b/test/case/cli_pretty/all.yaml
@@ -32,8 +32,13 @@
     - "-n vlan1"
 
 - case: run.sh
-  name: "interface-birdge"
+  name: "interface-bridge"
   opts:
     - "json/bloated.json"
     - "ietf-interfaces"
     - "-n br0"
+- case: run.sh
+  name: "routing"
+  opts:
+    - "json/bloated.json"
+    - "ietf-routing"

--- a/test/case/cli_pretty/json/bloated.json
+++ b/test/case/cli_pretty/json/bloated.json
@@ -1,4 +1,53 @@
 {
+  "ietf-routing:routing": {
+    "ribs": {
+      "rib": [
+        {
+          "name": "ipv4",
+          "address-family": "ietf-routing:ipv4",
+          "routes": {
+            "route": [
+              {
+                "next-hop": {
+                  "outgoing-interface": "e0"
+                },
+                "source-protocol": "infix-routing:kernel",
+                "ietf-ipv4-unicast-routing:destination-prefix": "1.1.1.0/24"
+              },
+              {
+                "next-hop": {
+                  "ietf-ipv4-unicast-routing:next-hop-address": "1.1.1.1"
+                },
+                "source-protocol": "infix-routing:static",
+                "ietf-ipv4-unicast-routing:destination-prefix": "192.168.100.0/24"
+              },
+              {
+                "next-hop": {
+                  "special-next-hop": "blackhole"
+                },
+                "source-protocol": "infix-routing:static",
+                "ietf-ipv4-unicast-routing:destination-prefix": "192.168.110.2/32"
+              },
+              {
+                "next-hop": {
+                  "special-next-hop": "blackhole"
+                },
+                "source-protocol": "infix-routing:static",
+                "ietf-ipv4-unicast-routing:destination-prefix": "192.168.120.2/32"
+              },
+              {
+                "next-hop": {
+                  "special-next-hop": "unreachable"
+                },
+                "source-protocol": "infix-routing:static",
+                "ietf-ipv4-unicast-routing:destination-prefix": "192.168.130.2/32"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
   "ietf-interfaces:interfaces": {
     "interface": [
       {
@@ -138,7 +187,7 @@
             {
               "ip": "10.140.211.247",
               "prefix-length": 24,
-              "origin" : "static"
+              "origin": "static"
             }
           ]
         },
@@ -175,22 +224,22 @@
             {
               "ip": "192.168.76.120",
               "prefix-length": 24,
-              "origin" : "static"
+              "origin": "static"
             },
             {
               "ip": "192.168.151.147",
               "prefix-length": 24,
-              "origin" : "static"
+              "origin": "static"
             },
             {
               "ip": "192.168.161.217",
               "prefix-length": 24,
-              "origin" : "dhcp"
+              "origin": "dhcp"
             },
             {
               "ip": "192.168.55.37",
               "prefix-length": 24,
-              "origin" : "dhcp"
+              "origin": "dhcp"
             },
             {
               "ip": "192.168.231.242",
@@ -457,12 +506,12 @@
             {
               "ip": "172.28.29.76",
               "prefix-length": 24,
-              "origin" : "static"
+              "origin": "static"
             },
             {
               "ip": "172.16.187.13",
               "prefix-length": 24,
-              "origin" : "static"
+              "origin": "static"
             }
           ]
         },


### PR DESCRIPTION
In the CLI:
admin@infix-00-00-00:/> show routes
```
PREFIX                        DESTINATION                   PROTOCOL  METRIC
1.1.1.0/24                    e0                            kernel
192.168.100.0/24              1.1.1.1                       static    20
192.168.110.2/32              blackhole                     static    20
192.168.120.2/32              blackhole                     static    20
192.168.130.2/32              unreachable                   static    20
```
EDIT by @rical : framed output in markdown ```