### PR TITLE
Simplify CLI use by collapsing containers with only list elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,20 @@ is brief example of how to set the IP address of an interface:
 
 ```
 admin@infix-12-34-56:/> configure
-admin@infix-12-34-56:/config/> edit interfaces interface eth0
-admin@infix-12-34-56:/config/interfaces/interface/eth0/> set ipv4 <TAB>
+admin@infix-12-34-56:/config/> edit interface eth0
+admin@infix-12-34-56:/config/interface/eth0/> set ipv4 <TAB>
       address     autoconf bind-ni-name      enabled
 	  forwarding  mtu      neighbor
-admin@infix-12-34-56:/config/interfaces/interface/eth0/> set ipv4 address 192.168.2.200 prefix-length 24
-admin@infix-12-34-56:/config/interfaces/interface/eth0/> show
-type ethernetCsmacd;
-ipv4 address 192.168.2.200 prefix-length 24;
-ipv6 enabled true;
-admin@infix-12-34-56:/config/interfaces/interface/eth0/> diff
+admin@infix-12-34-56:/config/interface/eth0/> set ipv4 address 192.168.2.200 prefix-length 24
+admin@infix-12-34-56:/config/interface/eth0/> show
+type ethernet;
+ipv4 {
+  address 192.168.2.200 {
+    prefix-length 24;
+  }
+}
+ipv6
+admin@infix-12-34-56:/config/interface/eth0/> diff
 interfaces {
   interface eth0 {
 +    ipv4 {
@@ -50,13 +54,15 @@ interfaces {
 +    }
   }
 }
-admin@infix-12-34-56:/config/interfaces/interface/eth0/> leave
-admin@infix-12-34-56:/> show interfaces brief
-lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
-eth0             UP             52:54:00:12:34:56 <BROADCAST,MULTICAST,UP,LOWER_UP>
-admin@infix-12-34-56:/> show ip brief
-lo               UNKNOWN        127.0.0.1/8 ::1/128
-eth0             UP             192.168.2.200/24 fe80::5054:ff:fe12:3456/64
+admin@infix-12-34-56:/config/interface/eth0/> leave
+admin@infix-12-34-56:/> show interfaces
+INTERFACE       PROTOCOL   STATE       DATA
+eth0            ethernet   UP          52:54:00:12:34:56
+                ipv4                   192.168.2.200/24 (static)
+                ipv6                   fe80::5054:ff:fe12:3456/64 (link-layer)
+lo              ethernet   UP          00:00:00:00:00:00
+                ipv4                   127.0.0.1/8 (static)
+                ipv6                   ::1/128 (static)
 admin@infix-12-34-56:/> copy running-config startup-config
 ```
 

--- a/doc/cli/introduction.md
+++ b/doc/cli/introduction.md
@@ -65,16 +65,16 @@ save the changes for the next reboot.
 
 ```
 admin@host-12-34-56:/> configure
-admin@host-12-34-56:/config/> edit interfaces interface eth0
-admin@host-12-34-56:/config/interfaces/interface/eth0/> set ipv4 <TAB>
+admin@host-12-34-56:/config/> edit interface eth0
+admin@host-12-34-56:/config/interface/eth0/> set ipv4 <TAB>
       address     autoconf bind-ni-name      enabled
 	  forwarding  mtu      neighbor
-admin@host-12-34-56:/config/interfaces/interface/eth0/> set ipv4 address 192.168.2.200 prefix-length 24
-admin@host-12-34-56:/config/interfaces/interface/eth0/> show
+admin@host-12-34-56:/config/interface/eth0/> set ipv4 address 192.168.2.200 prefix-length 24
+admin@host-12-34-56:/config/interface/eth0/> show
 type ethernetCsmacd;
 ipv4 address 192.168.2.200 prefix-length 24;
 ipv6 enabled true;
-admin@host-12-34-56:/config/interfaces/interface/eth0/> diff
+admin@host-12-34-56:/config/interface/eth0/> diff
 interfaces {
   interface eth0 {
 +    ipv4 {
@@ -84,7 +84,7 @@ interfaces {
 +    }
   }
 }
-admin@host-12-34-56:/config/interfaces/interface/eth0/> leave
+admin@host-12-34-56:/config/interface/eth0/> leave
 admin@host-12-34-56:/> show interfaces brief
 lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
 eth0             UP             52:54:00:12:34:56 <BROADCAST,MULTICAST,UP,LOWER_UP>

--- a/doc/cli/tutorial.md
+++ b/doc/cli/tutorial.md
@@ -133,15 +133,15 @@ admin@host:/config/>
 The `edit` command lets you change to a sub-configure context, e.g.:
 
 ```
-admin@host:/config/> edit interfaces interface eth0
-admin@host:/config/interfaces/interface/eth0/>
+admin@host:/config/> edit interface eth0
+admin@host:/config/interface/eth0/>
 ```
 
 Use `up` to go up one level.
 
 ```
-admin@host:/config/interfaces/interface/eth0/> up
-admin@host:/config/interfaces/>
+admin@host:/config/interface/eth0/> up
+admin@host:/config/>
 ```
 
 > **Note:** the tree structure in the configure context is automatically
@@ -154,16 +154,16 @@ admin@host:/config/interfaces/>
 ### Set IP Address on an Interface
 
 ```
-admin@host:/config/> edit interfaces interface eth0
-admin@host:/config/interfaces/interface/eth0/>
-admin@host:/config/interfaces/interface/eth0/> set ipv4 address 192.168.2.200 prefix-length 24
+admin@host:/config/> edit interface eth0
+admin@host:/config/interface/eth0/>
+admin@host:/config/interface/eth0/> set ipv4 address 192.168.2.200 prefix-length 24
 ```
 
 From anywhere in configure context you can see the changes you have
 made by typing `diff`:
 
 ```
-admin@host:/config/interfaces/interface/eth0/> diff
+admin@host:/config/interface/eth0/> diff
 interfaces {
   interface eth0 {
 +    ipv4 {
@@ -181,7 +181,7 @@ interfaces {
 Apply the changes (from candidate to `running-config`):
 
 ```
-admin@host:/config/interfaces/> leave
+admin@host:/config/interface/eth0/> leave
 admin@host:/> show running-config
 ...
 interfaces {
@@ -259,11 +259,11 @@ pair which is useful for connecting, e.g., a container to the physical
 world.  Here we also add an IPv4 address to one end of the pair.
 
 ```
-admin@host:/config/> edit interfaces interface veth0a
-admin@host:/config/interfaces/interface/veth0a/> set veth peer veth0b
-admin@host:/config/interfaces/interface/veth0a/> set ipv4 address 192.168.0.1 prefix-length 24
-admin@host:/config/interfaces/interface/veth0a/> up
-admin@host:/config/interfaces/> diff
+admin@host:/config/> edit interface veth0a
+admin@host:/config/interface/veth0a/> set veth peer veth0b
+admin@host:/config/interface/veth0a/> set ipv4 address 192.168.0.1 prefix-length 24
+admin@host:/config/interface/veth0a/> up
+admin@host:/config/> diff
 interfaces {
 +  interface veth0a {
 +    type veth;
@@ -283,7 +283,7 @@ interfaces {
 +    }
 +  }
 }
-admin@host:/config/interfaces/> leave
+admin@host:/config/> leave
 ```
 
 See the bridging example below for more.
@@ -301,12 +301,12 @@ between both its bridge ports: `eth0` and `vet0b`.
 
 ```
 admin@host:/> configure
-admin@host:/config/> edit interfaces interface br0
-admin@host:/config/interfaces/interface/br0/> set bridge ieee-group-forward lldp
-admin@host:/config/interfaces/interface/br0/> up
-admin@host:/config/interfaces/> set interface eth0 bridge-port bridge br0
-admin@host:/config/interfaces/> set interface veth0b bridge-port bridge br0
-admin@host:/config/interfaces/> diff
+admin@host:/config/> edit interface br0
+admin@host:/config/interface/br0/> set bridge ieee-group-forward lldp
+admin@host:/config/interface/br0/> up
+admin@host:/config/> set interface eth0 bridge-port bridge br0
+admin@host:/config/> set interface veth0b bridge-port bridge br0
+admin@host:/config/> diff
 interfaces {
 +  interface br0 {
 +    type bridge;

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -327,6 +327,44 @@ possible to specify use of a random identifier ([ietf-ip][ietf-ip-yang] YANG and
 Both the link-local address (fe80::) and the global address (2001:)
 have changed type to *random*. 
 
+## Routing support
+| **Yang Model**                                  | **Description**                                            |
+|:----------------------------------------------- |:---------------------------------------------------------- |
+| ietf-routing                                    |  Base routing model, required for all other routing models |
+| ietf-ipv4-unicast-routing                       |  Static IPv4 unicast routing                               |
+
+The only name allowed for a control-plane-protocol is just now
+*default*. This will result in that you can only have one instance per
+routing protocol.
+
+### Static routes
+
+	admin@example:/config/> edit routing
+	admin@example:/config/> edit routing control-plane-protocols control-plane-protocol static name default static-routes ipv4
+	admin@example:/config/routing/control-plane-protocols/control-plane-protocol/static/name/default/static-routes/ipv4/> set route 192.168.200.0/24 next-hop next-hop-address 192.168.1.1
+	admin@example:/config/routing/control-plane-protocols/control-plane-protocol/static/name/default/static-routes/ipv4/> leave
+
+
+### View IPv4 routing table
+The routing table can be viewed by Netconf or CLI
+
+	admin@example:/> show routes
+	PREFIX                        NEXT-HOP                      METRIC    PROTOCOL
+	192.168.1.0/24                e0                                      kernel
+	192.168.200.0/24              192.168.1.1                   20        static
+
+The source protocol describes the origin of the route.
+
+| **Protocol** | **Description**                                                      |
+|:-------------|:---------------------------------------------------------------------|
+| kernel       | Added when setting a subnet address on an interface                  |
+| static       | User created static routes                                           |
+| dhcp         | Routes retrieved from DHCP                                           |
+
+
+The YANG model *ietf-routing* support multiple ribs but only two is
+currently supported, they are named ipv4 and ipv6.
+
 [ietf-ip-yang]:         https://www.rfc-editor.org/rfc/rfc8344.html
 [ietf-ipv6-privacy]:    https://www.rfc-editor.org/rfc/rfc8981.html
 

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -34,11 +34,11 @@ In Infix ports are by default not switch ports, unless the customer specific fac
 
 ```
 admin@example:/> configure
-admin@example:/config/> edit interfaces interface br0
-admin@example:/config/interfaces/interface/br0/> up
-admin@example:/config/interfaces/> set interface eth0 bridge-port bridge br0
-admin@example:/config/interfaces/> set interface eth1 bridge-port bridge br0
-admin@example:/config/interfaces/> leave
+admin@example:/config/> edit interface br0
+admin@example:/config/interface/br0/> up
+admin@example:/config/> set interface eth0 bridge-port bridge br0
+admin@example:/config/> set interface eth1 bridge-port bridge br0
+admin@example:/config/> leave
 ```
 
 Here we add two ports to bridge `br0`: `eth0` and `eth1`. 
@@ -51,15 +51,15 @@ By default bridges in Linux do not filter based on VLAN tags.   It can be enable
 Use the port default VID (PVID) setting to control VLAN association for traffic ingressing a port untagged (default PVID: 1). 
 
 ```
-admin@example:/config/> edit interfaces interface br0 
-admin@example:/config/interfaces/interface/br0/> up
-admin@example:/config/interfaces/> set interface eth0 bridge-port bridge br0
-admin@example:/config/interfaces/> set interface eth0 bridge-port pvid 10
-admin@example:/config/interfaces/> set interface eth1 bridge-port bridge br0
-admin@example:/config/interfaces/> set interface eth1 bridge-port pvid 20
-admin@example:/config/interfaces/> edit interface br0
-admin@example:/config/interfaces/interface/br0/> set bridge vlans vlan 10 untagged eth0
-admin@example:/config/interfaces/interface/br0/> set bridge vlans vlan 20 untagged eth1
+admin@example:/config/> edit interface br0
+admin@example:/config/interface/br0/> up
+admin@example:/config/> set interface eth0 bridge-port bridge br0
+admin@example:/config/> set interface eth0 bridge-port pvid 10
+admin@example:/config interface eth1 bridge-port bridge br0
+admin@example:/config/> set interface eth1 bridge-port pvid 20
+admin@example:/config/> edit interface br0
+admin@example:/config/interface/br0/> set bridge vlans vlan 10 untagged eth0
+admin@example:/config/interface/br0/> set bridge vlans vlan 20 untagged eth1
 ```
 
 This sets `eth0` as an untagged member of VLAN 10 and `eth1` as an
@@ -69,8 +69,8 @@ prohibited.
 To terminate a VLAN in the switch itself, either for switch management or for routing, the bridge must become a (tagged) member of the VLAN. 
 
 ```
-admin@example:/config/interfaces/interface/br0/> set bridge vlans vlan 10 tagged br0
-admin@example:/config/interfaces/interface/br0/> set bridge vlans vlan 20 tagged br0
+admin@example:/config/interface/br0/> set bridge vlans vlan 10 tagged br0
+admin@example:/config/interface/br0/> set bridge vlans vlan 20 tagged br0
 ```
 > To route or to manage via a VLAN, a VLAN interface also needs to be created on top of the bridge, see section [VLAN Interfaces](#vlan-interfaces) below.
 
@@ -84,20 +84,20 @@ A VLAN interface is basically a filtering abstraction. When you run `tcpdump` on
 
 ```
 admin@example:/> configure 
-admin@example:/config/> edit interfaces interface eth0.20
-admin@example:/config/interfaces/interface/eth0.20/> set vlan id 20
-admin@example:/config/interfaces/interface/eth0.20/> set vlan lower-layer-if eth0
-admin@example:/config/interfaces/interface/eth0.20/> leave
+admin@example:/config/> edit interface eth0.20
+admin@example:/config/interface/eth0.20/> set vlan id 20
+admin@example:/config/interface/eth0.20/> set vlan lower-layer-if eth0
+admin@example:/config/interface/eth0.20/> leave
 ```
 
 The example below assumes bridge br0 is already created, see [VLAN Filtering Bridge](#vlan-filtering-bridge).
 
 ```
 admin@example:/> configure 
-admin@example:/config/> edit interfaces interface vlan10
-admin@example:/config/interfaces/interface/vlan10/> set vlan id 10
-admin@example:/config/interfaces/interface/vlan10/> set vlan lower-layer-if br0
-admin@example:/config/interfaces/interface/vlan10/> leave
+admin@example:/config/> edit interface vlan10
+admin@example:/config/interface/vlan10/> set vlan id 10
+admin@example:/config/interface/vlan10/> set vlan lower-layer-if br0
+admin@example:/config/interface/vlan10/> leave
 ```
 
 As conventions, a VLAN interface for VID 20 on top of an Ethernet interface *eth0* is named *eth0.20*, and a VLAN interface for VID 10 on top of a bridge interface *br0* is named *vlan10*. 
@@ -163,10 +163,10 @@ default.
 ![Setting static IPv4 (and link-local IPv4)](img/ip-address-example-ipv4-static.svg)
 
     admin@example:/> configure
-    admin@example:/config/> edit interfaces interface eth0 ipv4
-    admin@example:/config/interfaces/interface/eth0/ipv4/> set address 10.0.1.1 prefix-length 24
-    admin@example:/config/interfaces/interface/eth0/ipv4/> set autoconf enabled true 
-	admin@example:/config/interfaces/interface/eth0/ipv4/> diff
+    admin@example:/config/> edit interface eth0 ipv4
+    admin@example:/config/interface/eth0/ipv4/> set address 10.0.1.1 prefix-length 24
+    admin@example:/config/interface/eth0/ipv4/> set autoconf enabled true
+	admin@example:/config/interface/eth0/ipv4/> diff
     +interfaces {
     +  interface eth0 {
     +    ipv4 {
@@ -179,7 +179,7 @@ default.
     +    }
     +  }
     +}
-    admin@example:/config/interfaces/interface/eth0/ipv4/> leave
+    admin@example:/config/interface/eth0/ipv4/> leave
     admin@example:/> show interfaces 
     INTERFACE       PROTOCOL   STATE       DATA                                     
     eth0            ethernet   UP          02:00:00:00:00:00                        
@@ -202,7 +202,7 @@ enabled true`.  The resulting address (169.254.1.3/16) is of type
     admin@example:/> configure 
     admin@example:/config/> edit dhcp-client 
     admin@example:/config/dhcp-client/> set client-if eth0
-    admin@example:/config/dhcp-client/> set enabled true 
+    admin@example:/config/dhcp-client/> set enabled true
     admin@example:/config/dhcp-client/> leave
     admin@example:/> show interfaces 
     INTERFACE       PROTOCOL   STATE       DATA                                     
@@ -222,11 +222,11 @@ The resulting address (10.1.2.100/24) is of type *dhcp*.
 The (only) way to disable IPv6 link-local addresses is by disabling IPv6 on the interface.
 
 ```(disabling
-admin@example:/> configure 
-admin@example:/config/> edit interfaces interface eth0 ipv6
-admin@example:/config/interfaces/interface/eth0/ipv6/> set enabled false
-admin@example:/config/interfaces/interface/eth0/ipv6/> leave
-admin@example:/> show interfaces 
+admin@example:/> configure
+admin@example:/config/> edit interface eth0 ipv6
+admin@example:/config/interface/eth0/ipv6/> set enabled false
+admin@example:/config/interface/eth0/ipv6/> leave
+admin@example:/> show interfaces
 INTERFACE       PROTOCOL   STATE       DATA                                     
 eth0            ethernet   UP          02:00:00:00:00:00                        
 lo              ethernet   UP          00:00:00:00:00:00                        
@@ -239,10 +239,10 @@ admin@example:/>
 
 ![Setting static IPv6](img/ip-address-example-ipv6-static.svg)
 
-    admin@example:/> configure 
-    admin@example:/config/> edit interfaces interface eth0 ipv6
-    admin@example:/config/interfaces/interface/eth0/ipv6/> set address 2001:db8::1 prefix-length 64
-    admin@example:/config/interfaces/interface/eth0/ipv6/> leave
+    admin@example:/> configure
+    admin@example:/config/> edit interface eth0 ipv6
+    admin@example:/config/interface/eth0/ipv6/> set address 2001:db8::1 prefix-length 64
+    admin@example:/config/interface/eth0/ipv6/> leave
     admin@example:/> show interfaces 
     INTERFACE       PROTOCOL   STATE       DATA                                     
     eth0            ethernet   UP          02:00:00:00:00:00                        
@@ -264,7 +264,7 @@ identifier. The resulting address is of type *link-layer*, as it
 is formed based on the interface identifier ([IETF
 ip-yang][ietf-ip-yang]). 
 
-    admin@example:/> show interfaces 
+    admin@example:/> show interfaces
     INTERFACE       PROTOCOL   STATE       DATA                                     
     eth0            ethernet   UP          02:00:00:00:00:00                        
                     ipv6                   2001:db8:0:1:0:ff:fe00:0/64 (link-layer)
@@ -278,9 +278,9 @@ Disabling auto-configuration of global IPv6 addresses can be done as shown
 below.
 
     admin@example:/> configure
-    admin@example:/config/> edit interfaces interface eth0 ipv6
-    admin@example:/config/interfaces/interface/eth0/ipv6/> set autoconf create-global-addresses false 
-    admin@example:/config/interfaces/interface/eth0/ipv6/> leave
+    admin@example:/config/> edit interface eth0 ipv6
+    admin@example:/config/interface/eth0/ipv6/> set autoconf create-global-addresses false
+    admin@example:/config/interface/eth0/ipv6/> leave
     admin@example:/> show interfaces 
     INTERFACE       PROTOCOL   STATE       DATA                                     
     eth0            ethernet   UP          02:00:00:00:00:00                        
@@ -297,7 +297,7 @@ below.
 By default, the auto-configured link-local and global IPv6 addresses
 are formed from a link-identifier based on the MAC address.
 
-    admin@example:/> show interfaces 
+    admin@example:/> show interfaces
     INTERFACE       PROTOCOL   STATE       DATA                                     
     eth0            ethernet   UP          02:00:00:00:00:00                        
                     ipv6                   2001:db8:0:1:0:ff:fe00:0/64 (link-layer)
@@ -310,10 +310,10 @@ are formed from a link-identifier based on the MAC address.
 To avoid revealing identity information in the IPv6 address, it is
 possible to specify use of a random identifier ([ietf-ip][ietf-ip-yang] YANG and [RFC8981][ietf-ipv6-privacy]).
 
-    admin@example:/> configure 
-    admin@example:/config/> edit interfaces interface eth0 ipv6
-    admin@example:/config/interfaces/interface/eth0/ipv6/> set autoconf create-temporary-addresses true 
-    admin@example:/config/interfaces/interface/eth0/ipv6/> leave
+    admin@example:/> configure
+    admin@example:/config/> edit interface eth0 ipv6
+    admin@example:/config/interface/eth0/ipv6/> set autoconf create-temporary-addresses true
+    admin@example:/config/interface/eth0/ipv6/> leave
     admin@example:/> show interfaces 
     INTERFACE       PROTOCOL   STATE       DATA                                     
     eth0            ethernet   UP          02:00:00:00:00:00                        
@@ -328,30 +328,32 @@ Both the link-local address (fe80::) and the global address (2001:)
 have changed type to *random*. 
 
 ## Routing support
-| **Yang Model**                                  | **Description**                                            |
-|:----------------------------------------------- |:---------------------------------------------------------- |
-| ietf-routing                                    |  Base routing model, required for all other routing models |
-| ietf-ipv4-unicast-routing                       |  Static IPv4 unicast routing                               |
 
-The only name allowed for a control-plane-protocol is just now
-*default*. This will result in that you can only have one instance per
-routing protocol.
+| **Yang Model**            | **Description**                                           |
+|:--------------------------|:----------------------------------------------------------|
+| ietf-routing              | Base routing model, required for all other routing models |
+| ietf-ipv4-unicast-routing | Static IPv4 unicast routing                               |
 
 ### Static routes
 
-	admin@example:/config/> edit routing
-	admin@example:/config/> edit routing control-plane-protocols control-plane-protocol static name default static-routes ipv4
-	admin@example:/config/routing/control-plane-protocols/control-plane-protocol/static/name/default/static-routes/ipv4/> set route 192.168.200.0/24 next-hop next-hop-address 192.168.1.1
-	admin@example:/config/routing/control-plane-protocols/control-plane-protocol/static/name/default/static-routes/ipv4/> leave
+    admin@example:/> configure
+    admin@example:/config/> edit routing control-plane-protocol static name default
+    admin@example:/config/routing/control-plane-protocol/static/name/default/> set ipv4 route 192.168.200.0/24 next-hop next-hop-address 192.168.1.1
+    admin@example:/config/routing/control-plane-protocol/static/name/default/> leave
+    admin@example:/>
 
+> **Note:** The only name allowed for a control-plane-protocol is currently
+> *default*.  Meaning, you can only have one instance per routing protocol.
 
 ### View IPv4 routing table
-The routing table can be viewed by Netconf or CLI
 
-	admin@example:/> show routes
-	PREFIX                        NEXT-HOP                      METRIC    PROTOCOL
-	192.168.1.0/24                e0                                      kernel
-	192.168.200.0/24              192.168.1.1                   20        static
+The routing table can be viewed from the operational datastore over
+NETCONF or using the CLI:
+
+    admin@example:/> show routes
+    PREFIX                        NEXT-HOP                      METRIC    PROTOCOL
+    192.168.1.0/24                e0                                      kernel
+    192.168.200.0/24              192.168.1.1                   20        static
 
 The source protocol describes the origin of the route.
 
@@ -361,14 +363,15 @@ The source protocol describes the origin of the route.
 | static       | User created static routes                                           |
 | dhcp         | Routes retrieved from DHCP                                           |
 
-
-The YANG model *ietf-routing* support multiple ribs but only two is
-currently supported, they are named ipv4 and ipv6.
+The YANG model *ietf-routing* support multiple ribs but only two are
+currently supported, namely `ipv4` and `ipv6`.
 
 [ietf-ip-yang]:         https://www.rfc-editor.org/rfc/rfc8344.html
 [ietf-ipv6-privacy]:    https://www.rfc-editor.org/rfc/rfc8981.html
 
 [^1]: Please note, link aggregates are not yet supported in Infix.
-[^2]: Link-local IPv6 addresses are implicitly enabled when enabling IPv6. IPv6 can be enabled/disabled per interface in [ietf-ip][ietf-ip-yang] YANG model.
+[^2]: Link-local IPv6 addresses are implicitly enabled when enabling IPv6.
+    IPv6 can be enabled/disabled per interface in the [ietf-ip][ietf-ip-yang]
+    YANG model.
 
 

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
@@ -1,3 +1,3 @@
 # Locally calculated
 sha256  9d9d33b873917ca5d0bdcc47a36d2fd385971ab0c045d1472fcadf95ee5bcf5b  LICENCE
-sha256  90382b48994e3c56de1909dedc67ddd42d0af6fb12b8adfa41bde9316997ef2d  klish-plugin-sysrepo-5c1e96304093d8076dbc0920440328ecfb927663-br1.tar.gz
+sha256  468b9a4da872257795964e2fff17fbfc5a592070a98a0a51e5f54464171ee73f  klish-plugin-sysrepo-fa1228a7ff2b3500b8c1bc6f6f0d28bddd2d0a91-br1.tar.gz

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KLISH_PLUGIN_SYSREPO_VERSION = 5c1e96304093d8076dbc0920440328ecfb927663
+KLISH_PLUGIN_SYSREPO_VERSION = fa1228a7ff2b3500b8c1bc6f6f0d28bddd2d0a91
 KLISH_PLUGIN_SYSREPO_SITE = https://github.com/kernelkit/klish-plugin-sysrepo.git
 #KLISH_PLUGIN_SYSREPO_VERSION = cdd3eb51a7f7ee0ed5bd925fa636061d3b1b85fb
 #KLISH_PLUGIN_SYSREPO_SITE = https://src.libcode.org/pkun/klish-plugin-sysrepo.git

--- a/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
+++ b/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
@@ -23,14 +23,20 @@ module infix-ethernet-interface {
    * Data Nodes
    */
 
-
   /* Deviations for config and status */
+
+/* The following works with yanglint but is not supported by pyang.
+   Actually, the same error message is shown also by NETCONFc, so
+   we drop this for the v23.11 release.  Despite not supporting
+   writing to any of these nodes.
 
   deviation "/if:interfaces/if:interface/eth:ethernet" {
     deviate add {
       config false;
     }
   }
+*/
+
   deviation "/if:interfaces/if:interface/eth:ethernet/eth:flow-control" {
     deviate not-supported;
   }

--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -109,7 +109,7 @@
     <ACTION sym="prompt" exec_on="always">%u@%h:/> </ACTION>
 </PROMPT>
 
-<COMMAND name="help" help="Help system (also try '?' key)">
+<COMMAND name="help" help="Help system (try also the '?' key)">
   <PARAM name="topic" ptype="/STRING" min="0" help="Help topic">
     <COMPL>
       <ACTION sym="printl">keybindings</ACTION>
@@ -414,7 +414,7 @@
 
   <PROMPT>
     <ACTION sym="srp_prompt@sysrepo">%u@%h:%w%x/> </ACTION>
-</PROMPT>
+  </PROMPT>
 
 <HOTKEY key="^D" cmd="exit"/>
 <HOTKEY key="^Z" cmd="leave"/>
@@ -507,6 +507,5 @@
   <VIEW name="operational" ref="/main"/>
 </COMMAND>
 
-  </VIEW>
-
+</VIEW>
 </KLISH>


### PR DESCRIPTION
We've been annoyed by typing `edit interfaces interface e0` for a long time now, but with the addition of static routing I felt it was time to do something about it.  I started out playing with schema mounts, but since alias/subtree mounts and/or xpaths don't seem to be allowed atm. there does not seem much to be earned from going down that path[^1].  So instead I went for patching the klish-plugin-sysrepo code.

The insanity of having to type:

    admin@example:/config/> edit routing control-plane-protocols control-plane-protocol static name default static-routes ipv4
    admin@example:/config/routing/control-plane-protocols/control-plane-protocol/static/name/default/static-routes/ipv4/> set route 192.168.200.0/24 next-hop next-hop-address 192.168.1.1

has now been replaced with the slightly less annoying:

    admin@example:/config/> edit routing control-plane-protocol static name default
    admin@example:/config/routing/control-plane-protocol/static/name/default/> set ipv4 route 192.168.200.0/24 next-hop next-hop-address 192.168.1.1

The same goes for every other YANG construct where container is followed by a single list element.  E.g., `edit interface e0` instead.  For details, see https://github.com/kernelkit/klish-plugin-sysrepo/commit/fa1228a7ff2b3500b8c1bc6f6f0d28bddd2d0a91

The routing documentation and all other documentation has been updated accordingly.

----

While playing around with klish-plugin-sysrepo I also started looking at the `srp_show@` symbol and why it doesn't show everything, e.g., when in configure interface e0 context.  I couldn't fix it 100%, so that patch is for later.

[^1]: Found the following information that might be of interest later on: https://docplayer.net/234227614-Needing-an-extensible-mount-syntax-across-schema-alias-peers.html, https://github.com/sysrepo/sysrepo/issues/2842, and Clixon also describe this in their documentation today.