### PR TITLE
Fix klish bug not adding prefix to identityrefs

### DIFF
--- a/doc/networking.md
+++ b/doc/networking.md
@@ -416,39 +416,39 @@ Remember to enable [IPv4 forwarding](#IPv4-forwarding) for the interfaces.
 > **Note:** The only name allowed for a control-plane-protocol is currently
 > *default*.  Meaning, you can only have one instance per routing protocol.
 
-#### OSPFv2 Routing
+### OSPFv2 Routing
 Remember to enable [IPv4 forwarding](#IPv4-forwarding) for the
 interfaces you want to run OSPFv2.
 
-    admin@example:/config/> edit routing control-plane-protocol ietf-ospf:ospfv2 name default
-    admin@example:/config/routing/control-plane-protocol/ietf-ospf:ospfv2/name/default/> set ospf area 0.0.0.0 interface e0 enabled true
-    admin@example:/config/routing/control-plane-protocol/static/name/default/> leave
+    admin@example:/config/> edit routing control-plane-protocol ospfv2 name default
+    admin@example:/config/routing/control-plane-protocol/ospfv2/name/default/> set ospf area 0.0.0.0 interface e0 enabled true
+    admin@example:/config/routing/control-plane-protocol/ospfv2/name/default/> leave
     admin@example:/>
 
 > **Note:** The only name allowed for a control-plane-protocol is currently
 > *default*.  Meaning, you can only have one instance per routing protocol.
 
-### Stub area types
+#### Stub area types
 NSSA and Stub areas are currently supported.
 
 To configure a NSSA area with summary routes:
 
-    admin@example:/config/> edit routing control-plane-protocol ietf-ospf:ospfv2 name default
-    admin@example:/config/routing/control-plane-protocol/ietf-ospf:ospfv2/name/default/> set ospf area 0.0.0.1 area-type nssa-area
-    admin@example:/config/routing/control-plane-protocol/ietf-ospf:ospfv2/name/default/> set ospf area 0.0.0.1 summary true
-    admin@example:/config/routing/control-plane-protocol/static/name/default/> leave
+    admin@example:/config/> edit routing control-plane-protocol ospfv2 name default
+    admin@example:/config/routing/control-plane-protocol/ospfv2/name/default/> set ospf area 0.0.0.1 area-type nssa-area
+    admin@example:/config/routing/control-plane-protocol/ospfv2/name/default/> set ospf area 0.0.0.1 summary true
+    admin@example:/config/routing/control-plane-protocol/ospfv2/name/default/> leave
     admin@example:/>
 
-### Bidirectional Forwarding Detection (BFD)
+#### Bidirectional Forwarding Detection (BFD)
 It is possible to enable BFD per interface to speed up detection of
 link loss.
 
-    admin@example:/config/> edit routing control-plane-protocol ietf-ospf:ospfv2 name default
-    admin@example:/config/routing/control-plane-protocol/ietf-ospf:ospfv2/name/default/ospf/> set area 0.0.0.0 interface e0 bfd enabled true
-    admin@example:/config/routing/control-plane-protocol/static/name/default/> leave
+    admin@example:/config/> edit routing control-plane-protocol ospfv2 name default
+    admin@example:/config/routing/control-plane-protocol/ospfv2/name/default/ospf/> set area 0.0.0.0 interface e0 bfd enabled true
+    admin@example:/config/routing/control-plane-protocol/ospfv2/name/default/> leave
     admin@example:/>
 
-### Debug OSPFv2
+#### Debug OSPFv2
 Using NETCONF and the YANG model *ietf-routing* it is possible to read the OSPF routing table, neighbors
 and more, that may be useful for debugging the OSPFv2 setup.
 
@@ -486,6 +486,7 @@ The source protocol describes the origin of the route.
 | kernel       | Added when setting a subnet address on an interface                  |
 | static       | User created static routes                                           |
 | dhcp         | Routes retrieved from DHCP                                           |
+| ospf         | Routes retreived from OSPFv2                                         |
 
 The YANG model *ietf-routing* support multiple ribs but only two are
 currently supported, namely `ipv4` and `ipv6`.

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
@@ -1,3 +1,3 @@
 # Locally calculated
 sha256  9d9d33b873917ca5d0bdcc47a36d2fd385971ab0c045d1472fcadf95ee5bcf5b  LICENCE
-sha256  0e7ad75fb28dd1ba7700aaaa9b0678819f81a397aefd262f64bbc50722ef6687  klish-plugin-sysrepo-51fc0afcaec5e36f23c06085cf319e8514ffb980-br1.tar.gz
+sha256  59ce3461a002a8113be030ef476940027f5e0e73dbe8afc56739cda6b55349ab  klish-plugin-sysrepo-f828a96efb12c3f7f8807aae089561fd69f4a6af-br1.tar.gz

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KLISH_PLUGIN_SYSREPO_VERSION = 51fc0afcaec5e36f23c06085cf319e8514ffb980
+KLISH_PLUGIN_SYSREPO_VERSION = f828a96efb12c3f7f8807aae089561fd69f4a6af
 KLISH_PLUGIN_SYSREPO_SITE = https://github.com/kernelkit/klish-plugin-sysrepo.git
 #KLISH_PLUGIN_SYSREPO_VERSION = cdd3eb51a7f7ee0ed5bd925fa636061d3b1b85fb
 #KLISH_PLUGIN_SYSREPO_SITE = https://src.libcode.org/pkun/klish-plugin-sysrepo.git

--- a/src/confd/yang/infix-routing@2024-01-09.yang
+++ b/src/confd/yang/infix-routing@2024-01-09.yang
@@ -172,6 +172,16 @@ module infix-routing {
       }
     }
 
+
+    deviation "/ietf-r:routing/ietf-r:control-plane-protocols/ietf-r:control-plane-protocol/ietf-r:type" {
+      deviate add {
+	must "derived-from-or-self(., 'ospf:ospfv2') or "+
+	     "derived-from-or-self(., 'ietf-r:static')" {
+	  description "Only OSPFv2 and Static routes are supported in Infix.";
+	}
+      }
+    }
+
     augment "/ietf-r:routing/ietf-r:control-plane-protocols/ietf-r:control-plane-protocol/ospf:ospf" {
       description "ietf-ospf lack the setting to generate a default route";
       container default-route-advertise {


### PR DESCRIPTION
* Update klish to fix the bug
* Update documentation (simplier configuration now)
* Add limitation (must expression) in yang to limit to supported routing protocols