### PR TITLE
Change the default shell of the admin user to bash

### DIFF
--- a/board/common/rootfs/etc/motd
+++ b/board/common/rootfs/etc/motd
@@ -1,0 +1,4 @@
+.-------.
+|  . .  | Infix -- a Network Operating System
+|-. v .-| https://kernelkit.github.io
+'-'---'-'

--- a/board/netconf/rootfs/bin/clish
+++ b/board/netconf/rootfs/bin/clish
@@ -1,4 +1,3 @@
-#!/bin/bash -li
+#!/bin/sh
 # Source settings, aliases, and probe terminal size, then hand over to klish
-unset HISTFILE
-exec /usr/bin/klish
+exec env CLISH=yes bash -ilc /usr/bin/klish

--- a/board/netconf/rootfs/etc/profile.d/cli-hint.sh
+++ b/board/netconf/rootfs/etc/profile.d/cli-hint.sh
@@ -1,0 +1,7 @@
+if [ -z "$CLISH" ]; then
+    cat <<EOF
+
+Run the command 'cli' for interactive OAM
+
+EOF
+fi

--- a/src/confd/bin/Makefile.am
+++ b/src/confd/bin/Makefile.am
@@ -1,2 +1,2 @@
 pkglibexec_SCRIPTS  = bootstrap error load \
-		      gen-hostkeys gen-admin-auth gen-hostname gen-interfaces
+		      gen-hostkeys gen-admin-auth gen-hostname gen-interfaces gen-motd

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -97,6 +97,7 @@ factory()
 
     # Create an overlay for /etc/hostname to change the default in an br2-external
     gen-hostname                                            >"$FACTORY_D/20-hostname.json"
+    gen-motd                                                >"$FACTORY_D/20-motd.json"
     # shellcheck disable=SC2086
     gen-interfaces $GEN_IFACE_OPTS                          >"$FACTORY_D/20-interfaces.json"
 

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -102,7 +102,7 @@ factory()
     gen-interfaces $GEN_IFACE_OPTS                          >"$FACTORY_D/20-interfaces.json"
 
     # Extract password for admin user from VPD
-    if ! gen-admin-auth infix-shell-type:clish >"$FACTORY_D/20-authentication.json"; then
+    if ! gen-admin-auth infix-shell-type:bash >"$FACTORY_D/20-authentication.json"; then
         console_error "Unable to create factory-config, gen-admin-auth failed"
         return
     fi

--- a/src/confd/bin/gen-motd
+++ b/src/confd/bin/gen-motd
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ -f /etc/motd ]; then
+    cat <<EOF
+{
+  "ietf-system:system": {
+    "infix-system:motd": "$(sed ':a;N;$!ba;s/\n/\\n/g;s/\t/\\t/g' /etc/motd)"
+  }
+}
+EOF
+else
+    echo "{}"
+fi

--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -148,7 +148,7 @@
 </COMMAND>
 
 <COMMAND name="shell" help="Enter system shell">
-  <ACTION sym="script" in="tty" out="tty" interrupt="true">/bin/bash -l</ACTION>
+  <ACTION sym="script" in="tty" out="tty" interrupt="true">/usr/bin/env CLISH=yes bash -l</ACTION>
 </COMMAND>
 
 <COMMAND name="exit" help="Exit from CLI (log out)">


### PR DESCRIPTION
This opens up lots of scripting opportunities via ssh, without first having to install some NETCONF tools to change admin's shell. 

Some things you can now do:

- SCP works out-of-the-box now: `scp admin@[fe80::ff:fe00:0%qtap0]:/etc/motd /tmp/ix-motd`
- Config can be read/modified via SSH, using sysrepocfg: `ssh admin@fe80::ff:fe00:0%qtap0 sysrepocfg -X -fjson -d operational -x "/system/hostname"`