### PR TITLE
package/confd: install avahi _netconf-ssh._tcp service record

### DIFF
--- a/package/confd/avahi.service
+++ b/package/confd/avahi.service
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">%h</name>
+  <service>
+    <type>_netconf-ssh._tcp</type>
+    <port>830</port>
+  </service>
+</service-group>

--- a/package/confd/confd.mk
+++ b/package/confd/confd.mk
@@ -17,6 +17,8 @@ define CONFD_INSTALL_EXTRA
 	cp $(CONFD_PKGDIR)/confd.conf  $(FINIT_D)/available/
 	ln -sf ../available/confd.conf $(FINIT_D)/enabled/confd.conf
 	cp $(CONFD_PKGDIR)/tmpfiles.conf $(TARGET_DIR)/etc/tmpfiles.d/confd.conf
+	mkdir -p $(TARGET_DIR)/etc/avahi/services
+	cp $(CONFD_PKGDIR)/avahi.service $(TARGET_DIR)/etc/avahi/services/netconf.service
 endef
 CONFD_POST_INSTALL_TARGET_HOOKS += CONFD_INSTALL_EXTRA
 


### PR DESCRIPTION
Currently we only advertise SSH+SFTP services over mDNS-SD, which are the default services from the avahi package.  This patch adds support for _netconf-ssh._tcp as well.