### PR TITLE
confd: add the ability to set speed, duplex and autoneg

### DIFF
--- a/board/netconf/rootfs/libexec/infix/yanger
+++ b/board/netconf/rootfs/libexec/infix/yanger
@@ -13,6 +13,9 @@ def json_get_yang_type(iface_in):
     if iface_in['link_type'] != "ether":
         return "infix-if-type:other";
 
+    if 'parentbus' in iface_in and iface_in['parentbus'] == "virtio":
+        return "infix-if-type:etherlike";
+
     if not 'linkinfo' in iface_in:
         return "infix-if-type:ethernet"
 

--- a/board/netconf/rootfs/libexec/infix/yanger
+++ b/board/netconf/rootfs/libexec/infix/yanger
@@ -584,8 +584,10 @@ if __name__ == "__main__":
 
         add_ip_link(ifname, iface_out, args.test)
         add_ip_addr(ifname, iface_out, args.test)
-        add_ethtool_groups(ifname, iface_out, args.test)
-        add_ethtool_std(ifname, iface_out, args.test)
+
+        if 'type' in iface_out and iface_out['type'] == "infix-if-type:ethernet":
+            add_ethtool_groups(ifname, iface_out, args.test)
+            add_ethtool_std(ifname, iface_out, args.test)
     elif (args.model == 'ietf-routing'):
         yang_data = {
             "ietf-routing:routing": {

--- a/src/confd/bin/gen-interfaces
+++ b/src/confd/bin/gen-interfaces
@@ -69,16 +69,16 @@ gen_interface()
 EOF
 
     if [ -n "$br" ]; then
-	cat <<EOF
+        cat <<EOF
         "ietf-ip:ipv6": {
-	    "enabled": false
-	},
-	"infix-interfaces:bridge-port": {
-	    "bridge": "$br"
-	}
+            "enabled": false
+        },
+        "infix-interfaces:bridge-port": {
+            "bridge": "$br"
+        }
 EOF
     else
-	cat <<EOF
+        cat <<EOF
         "ietf-ip:ipv6": {}
 EOF
     fi
@@ -90,48 +90,48 @@ EOF
 
 while [ "$1" != "" ]; do
     case $1 in
-	-4)
-	    ipv4=true
-	    ;;
-	-b)
-	    bridge="$2"
-	    shift
-	    ;;
-	-d)
-	    dhcp=true
-	    ;;
-	-h)
-	    usage
-	    ;;
-	*)
-	    break
+        -4)
+            ipv4=true
+            ;;
+        -b)
+            bridge="$2"
+            shift
+            ;;
+        -d)
+            dhcp=true
+            ;;
+        -h)
+            usage
+            ;;
+        *)
+            break
     esac
     shift
 done
 
 phys_ifaces=$(ip -d -j link show | jq -r '
-	 .[] |
-	 select(.link_type == "ether") |
-	 select(.group != "internal")  |
-	 select(has("parentbus")) |
-	 .ifname' | sort -V)
+         .[] |
+         select(.link_type == "ether") |
+         select(.group != "internal")  |
+         select(has("parentbus")) |
+         .ifname' | sort -V)
 ports=$(ip -d -j link show group port | jq -r '
-	 .[] |
-	 select(.link_type == "ether") |
-	 select(.group != "internal")  |
-	 select(has("parentbus")) |
-	 .ifname' | sort -V)
+         .[] |
+         select(.link_type == "ether") |
+         select(.group != "internal")  |
+         select(has("parentbus")) |
+         .ifname' | sort -V)
 ifaces=""
 for phy in $phys_ifaces; do
     found=""
     for port in $ports; do
-	if [ "$port" = "$phy" ]; then
-	   found=true
-	   break
-	fi
+        if [ "$port" = "$phy" ]; then
+           found=true
+           break
+        fi
     done
     if [ -z "$found" ]; then
-	ifaces="$ifaces $phy"
+        ifaces="$ifaces $phy"
     fi
 done
 
@@ -156,12 +156,12 @@ if [ -n "$bridge" ]; then
         "name": "$bridge",
         "type": "infix-if-type:bridge",
         "ietf-ip:ipv4": {
-	    "infix-ip:autoconf": {
+            "infix-ip:autoconf": {
                 "enabled": $ipv4
             }
         },
-	"ietf-ip:ipv6": {
-	    "enabled": true
+        "ietf-ip:ipv6": {
+            "enabled": true
         }
 EOF
 fi

--- a/src/confd/bin/gen-interfaces
+++ b/src/confd/bin/gen-interfaces
@@ -57,15 +57,16 @@ EOF
 }
 
 # shellcheck disable=SC3043
-gen_interface()
+gen_iface_json()
 {
-    local ifname="$1"
-    local br="$2"
+    local iftype="$1"
+    local ifname="$2"
+    local br="$3"
 
     cat <<EOF
       ,{
         "name": "$ifname",
-        "type": "infix-if-type:ethernet",
+        "type": "$iftype",
 EOF
 
     if [ -n "$br" ]; then
@@ -86,6 +87,27 @@ EOF
     cat <<EOF
       }
 EOF
+}
+
+filter_iface_ports()
+{
+    ifaces="$1"
+    ports="$2"
+
+    iface_devs=""
+    for phy in $ifaces; do
+        found=""
+        for port in $ports; do
+            if [ "$port" = "$phy" ]; then
+               found=true
+               break
+            fi
+        done
+        if [ -z "$found" ]; then
+            iface_devs="$iface_devs $phy"
+        fi
+    done
+    echo -n "$iface_devs"
 }
 
 while [ "$1" != "" ]; do
@@ -114,6 +136,14 @@ phys_ifaces=$(ip -d -j link show | jq -r '
          select(.link_type == "ether") |
          select(.group != "internal")  |
          select(has("parentbus")) |
+         select(.parentbus != "virtio") |
+         .ifname' | sort -V)
+virtio_ifaces=$(ip -d -j link show | jq -r '
+         .[] |
+         select(.link_type == "ether") |
+         select(.group != "internal")  |
+         select(has("parentbus")) |
+         select(.parentbus == "virtio") |
          .ifname' | sort -V)
 ports=$(ip -d -j link show group port | jq -r '
          .[] |
@@ -121,19 +151,9 @@ ports=$(ip -d -j link show group port | jq -r '
          select(.group != "internal")  |
          select(has("parentbus")) |
          .ifname' | sort -V)
-ifaces=""
-for phy in $phys_ifaces; do
-    found=""
-    for port in $ports; do
-        if [ "$port" = "$phy" ]; then
-           found=true
-           break
-        fi
-    done
-    if [ -z "$found" ]; then
-        ifaces="$ifaces $phy"
-    fi
-done
+
+eth_ifaces="$(filter_iface_ports "$phys_ifaces" "$ports")"
+ethlike_ifaces="$(filter_iface_ports "$virtio_ifaces" "$ports")"
 
 cat <<EOF
 {
@@ -168,8 +188,9 @@ fi
 
 cat <<EOF
       }
-$(for iface in $ifaces; do gen_interface "$iface"; done)
-$(for iface in $ports; do gen_interface "$iface" "$bridge"; done)
+$(for iface in $eth_ifaces; do gen_iface_json "infix-if-type:ethernet" "$iface"; done)
+$(for iface in $ethlike_ifaces; do gen_iface_json "infix-if-type:etherlike" "$iface"; done)
+$(for iface in $ports; do gen_iface_json "infix-if-type:ethernet" "$iface" "$bridge"; done)
     ]
 EOF
 if [ "$dhcp" = "true" ] && [ -n "$bridge" ]; then

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -653,191 +653,74 @@ skip_mtu:
 	return err;
 }
 
-static int netdag_write_ethtool(struct dagger *net, const char *ifname,
-				const char *fmt, ...)
+static int netdag_gen_ethtool_autoneg(struct dagger *net, struct lyd_node *cif)
 {
-	va_list ap;
+	struct lyd_node *eth = lydx_get_child(cif, "ethernet");
+	struct lyd_node *aneg = lydx_get_child(eth, "auto-negotiation");
+	const char *ifname = lydx_get_cattr(cif, "name");
+	const char *speed, *duplex;
+	int mbps, err = 0;
 	FILE *fp;
 
-	fp = dagger_fopen_next(net, "init", ifname, 65, "ethtool.sh");
+	fp = dagger_fopen_next(net, "init", ifname, 10, "ethtool-aneg.sh");
 	if (!fp)
 		return -EIO;
 
-	va_start(ap, fmt);
-	vfprintf(fp, fmt, ap);
-	va_end(ap);
+	fprintf(fp, "ethtool --change %s autoneg ", ifname);
 
+	if (!aneg || lydx_is_enabled(aneg, "enable")) {
+		fputs("on\n", fp);
+	} else {
+		speed = lydx_get_cattr(eth, "speed");
+		if (!speed) {
+			sr_session_set_error_message(net->session, "%s: "
+						     "\"speed\" must be specified "
+						     "when auto-negotiation is disabled", ifname);
+			err = -EINVAL;
+			goto out;
+		}
+
+		mbps = (int)(atof(speed) * 1000.);
+		if (!((mbps == 10) || (mbps == 100))) {
+				sr_session_set_error_message(net->session, "%s: "
+						     "\"speed\" must be either 0.01 or 0.1 "
+						     "when auto-negotiation is disabled", ifname);
+			err = -EINVAL;
+			goto out;
+		}
+
+		duplex = lydx_get_cattr(eth, "duplex");
+		if (!duplex || (strcmp(duplex, "full") && strcmp(duplex, "half"))) {
+			sr_session_set_error_message(net->session, "%s: "
+						     "\"duplex\" must be either "
+						     "\"full\" or \"half\" "
+						     "when auto-negotiation is disabled", ifname);
+			err = -EINVAL;
+			goto out;
+		}
+
+		fprintf(fp,"off speed %d duplex %s\n", mbps, duplex);
+	}
+out:
 	fclose(fp);
+	return err;
 
-	return 0;
-}
-
-static const char *lyd_get_autoneg(struct lyd_node *cif)
-{
-	struct lydx_diff nd;
-	struct lyd_node *node;
-
-	node = lydx_get_descendant(lyd_child(cif), "ethernet", "auto-negotiation", "enable", NULL);
-	if (node && lydx_get_diff(node, &nd) && nd.new)
-		return (strcmp(nd.val, "true") == 0) ? "on" : "off";
-
-	return NULL;
-}
-
-static const char *lyd_get_duplex(struct lyd_node *cif)
-{
-	struct lydx_diff nd;
-	struct lyd_node *node;
-
-	node = lydx_get_descendant(lyd_child(cif), "ethernet", "duplex", NULL);
-	if (node && lydx_get_diff(node, &nd) && nd.new)
-		return nd.val;
-
-	return NULL;
-}
-
-static int lyd_get_speed(struct lyd_node *cif)
-{
-	struct lydx_diff nd;
-	struct lyd_node *n;
-
-	n = lydx_get_descendant(lyd_child(cif), "ethernet", "speed", NULL);
-	if (n && lydx_get_diff(n, &nd) && nd.new)
-		return (int)(atof(nd.val) * 1000);
-
-	return 0;
-}
-
-static int lyd_speed_has_changed(struct lyd_node *dif)
-{
-	struct lydx_diff nd;
-	struct lyd_node *n;
-
-	n = lydx_get_descendant(lyd_child(dif), "ethernet", "speed", NULL);
-	return (n && lydx_get_diff(n, &nd));
-}
-
-static int lyd_duplex_has_changed(struct lyd_node *dif)
-{
-	struct lydx_diff nd;
-	struct lyd_node *n;
-
-	n = lydx_get_descendant(lyd_child(dif), "ethernet", "duplex", NULL);
-	return (n && lydx_get_diff(n, &nd));
-}
-
-static int lyd_autoneg_has_changed(struct lyd_node *dif)
-{
-	struct lydx_diff nd;
-	struct lyd_node *n;
-
-	n = lydx_get_descendant(lyd_child(dif), "ethernet", "auto-negotiation", "enable", NULL);
-	return (n && lydx_get_diff(n, &nd));
-}
-
-static int lyd_autoneg_is_on(struct lyd_node *cif)
-{
-	const char *val;
-
-	val = lyd_get_autoneg(cif);
-	if (!val) {
-		/* TODO Change this to error when auto-neg is true in factory config */
-		return 1;
-	}
-	return (strcmp(val, "on") == 0);
-}
-
-static int netdag_set_autoneg_off(struct dagger *net, const char *ifname,
-				  const char *duplex, int speed)
-{
-	if (!speed || !duplex) {
-		sr_session_set_error_message(net->session,
-					     "Autoneg off requires explicit speed and duplex");
-		return SR_ERR_INVAL_ARG;
-	}
-
-	return netdag_write_ethtool(net, ifname,
-				    "ethtool -s %s autoneg off duplex %s speed %d\n",
-				    ifname, duplex, speed);
-}
-
-static int netdag_set_autoneg_on(struct dagger *net, const char *ifname)
-{
-	return netdag_write_ethtool(net, ifname, "ethtool -s %s autoneg on\n", ifname);
-}
-
-static int netdag_set_autoneg(struct dagger *net, const char *ifname, struct lyd_node *cif)
-{
-	const char *autoneg = lyd_get_autoneg(cif);
-	const char *duplex = lyd_get_duplex(cif);
-	int speed = lyd_get_speed(cif);
-
-	if (!autoneg)
-		return SR_ERR_INVAL_ARG;
-
-	if (strcmp(autoneg, "off") == 0)
-		return netdag_set_autoneg_off(net, ifname, duplex, speed);
-
-	return netdag_set_autoneg_on(net, ifname);
-}
-
-static int netdag_set_speed(struct dagger *net, const char *ifname, struct lyd_node *cif)
-{
-	int speed = lyd_get_speed(cif);
-
-	if (!speed && !lyd_autoneg_is_on(cif)) {
-		sr_session_set_error_message(net->session,
-					     "Can't remove speed when autoneg is disabled");
-		return SR_ERR_INVAL_ARG;
-	}
-
-	return netdag_write_ethtool(net, ifname, "ethtool -s %s speed %d\n",
-				    ifname, speed);
-}
-
-static int netdag_set_duplex(struct dagger *net, const char *ifname, struct lyd_node *cif)
-{
-	const char *duplex = lyd_get_duplex(cif);
-
-	/**
-	 * Duplex has a default value, no need to check if autoneg is off and
-	 * the duplex is removed, which would be a problem otherwise.
-	 */
-
-	return netdag_write_ethtool(net, ifname, "ethtool -s %s duplex %s\n",
-				    ifname, duplex);
 }
 
 static int netdag_gen_ethtool(struct dagger *net, struct lyd_node *cif, struct lyd_node *dif)
 {
-	const char *ifname = lydx_get_cattr(cif, "name");
+	struct lyd_node *eth = lydx_get_child(dif, "ethernet");
 	int err;
 
-	if (!strcmp(ifname, "lo"))
-		return SR_ERR_OK;
-
-	/**
-	 * Autoneg on means duplex and speed doesn't matter.
-	 * Autoneg off requires and set both speed and duplex.
-	 *
-	 * Either way, if autoneg has changed duplex and speed are handled.
-	 */
-	if (lyd_autoneg_has_changed(dif))
-		return netdag_set_autoneg(net, ifname, cif);
-
-	if (lyd_duplex_has_changed(dif)) {
-		err = netdag_set_duplex(net, ifname, cif);
+	if (lydx_get_descendant(lyd_child(eth), "auto-negotiation", "enable", NULL) ||
+	    lydx_get_child(eth, "speed") ||
+	    lydx_get_child(eth, "duplex")) {
+		err = netdag_gen_ethtool_autoneg(net, cif);
 		if (err)
 			return err;
 	}
 
-	if (lyd_speed_has_changed(dif)) {
-		err = netdag_set_speed(net, ifname, cif);
-		if (err)
-			return err;
-	}
-
-	return SR_ERR_OK;
+	return 0;
 }
 
 static int bridge_diff_vlan_port(struct dagger *net, FILE *br, const char *brname, int vid,

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -1070,7 +1070,8 @@ static bool netdag_must_del(struct lyd_node *dif, struct lyd_node *cif)
 {
 	const char *iftype = lydx_get_cattr(cif, "type");
 
-	if (strcmp(iftype, "infix-if-type:ethernet")) {
+	if (strcmp(iftype, "infix-if-type:ethernet") &&
+	    strcmp(iftype, "infix-if-type:etherlike")) {
 		if (is_phys_addr_deleted(dif))
 			return true;
 	}

--- a/src/confd/yang/infix-if-type@2023-08-21.yang
+++ b/src/confd/yang/infix-if-type@2023-08-21.yang
@@ -40,7 +40,13 @@ module infix-if-type {
   identity ethernet {
     base infix-interface-type;
     base ianaift:ethernetCsmacd;
-    description "Any Ethernet-like interfaces, regardless of speed, RFC 3635.";
+    description "Any Ethernet interfaces, regardless of speed, RFC 3635.";
+    reference   "RFC 3635";
+  }
+  identity etherlike {
+    base infix-interface-type;
+    base ianaift:ilan;
+    description "Interface with properties resembling Ethernet";
     reference   "RFC 3635";
   }
   identity lag {

--- a/test/case/cli/cli-output/show-interface-br0.txt
+++ b/test/case/cli/cli-output/show-interface-br0.txt
@@ -2,21 +2,8 @@ name                : br0
 index               : 7
 mtu                 : 1500
 operational status  : up
-auto-negotiation    : on
-duplex              : full
-speed               : 10000
 physical address    : 02:00:00:00:00:00
 ipv4 addresses      :
 ipv6 addresses      :
 in-octets           : 0
 out-octets          : 3158
-
-eth-out-frames               : 713
-eth-out-multicast-frames     : 605
-eth-out-broadcast-frames     : 69
-eth-in-frames                : 418
-eth-in-multicast-frames      : 336
-eth-in-broadcast-frames      : 46
-eth-in-error-fcs-frames      : 0
-eth-in-total-frames          : 418
-eth-in-error-oversize-frames : 0

--- a/test/case/cli/cli-output/show-interface-e2.txt
+++ b/test/case/cli/cli-output/show-interface-e2.txt
@@ -2,21 +2,8 @@ name                : e2
 index               : 4
 mtu                 : 1500
 operational status  : up
-auto-negotiation    : on
-duplex              : full
-speed               : 10000
 physical address    : 02:00:00:00:00:02
 ipv4 addresses      :
 ipv6 addresses      :
 in-octets           : 17582
 out-octets          : 1327
-
-eth-out-frames               : 713
-eth-out-multicast-frames     : 605
-eth-out-broadcast-frames     : 69
-eth-in-frames                : 418
-eth-in-multicast-frames      : 336
-eth-in-broadcast-frames      : 46
-eth-in-error-fcs-frames      : 0
-eth-in-total-frames          : 418
-eth-in-error-oversize-frames : 0

--- a/test/case/cli/cli-output/show-interface-e3.txt
+++ b/test/case/cli/cli-output/show-interface-e3.txt
@@ -2,21 +2,8 @@ name                : e3
 index               : 5
 mtu                 : 1500
 operational status  : up
-auto-negotiation    : on
-duplex              : full
-speed               : 10000
 physical address    : 02:00:00:00:00:03
 ipv4 addresses      :
 ipv6 addresses      :
 in-octets           : 15057
 out-octets          : 1327
-
-eth-out-frames               : 713
-eth-out-multicast-frames     : 605
-eth-out-broadcast-frames     : 69
-eth-in-frames                : 418
-eth-in-multicast-frames      : 336
-eth-in-broadcast-frames      : 46
-eth-in-error-fcs-frames      : 0
-eth-in-total-frames          : 418
-eth-in-error-oversize-frames : 0

--- a/test/case/cli/cli-output/show-interface-e4.txt
+++ b/test/case/cli/cli-output/show-interface-e4.txt
@@ -2,21 +2,8 @@ name                : e4
 index               : 6
 mtu                 : 1500
 operational status  : down
-auto-negotiation    : on
-duplex              : full
-speed               : 10000
 physical address    : 02:00:00:00:00:04
 ipv4 addresses      :
 ipv6 addresses      :
 in-octets           : 19022
 out-octets          : 1327
-
-eth-out-frames               : 713
-eth-out-multicast-frames     : 605
-eth-out-broadcast-frames     : 69
-eth-in-frames                : 418
-eth-in-multicast-frames      : 336
-eth-in-broadcast-frames      : 46
-eth-in-error-fcs-frames      : 0
-eth-in-total-frames          : 418
-eth-in-error-oversize-frames : 0

--- a/test/case/cli/system-output/ethtool-br0.txt
+++ b/test/case/cli/system-output/ethtool-br0.txt
@@ -1,39 +1,17 @@
-Settings for e0:
-	Supported ports: [  ]
-	Supported link modes:   10baseT/Half 10baseT/Full
-	                        100baseT/Half 100baseT/Full
-	                        1000baseT/Full
-	                        10000baseT/Full
-	                        2500baseT/Full
-	                        5000baseT/Full
-	Supported pause frame use: Symmetric
-	Supports auto-negotiation: Yes
-	Supported FEC modes: Not reported
-	Advertised link modes:  10baseT/Half 10baseT/Full
-	                        100baseT/Half 100baseT/Full
-	                        1000baseT/Full
-	                        10000baseT/Full
-	                        2500baseT/Full
-	                        5000baseT/Full
-	Advertised pause frame use: Symmetric
-	Advertised auto-negotiation: Yes
-	Advertised FEC modes: Not reported
-	Link partner advertised link modes:  10baseT/Half 10baseT/Full
-	                                     100baseT/Half 100baseT/Full
-	                                     1000baseT/Full
-	                                     10000baseT/Full
-	                                     2500baseT/Full
-	                                     5000baseT/Full
-	Link partner advertised pause frame use: Symmetric
-	Link partner advertised auto-negotiation: Yes
-	Link partner advertised FEC modes: Not reported
-	Speed: 10000Mb/s
-	Duplex: Full
-	Auto-negotiation: on
-	Port: Twisted Pair
-	PHYAD: 4
-	Transceiver: external
-	MDI-X: on (auto)
-	Supports Wake-on: g
-	Wake-on: d
-	Link detected: yes
+Settings for br0:
+        Supported ports: [  ]
+        Supported link modes:   Not reported
+        Supported pause frame use: No
+        Supports auto-negotiation: No
+        Supported FEC modes: Not reported
+        Advertised link modes:  Not reported
+        Advertised pause frame use: No
+        Advertised auto-negotiation: No
+        Advertised FEC modes: Not reported
+        Speed: Unknown!
+        Duplex: Unknown! (255)
+        Auto-negotiation: off
+        Port: Other
+        PHYAD: 0
+        Transceiver: internal
+        Link detected: yes

--- a/test/case/cli/system-output/ip-link-show-dev-e0.json
+++ b/test/case/cli/system-output/ip-link-show-dev-e0.json
@@ -67,8 +67,8 @@
     "tso_max_size": 65536,
     "tso_max_segs": 65535,
     "gro_max_size": 65536,
-    "parentbus": "virtio",
-    "parentdev": "virtio2",
+    "parentbus": "e1000",
+    "parentdev": "e1000-foobar",
     "stats64": {
       "rx": {
         "bytes": 6537,

--- a/test/case/cli/system-output/ip-link-show-dev-e1.json
+++ b/test/case/cli/system-output/ip-link-show-dev-e1.json
@@ -67,8 +67,8 @@
     "tso_max_size": 65536,
     "tso_max_segs": 65535,
     "gro_max_size": 65536,
-    "parentbus": "virtio",
-    "parentdev": "virtio3",
+    "parentbus": "e1000",
+    "parentdev": "e1000-foobar",
     "stats64": {
       "rx": {
         "bytes": 1397,

--- a/test/case/ietf_interfaces/iface_phys_address.py
+++ b/test/case/ietf_interfaces/iface_phys_address.py
@@ -20,7 +20,6 @@ with infamy.Test() as test:
             "interfaces": {
                 "interface": [{
                     "name": f"{tport}",
-                    "type": "infix-if-type:ethernet",
                     "phys-address": f"{cmac}"
                 }]
             }

--- a/test/case/ietf_interfaces/ipv4_address.py
+++ b/test/case/ietf_interfaces/ipv4_address.py
@@ -79,7 +79,6 @@ with infamy.Test() as test:
             "interfaces": {
                 "interface": [{
                     "name": f"{interface_name}",
-                    "type": "infix-if-type:ethernet",
                     "ipv4": {
                         "address": [{
                             "ip": f"{new_ip_address}",

--- a/test/case/ietf_interfaces/routing_basic.py
+++ b/test/case/ietf_interfaces/routing_basic.py
@@ -24,7 +24,6 @@ def config_target(target, tport0, tport1, enable_fwd):
                 "interface": [
                     {
                         "name": tport0,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": enable_fwd,
@@ -36,7 +35,6 @@ def config_target(target, tport0, tport1, enable_fwd):
                     },
                     {
                         "name": tport1,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": enable_fwd,

--- a/test/case/ietf_interfaces/vlan_ping.py
+++ b/test/case/ietf_interfaces/vlan_ping.py
@@ -33,7 +33,6 @@ with infamy.Test() as test:
                 "interface": [
                     {
                         "name": tport,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                     },
                     {

--- a/test/case/ietf_routing/ospf_basic.py
+++ b/test/case/ietf_routing/ospf_basic.py
@@ -9,7 +9,6 @@ def config_target1(target, data, link):
                 "interface": [
                     {
                         "name": data,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -20,7 +19,6 @@ def config_target1(target, data, link):
                     },
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -32,7 +30,6 @@ def config_target1(target, data, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "address": [{
@@ -89,7 +86,6 @@ def config_target2(target, link):
                 "interface": [
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -101,7 +97,6 @@ def config_target2(target, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "forwarding": True,
                         "ipv4": {

--- a/test/case/ietf_routing/ospf_multiarea.py
+++ b/test/case/ietf_routing/ospf_multiarea.py
@@ -35,7 +35,6 @@ def config_target1(target, ring1, ring2, cross, link):
                 "interface": [
                     {
                         "name": ring1,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -46,7 +45,6 @@ def config_target1(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": ring2,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -57,7 +55,6 @@ def config_target1(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -72,7 +69,6 @@ def config_target1(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": cross,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -84,7 +80,6 @@ def config_target1(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "address": [{
@@ -180,7 +175,6 @@ def config_target2(target, ring1, ring2, cross, link):
                 "interface": [
                     {
                         "name": ring1,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -191,7 +185,6 @@ def config_target2(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": ring2,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -202,7 +195,6 @@ def config_target2(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": cross,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -213,7 +205,6 @@ def config_target2(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -247,7 +238,6 @@ def config_target2(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "address": [{
@@ -341,7 +331,6 @@ def config_target3(target, ring1, ring2, cross, link):
             "interface": [
                 {
                     "name": ring2,
-                    "type": "infix-if-type:ethernet",
                     "enabled": True,
                     "ipv4": {
                         "forwarding": True,
@@ -353,7 +342,6 @@ def config_target3(target, ring1, ring2, cross, link):
                 },
                 {
                     "name": link,
-                    "type": "infix-if-type:ethernet",
                     "enabled": True,
                     "ipv4": {
                         "forwarding": True,
@@ -365,7 +353,6 @@ def config_target3(target, ring1, ring2, cross, link):
                 },
                 {
                     "name": cross,
-                    "type": "infix-if-type:ethernet",
                     "enabled": True,
                     "ipv4": {
                         "forwarding": True,
@@ -377,7 +364,6 @@ def config_target3(target, ring1, ring2, cross, link):
                 },
                 {
                     "name": "lo",
-                    "type": "infix-if-type:ethernet",
                     "enabled": True,
                     "ipv4": {
                         "address": [{
@@ -449,7 +435,6 @@ def config_target4(target, ring1, ring2, cross, link):
                 "interface": [
                     {
                         "name": ring1,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -460,7 +445,6 @@ def config_target4(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": cross,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -471,7 +455,6 @@ def config_target4(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -483,7 +466,6 @@ def config_target4(target, ring1, ring2, cross, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "address": [{

--- a/test/case/ietf_routing/ospf_unnumbered_interface.py
+++ b/test/case/ietf_routing/ospf_unnumbered_interface.py
@@ -13,7 +13,6 @@ def config_target1(target, data, link):
                 "interface": [
                     {
                         "name": data,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -24,7 +23,6 @@ def config_target1(target, data, link):
                     },
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -36,7 +34,6 @@ def config_target1(target, data, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "address": [{
@@ -96,7 +93,6 @@ def config_target2(target, link):
                 "interface": [
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -108,7 +104,6 @@ def config_target2(target, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "forwarding": True,
                         "ipv4": {

--- a/test/case/ietf_routing/static_routing.py
+++ b/test/case/ietf_routing/static_routing.py
@@ -29,7 +29,6 @@ def config_target1(target, data, link):
                 "interface": [
                     {
                         "name": data,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -47,7 +46,6 @@ def config_target1(target, data, link):
                     },
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -66,7 +64,6 @@ def config_target1(target, data, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "address": [{
@@ -119,7 +116,6 @@ def config_target2(target, link):
                 "interface": [
                     {
                         "name": link,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "forwarding": True,
@@ -138,7 +134,6 @@ def config_target2(target, link):
                     },
                     {
                         "name": "lo",
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "forwarding": True,
                         "ipv4": {

--- a/test/case/infix_interfaces/bridge_basic.py
+++ b/test/case/infix_interfaces/bridge_basic.py
@@ -33,7 +33,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0"

--- a/test/case/infix_interfaces/bridge_fwd_dual_dut.py
+++ b/test/case/infix_interfaces/bridge_fwd_dual_dut.py
@@ -52,7 +52,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport10,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 10,
@@ -61,7 +60,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport11,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 10,
@@ -70,7 +68,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport12,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0",
@@ -101,7 +98,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport20,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 10,
@@ -110,7 +106,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport21,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 10,
@@ -119,7 +114,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport22,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0",

--- a/test/case/infix_interfaces/bridge_fwd_sgl_dut.py
+++ b/test/case/infix_interfaces/bridge_fwd_sgl_dut.py
@@ -36,7 +36,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport0,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0"
@@ -44,7 +43,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport1,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0"

--- a/test/case/infix_interfaces/bridge_veth.py
+++ b/test/case/infix_interfaces/bridge_veth.py
@@ -25,7 +25,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0"

--- a/test/case/infix_interfaces/bridge_vlan.py
+++ b/test/case/infix_interfaces/bridge_vlan.py
@@ -56,7 +56,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 10,

--- a/test/case/infix_interfaces/bridge_vlan_separation.py
+++ b/test/case/infix_interfaces/bridge_vlan_separation.py
@@ -57,7 +57,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport10,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 10,
@@ -66,7 +65,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport11,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 20,
@@ -75,7 +73,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport12,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0",
@@ -111,7 +108,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport20,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 10,
@@ -120,7 +116,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport21,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "pvid": 20,
@@ -129,7 +124,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport22,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0",

--- a/test/case/infix_interfaces/dual_bridge.py
+++ b/test/case/infix_interfaces/dual_bridge.py
@@ -60,7 +60,6 @@ with infamy.Test() as test:
                     },
                     {
                         "name": tport,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "infix-interfaces:bridge-port": {
                             "bridge": "br0"

--- a/test/case/infix_interfaces/ipv4_autoconf.py
+++ b/test/case/infix_interfaces/ipv4_autoconf.py
@@ -18,7 +18,6 @@ with infamy.Test() as test:
                 "interface": [
                     {
                         "name": tport,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "autoconf": {

--- a/test/case/infix_services/services_basic.py
+++ b/test/case/infix_services/services_basic.py
@@ -54,7 +54,6 @@ with infamy.Test() as test:
                 "interface": [
                     {
                         "name": tport,
-                        "type": "infix-if-type:ethernet",
                         "enabled": True,
                         "ipv4": {
                             "address": [


### PR DESCRIPTION
Add the ability to configure interface speed, duplex and autoneg. Initially this was pared with YANG model deviations that restricted explicit interface speed and duplex when autoneg was enabled. But due to conflicting default states in YANG and the fact that statd also uses the same YANG meant this code was dropped.

Turning autoneg on (which is the default) is as simple as:
` > set interface x10 ethernet auto-negotiation enable true` 

However, when turning it off the kernel requires an explicit speed and duplex to be set. Ideally we would like to ensure this in the YANG model frontend, as mentioned above. This PR implements a check in the backend witch gives this error when turning off autoneg without an explicit speed and/or duplex (duplex has default):

```
> set interface x10 ethernet auto-negotiation enable false
> leave
Error: Autoneg off requires explicit speed and duplex
Please check your changes, try 'diff' and 'do show interfaces'.
```

The logic here is messy. The fact that `duplex` has a default value and `speed` does not complicates things slightly. The fact that we would prefer not to have an unused `speed` or `duplex` when autoneg is enabled is hard to solve in the backend, as we don't really want to throw an error. Also, the default `duplex` will always exists, making that check impossible without deviating it away(?)

Anyway, I tired to make the code a bit more verbose, with boilerplate like helper functions to make this messy logic easier to follow. Room for improvement here in the future.