### PR TITLE
Update infix-ethernet-interface

### DIFF
--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -223,7 +223,7 @@ sysrepoctl -s $SEARCH							\
 	   -i infix-system@2023-10-19.yang	-g wheel -p 0660	\
 	   -i infix-services@2023-10-16.yang	-g wheel -p 0660	\
 	   -i ieee802-ethernet-interface@2019-06-21.yang -g wheel -p 0660 \
-	   -i infix-ethernet-interface@2023-11-22.yang -g wheel -p 0660 \
+	   -i infix-ethernet-interface@2024-01-22.yang -g wheel -p 0660 \
 	   -I "${INIT_DATA}"
 rc=$?
 

--- a/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
+++ b/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
@@ -40,6 +40,9 @@ module infix-ethernet-interface {
   deviation "/if:interfaces/if:interface/eth:ethernet/eth:capabilities" {
     deviate not-supported;
   }
+  deviation "/if:interfaces/if:interface/eth:ethernet/eth:auto-negotiation/eth:negotiation-status" {
+    deviate not-supported;
+  }
 
   /* Deviations for statistics */
   deviation "/if:interfaces/if:interface/eth:ethernet/eth:statistics/eth:frame/eth:in-total-frames" {

--- a/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
+++ b/src/confd/yang/infix-ethernet-interface@2023-11-22.yang
@@ -25,18 +25,6 @@ module infix-ethernet-interface {
 
   /* Deviations for config and status */
 
-/* The following works with yanglint but is not supported by pyang.
-   Actually, the same error message is shown also by NETCONFc, so
-   we drop this for the v23.11 release.  Despite not supporting
-   writing to any of these nodes.
-
-  deviation "/if:interfaces/if:interface/eth:ethernet" {
-    deviate add {
-      config false;
-    }
-  }
-*/
-
   deviation "/if:interfaces/if:interface/eth:ethernet/eth:flow-control" {
     deviate not-supported;
   }

--- a/src/confd/yang/infix-ethernet-interface@2024-01-22.yang
+++ b/src/confd/yang/infix-ethernet-interface@2024-01-22.yang
@@ -14,6 +14,11 @@ module infix-ethernet-interface {
   contact      "kernelkit@googlegroups.com";
   description  "Extensions and deviations to ieee802-ethernet-interface.yang";
 
+  revision 2024-01-22 {
+    description "Support ethernet but not negotiation-status";
+    reference "internal";
+  }
+
   revision 2023-11-22 {
     description "Initial revision.";
     reference "internal";


### PR DESCRIPTION
* Deviate negotiation-status -> not-supported.
* Remove comment about unsupported Ethernet which is now implemented.
* Bump revision.