### PR TITLE
Draft infix deviations for ieee802-ethernet-interfaces

### DIFF
--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -180,6 +180,7 @@ sysrepoctl -s $SEARCH							\
 	   -i infix-system@2023-10-19.yang	-g wheel -p 0660	\
 	   -i infix-services@2023-10-16.yang	-g wheel -p 0660	\
 	   -i ieee802-ethernet-interface@2019-06-21.yang -g wheel -p 0660 \
+	   -i infix-ethernet-interface@2023-11-22.yang -g wheel -p 0660 \
 	   -I "${INIT_DATA}"
 rc=$?
 

--- a/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
+++ b/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
@@ -25,8 +25,9 @@ module infix-ethernet-interface {
 
 
   /* Deviations for config and status */
+
   deviation "/if:interfaces/if:interface/eth:ethernet" {
-    deviate replace {
+    deviate add {
       config false;
     }
   }

--- a/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
+++ b/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
@@ -1,0 +1,62 @@
+module infix-ethernet-interface {
+  yang-version 1.1;
+  namespace "urn:infix:ethernet-interface:ns:yang:1.0";
+  prefix infix-eth;
+
+  import ieee802-ethernet-interface {
+    prefix eth;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
+
+  organization "KernelKit";
+  contact      "kernelkit@googlegroups.com";
+  description  "Extensions and deviations to ieee802-ethernet-interface.yang";
+
+  revision 2023-11-22 {
+    description "Initial revision.";
+    reference "internal";
+  }
+
+  /*
+   * Data Nodes
+   */
+
+
+  /* Deviations for config and status */
+  deviation "/if:interfaces/if:interface/eth:ethernet" {
+    deviate replace {
+      config false;
+    }
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:flow-control" {
+    deviate not-supported;
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:max-frame-length" {
+    deviate not-supported;
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:mac-control-extension-control" {
+    deviate not-supported;
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:frame-limit-slow-protocol" {
+    deviate not-supported;
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:capabilities" {
+    deviate not-supported;
+  }
+
+  /* Deviations for statistics */
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:statistics/eth:frame/eth:in-total-frames" {
+    deviate not-supported;
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:statistics/eth:frame/eth:out-error-mac-internal-frames" {
+    deviate not-supported;
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:statistics/eth:phy" {
+    deviate not-supported;
+  }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:statistics/eth:mac-control" {
+    deviate not-supported;
+  } 
+}


### PR DESCRIPTION
- Add deviations for non-supported statistics
- Limit config, currently we only have ro support
- Add deviations for non-supported configs and status leafs

[skip ci]