### PR TITLE
Initial multicast filtering support for bridge

### DIFF
--- a/package/querierd/querierd.mk
+++ b/package/querierd/querierd.mk
@@ -13,13 +13,15 @@ QUERIERD_INSTALL_STAGING = YES
 
 define QUERIERD_INSTALL_CONFIG
 	$(INSTALL) -D -m 0644 $(QUERIERD_PKGDIR)/querierd.conf \
-		$(TARGET_DIR)/etc/
+		$(TARGET_DIR)/etc/querierd/example.conf
 endef
 QUERIERD_POST_INSTALL_TARGET_HOOKS += QUERIERD_INSTALL_CONFIG
 
 define QUERIERD_INSTALL_FINIT_SVC
 	$(INSTALL) -D -m 0644 $(QUERIERD_PKGDIR)/querierd.svc \
 		$(FINIT_D)/available/querierd.conf
+	$(INSTALL) -D -m 0644 $(QUERIERD_PKGDIR)/template.svc \
+		$(FINIT_D)/available/querierd@.conf
 endef
 
 QUERIERD_POST_INSTALL_TARGET_HOOKS += QUERIERD_INSTALL_FINIT_SVC

--- a/package/querierd/template.svc
+++ b/package/querierd/template.svc
@@ -1,0 +1,3 @@
+service <net/%i/exist> \
+	[2345] querierd -sn -f /etc/querierd/%i.conf -i %i \
+	-- IGMP querier daemon @%i

--- a/patches/iproute2/0003-iplink_bridge-add-mcast_flood_always-bridge-option.patch
+++ b/patches/iproute2/0003-iplink_bridge-add-mcast_flood_always-bridge-option.patch
@@ -1,0 +1,175 @@
+From 5a2ab621675d39dc9ecbd4d65d5c7a424248cd11 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Tue, 5 Mar 2024 09:41:46 +0100
+Subject: [PATCH] iplink_bridge: add mcast_flood_always bridge option
+Organization: Addiva Elektronik
+
+ - Break out boolopt handling to simplify parsing and setting
+ - Add set/get support for mcast_flood_always
+ - Add get support for mst_enabled
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ include/uapi/linux/if_bridge.h |  1 +
+ ip/iplink_bridge.c             | 75 +++++++++++++++++++++++++---------
+ man/man8/ip-link.8.in          | 12 ++++++
+ 3 files changed, 68 insertions(+), 20 deletions(-)
+
+diff --git a/include/uapi/linux/if_bridge.h b/include/uapi/linux/if_bridge.h
+index f6d58238..aaab505d 100644
+--- a/include/uapi/linux/if_bridge.h
++++ b/include/uapi/linux/if_bridge.h
+@@ -777,6 +777,7 @@ enum br_boolopt_id {
+ 	BR_BOOLOPT_NO_LL_LEARN,
+ 	BR_BOOLOPT_MCAST_VLAN_SNOOPING,
+ 	BR_BOOLOPT_MST_ENABLE,
++	BR_BOOLOPT_MCAST_FLOOD_ALWAYS,
+ 	BR_BOOLOPT_MAX
+ };
+ 
+diff --git a/ip/iplink_bridge.c b/ip/iplink_bridge.c
+index 8b0c1422..8d4a6bb2 100644
+--- a/ip/iplink_bridge.c
++++ b/ip/iplink_bridge.c
+@@ -43,6 +43,7 @@ static void print_explain(FILE *f)
+ 		"		  [ vlan_default_pvid VLAN_DEFAULT_PVID ]\n"
+ 		"		  [ vlan_stats_enabled VLAN_STATS_ENABLED ]\n"
+ 		"		  [ vlan_stats_per_port VLAN_STATS_PER_PORT ]\n"
++		"		  [ mcast_flood_always ENABLED ]\n"
+ 		"		  [ mcast_snooping MULTICAST_SNOOPING ]\n"
+ 		"		  [ mcast_vlan_snooping MULTICAST_VLAN_SNOOPING ]\n"
+ 		"		  [ mcast_router MULTICAST_ROUTER ]\n"
+@@ -82,6 +83,18 @@ void br_dump_bridge_id(const struct ifla_bridge_id *id, char *buf, size_t len)
+ 	snprintf(buf, len, "%.2x%.2x.%s", id->prio[0], id->prio[1], eaddr);
+ }
+ 
++static void set_boolopt(struct br_boolopt_multi *bm, enum br_boolopt_id opt,
++			bool set)
++{
++	__u32 bit = 1 << opt;
++
++	bm->optmask |= 1 << opt;
++	if (set)
++		bm->optval |= bit;
++	else
++		bm->optval &= ~bit;
++}
++
+ static int bridge_parse_opt(struct link_util *lu, int argc, char **argv,
+ 			    struct nlmsghdr *n)
+ {
+@@ -216,17 +229,21 @@ static int bridge_parse_opt(struct link_util *lu, int argc, char **argv,
+ 
+ 			addattr8(n, 1024, IFLA_BR_MCAST_SNOOPING, mcast_snoop);
+ 		} else if (strcmp(*argv, "mcast_vlan_snooping") == 0) {
+-			__u32 mcvl_bit = 1 << BR_BOOLOPT_MCAST_VLAN_SNOOPING;
+-			__u8 mcast_vlan_snooping;
++			__u8 val;
+ 
+ 			NEXT_ARG();
+-			if (get_u8(&mcast_vlan_snooping, *argv, 0))
++			if (get_u8(&val, *argv, 0))
+ 				invarg("invalid mcast_vlan_snooping", *argv);
+-			bm.optmask |= 1 << BR_BOOLOPT_MCAST_VLAN_SNOOPING;
+-			if (mcast_vlan_snooping)
+-				bm.optval |= mcvl_bit;
+-			else
+-				bm.optval &= ~mcvl_bit;
++
++			set_boolopt(&bm, BR_BOOLOPT_MCAST_VLAN_SNOOPING, val);
++		} else if (strcmp(*argv, "mcast_flood_always") == 0) {
++			__u8 val;
++
++			NEXT_ARG();
++			if (get_u8(&val, *argv, 0))
++				invarg("invalid mcast_flood_always", *argv);
++
++			set_boolopt(&bm, BR_BOOLOPT_MCAST_FLOOD_ALWAYS, val);
+ 		} else if (matches(*argv, "mcast_query_use_ifaddr") == 0) {
+ 			__u8 mcast_qui;
+ 
+@@ -590,21 +607,39 @@ static void bridge_print_opt(struct link_util *lu, FILE *f, struct rtattr *tb[])
+ 			   rta_getattr_u8(tb[IFLA_BR_MCAST_SNOOPING]));
+ 
+ 	if (tb[IFLA_BR_MULTI_BOOLOPT]) {
+-		__u32 mcvl_bit = 1 << BR_BOOLOPT_MCAST_VLAN_SNOOPING;
+-		__u32 no_ll_learn_bit = 1 << BR_BOOLOPT_NO_LL_LEARN;
+ 		struct br_boolopt_multi *bm;
++		int opt;
+ 
+ 		bm = RTA_DATA(tb[IFLA_BR_MULTI_BOOLOPT]);
+-		if (bm->optmask & no_ll_learn_bit)
+-			print_uint(PRINT_ANY,
+-				   "no_linklocal_learn",
+-				   "no_linklocal_learn %u ",
+-				    !!(bm->optval & no_ll_learn_bit));
+-		if (bm->optmask & mcvl_bit)
+-			print_uint(PRINT_ANY,
+-				   "mcast_vlan_snooping",
+-				   "mcast_vlan_snooping %u ",
+-				    !!(bm->optval & mcvl_bit));
++		for (opt = 0; opt < BR_BOOLOPT_MAX; opt++) {
++			__u32 bit = 1 << opt;
++			__u32 val = !!(bm->optval & bit);
++
++			if (!(bm->optmask & bit))
++				continue;
++
++			switch (opt) {
++			case BR_BOOLOPT_NO_LL_LEARN:
++				print_uint(PRINT_ANY,
++					   "no_linklocal_learn",
++					   "no_linklocal_learn %u ", val);
++				break;
++			case BR_BOOLOPT_MCAST_VLAN_SNOOPING:
++				print_uint(PRINT_ANY,
++					   "mcast_vlan_snooping",
++					   "mcast_vlan_snooping %u ", val);
++				break;
++			case BR_BOOLOPT_MST_ENABLE:
++				print_uint(PRINT_ANY,
++					   "mst_enabled",
++					   "mst_enabled %u ", val);
++				break;
++			case BR_BOOLOPT_MCAST_FLOOD_ALWAYS:
++				print_uint(PRINT_ANY,
++					   "mcast_flood_always",
++					   "mcast_flood_always %u ", val);
++			}
++		}
+ 	}
+ 
+ 	if (tb[IFLA_BR_MCAST_ROUTER])
+diff --git a/man/man8/ip-link.8.in b/man/man8/ip-link.8.in
+index 6c72e122..4730e73a 100644
+--- a/man/man8/ip-link.8.in
++++ b/man/man8/ip-link.8.in
+@@ -1590,6 +1590,8 @@ the following additional arguments are supported:
+ ] [
+ .BI vlan_stats_per_port " VLAN_STATS_PER_PORT "
+ ] [
++.BI mcast_flood_always " ENABLED "
++] [
+ .BI mcast_snooping " MULTICAST_SNOOPING "
+ ] [
+ .BI mcast_vlan_snooping " MULTICAST_VLAN_SNOOPING "
+@@ -1718,6 +1720,16 @@ or disable
+ .RI ( VLAN_STATS_PER_PORT " == 0) "
+ per-VLAN per-port stats accounting. Can be changed only when there are no port VLANs configured.
+ 
++.BI mcast_flood_always " ENABLED "
++- always
++.RI ( ENABLED " > 0) "
++flood unknown multicast according to per-port
++.BI mcast_flood
++settings.  By default
++.RI ( ENABLED " == 0). "
++the bridge only floods until it has learned of a querier, or takes on
++the role itself.
++
+ .BI mcast_snooping " MULTICAST_SNOOPING "
+ - turn multicast snooping on
+ .RI ( MULTICAST_SNOOPING " > 0) "
+-- 
+2.34.1
+

--- a/patches/iproute2/0004-bridge-mdb-Add-replace-support.patch
+++ b/patches/iproute2/0004-bridge-mdb-Add-replace-support.patch
@@ -1,0 +1,101 @@
+From 8557acdc7218cbaf2b9d70ecfa118c05f988ed77 Mon Sep 17 00:00:00 2001
+From: Ido Schimmel <idosch@nvidia.com>
+Date: Thu, 15 Dec 2022 19:52:30 +0200
+Subject: [PATCH] bridge: mdb: Add replace support
+Organization: Addiva Elektronik
+
+Allow user space to replace MDB port group entries by specifying the
+'NLM_F_REPLACE' flag in the netlink message header.
+
+Examples:
+
+ # bridge mdb replace dev br0 port dummy10 grp 239.1.1.1 permanent source_list 192.0.2.1,192.0.2.2 filter_mode include
+ # bridge -d -s mdb show
+ dev br0 port dummy10 grp 239.1.1.1 src 192.0.2.2 permanent filter_mode include proto static     0.00
+ dev br0 port dummy10 grp 239.1.1.1 src 192.0.2.1 permanent filter_mode include proto static     0.00
+ dev br0 port dummy10 grp 239.1.1.1 permanent filter_mode include source_list 192.0.2.2/0.00,192.0.2.1/0.00 proto static     0.00
+
+ # bridge mdb replace dev br0 port dummy10 grp 239.1.1.1 permanent source_list 192.0.2.1,192.0.2.3 filter_mode exclude proto zebra
+ # bridge -d -s mdb show
+ dev br0 port dummy10 grp 239.1.1.1 src 192.0.2.3 permanent filter_mode include proto zebra  blocked    0.00
+ dev br0 port dummy10 grp 239.1.1.1 src 192.0.2.1 permanent filter_mode include proto zebra  blocked    0.00
+ dev br0 port dummy10 grp 239.1.1.1 permanent filter_mode exclude source_list 192.0.2.3/0.00,192.0.2.1/0.00 proto zebra     0.00
+
+ # bridge mdb replace dev br0 port dummy10 grp 239.1.1.1 temp source_list 192.0.2.4,192.0.2.3 filter_mode include proto bgp
+ # bridge -d -s mdb show
+ dev br0 port dummy10 grp 239.1.1.1 src 192.0.2.4 temp filter_mode include proto bgp     0.00
+ dev br0 port dummy10 grp 239.1.1.1 src 192.0.2.3 temp filter_mode include proto bgp     0.00
+ dev br0 port dummy10 grp 239.1.1.1 temp filter_mode include source_list 192.0.2.4/259.44,192.0.2.3/259.44 proto bgp     0.00
+
+Signed-off-by: Ido Schimmel <idosch@nvidia.com>
+Reviewed-by: Nikolay Aleksandrov <razor@blackwall.org>
+Signed-off-by: David Ahern <dsahern@kernel.org>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ bridge/mdb.c      |  4 +++-
+ man/man8/bridge.8 | 13 ++++++++++---
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/bridge/mdb.c b/bridge/mdb.c
+index d3afc900..60cf0066 100644
+--- a/bridge/mdb.c
++++ b/bridge/mdb.c
+@@ -31,7 +31,7 @@ static unsigned int filter_index, filter_vlan;
+ static void usage(void)
+ {
+ 	fprintf(stderr,
+-		"Usage: bridge mdb { add | del } dev DEV port PORT grp GROUP [src SOURCE] [permanent | temp] [vid VID]\n"
++		"Usage: bridge mdb { add | del | replace } dev DEV port PORT grp GROUP [src SOURCE] [permanent | temp] [vid VID]\n"
+ 		"       bridge mdb {show} [ dev DEV ] [ vid VID ]\n");
+ 	exit(-1);
+ }
+@@ -571,6 +571,8 @@ int do_mdb(int argc, char **argv)
+ 	if (argc > 0) {
+ 		if (matches(*argv, "add") == 0)
+ 			return mdb_modify(RTM_NEWMDB, NLM_F_CREATE|NLM_F_EXCL, argc-1, argv+1);
++		if (strcmp(*argv, "replace") == 0)
++			return mdb_modify(RTM_NEWMDB, NLM_F_CREATE|NLM_F_REPLACE, argc-1, argv+1);
+ 		if (matches(*argv, "delete") == 0)
+ 			return mdb_modify(RTM_DELMDB, 0, argc-1, argv+1);
+ 
+diff --git a/man/man8/bridge.8 b/man/man8/bridge.8
+index d4df772e..5bf15deb 100644
+--- a/man/man8/bridge.8
++++ b/man/man8/bridge.8
+@@ -126,7 +126,7 @@ bridge \- show / manipulate bridge addresses and devices
+ .BR [no]sticky " ] [ " [no]offloaded " ]"
+ 
+ .ti -8
+-.BR "bridge mdb" " { " add " | " del " } "
++.BR "bridge mdb" " { " add " | " del " | " replace " } "
+ .B dev
+ .I DEV
+ .B port
+@@ -873,8 +873,8 @@ if "no" is prepended then only entries without offloaded flag will be deleted.
+ objects contain known IP or L2 multicast group addresses on a link.
+ 
+ .P
+-The corresponding commands display mdb entries, add new entries,
+-and delete old ones.
++The corresponding commands display mdb entries, add new entries, replace
++entries and delete old ones.
+ 
+ .SS bridge mdb add - add a new multicast group database entry
+ 
+@@ -919,6 +919,13 @@ This command removes an existing mdb entry.
+ The arguments are the same as with
+ .BR "bridge mdb add" .
+ 
++.SS bridge mdb replace - replace a multicast group database entry
++If no matching entry is found, a new one will be created instead.
++
++.PP
++The arguments are the same as with
++.BR "bridge mdb add" .
++
+ .SS bridge mdb show - list multicast group database entries
+ 
+ This command displays the current multicast group membership table. The table
+-- 
+2.34.1
+

--- a/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
+++ b/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
@@ -1,0 +1,236 @@
+From 7072b44955fc0bdc4b3e96648f2ff9c3e9d68c8e Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Mon, 4 Mar 2024 16:47:28 +0100
+Subject: [PATCH 18/19] net: bridge: avoid classifying unknown multicast as
+ mrouters_only
+Organization: Addiva Elektronik
+
+Unknown multicast, MAC/IPv4/IPv6, should always be flooded according to
+the per-port mcast_flood setting, as well as to detected and configured
+mcast_router ports.
+
+This patch drops the mrouters_only classifier of unknown IP multicast
+and moves the flow handling from br_multicast_flood() to br_flood().
+This in turn means br_flood() must know about multicast router ports.
+Because a multicast router should always receive both known and unknown
+multicast.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ include/uapi/linux/if_bridge.h |  1 +
+ net/bridge/br.c                |  5 +++++
+ net/bridge/br_device.c         | 10 ++++++----
+ net/bridge/br_forward.c        | 14 ++++++++++++--
+ net/bridge/br_input.c          |  2 +-
+ net/bridge/br_multicast.c      | 11 +++++++++--
+ net/bridge/br_private.h        | 18 ++++++++++++++++--
+ 7 files changed, 50 insertions(+), 11 deletions(-)
+
+diff --git a/include/uapi/linux/if_bridge.h b/include/uapi/linux/if_bridge.h
+index f95326fce6bb..2b1320025ec2 100644
+--- a/include/uapi/linux/if_bridge.h
++++ b/include/uapi/linux/if_bridge.h
+@@ -811,6 +811,7 @@ enum br_boolopt_id {
+ 	BR_BOOLOPT_NO_LL_LEARN,
+ 	BR_BOOLOPT_MCAST_VLAN_SNOOPING,
+ 	BR_BOOLOPT_MST_ENABLE,
++	BR_BOOLOPT_MCAST_FLOOD_ALWAYS,
+ 	BR_BOOLOPT_MAX
+ };
+ 
+diff --git a/net/bridge/br.c b/net/bridge/br.c
+index 4f5098d33a46..a512c8ad9860 100644
+--- a/net/bridge/br.c
++++ b/net/bridge/br.c
+@@ -269,6 +269,9 @@ int br_boolopt_toggle(struct net_bridge *br, enum br_boolopt_id opt, bool on,
+ 	case BR_BOOLOPT_MST_ENABLE:
+ 		err = br_mst_set_enabled(br, on, extack);
+ 		break;
++	case BR_BOOLOPT_MCAST_FLOOD_ALWAYS:
++		br_opt_toggle(br, BROPT_MCAST_FLOOD_ALWAYS, on);
++		break;
+ 	default:
+ 		/* shouldn't be called with unsupported options */
+ 		WARN_ON(1);
+@@ -287,6 +290,8 @@ int br_boolopt_get(const struct net_bridge *br, enum br_boolopt_id opt)
+ 		return br_opt_get(br, BROPT_MCAST_VLAN_SNOOPING_ENABLED);
+ 	case BR_BOOLOPT_MST_ENABLE:
+ 		return br_opt_get(br, BROPT_MST_ENABLED);
++	case BR_BOOLOPT_MCAST_FLOOD_ALWAYS:
++		return br_opt_get(br, BROPT_MCAST_FLOOD_ALWAYS);
+ 	default:
+ 		/* shouldn't be called with unsupported options */
+ 		WARN_ON(1);
+diff --git a/net/bridge/br_device.c b/net/bridge/br_device.c
+index 9a5ea06236bd..5f537dbd597a 100644
+--- a/net/bridge/br_device.c
++++ b/net/bridge/br_device.c
+@@ -81,10 +81,10 @@ netdev_tx_t br_dev_xmit(struct sk_buff *skb, struct net_device *dev)
+ 
+ 	dest = eth_hdr(skb)->h_dest;
+ 	if (is_broadcast_ether_addr(dest)) {
+-		br_flood(br, skb, BR_PKT_BROADCAST, false, true, vid);
++		br_flood(br, skb, NULL, BR_PKT_BROADCAST, false, true, vid);
+ 	} else if (is_multicast_ether_addr(dest)) {
+ 		if (unlikely(netpoll_tx_running(dev))) {
+-			br_flood(br, skb, BR_PKT_MULTICAST, false, true, vid);
++			br_flood(br, skb, brmctx, BR_PKT_MULTICAST, false, true, vid);
+ 			goto out;
+ 		}
+ 		if (br_multicast_rcv(&brmctx, &pmctx_null, vlan, skb, vid)) {
+@@ -97,11 +97,11 @@ netdev_tx_t br_dev_xmit(struct sk_buff *skb, struct net_device *dev)
+ 		    br_multicast_querier_exists(brmctx, eth_hdr(skb), mdst))
+ 			br_multicast_flood(mdst, skb, brmctx, false, true);
+ 		else
+-			br_flood(br, skb, BR_PKT_MULTICAST, false, true, vid);
++			br_flood(br, skb, brmctx, BR_PKT_MULTICAST, false, true, vid);
+ 	} else if ((dst = br_fdb_find_rcu(br, dest, vid)) != NULL) {
+ 		br_forward(dst->dst, skb, false, true);
+ 	} else {
+-		br_flood(br, skb, BR_PKT_UNICAST, false, true, vid);
++		br_flood(br, skb, NULL, BR_PKT_UNICAST, false, true, vid);
+ 	}
+ out:
+ 	rcu_read_unlock();
+@@ -531,6 +531,8 @@ void br_dev_setup(struct net_device *dev)
+ 	br->bridge_ageing_time = br->ageing_time = BR_DEFAULT_AGEING_TIME;
+ 	dev->max_mtu = ETH_MAX_MTU;
+ 
++	br_opt_toggle(br, BROPT_MCAST_FLOOD_ALWAYS, false);
++
+ 	br_netfilter_rtable_init(br);
+ 	br_stp_timer_init(br);
+ 	br_multicast_init(br);
+diff --git a/net/bridge/br_forward.c b/net/bridge/br_forward.c
+index bb1ab53e54e0..c5ac65628a7a 100644
+--- a/net/bridge/br_forward.c
++++ b/net/bridge/br_forward.c
+@@ -197,14 +197,19 @@ static struct net_bridge_port *maybe_deliver(
+ 
+ /* called under rcu_read_lock */
+ void br_flood(struct net_bridge *br, struct sk_buff *skb,
+-	      enum br_pkt_type pkt_type, bool local_rcv, bool local_orig,
+-	      u16 vid)
++	      struct net_bridge_mcast *brmctx, enum br_pkt_type pkt_type,
++	      bool local_rcv, bool local_orig, u16 vid)
+ {
++	struct net_bridge_port *rport = NULL;
+ 	struct net_bridge_port *prev = NULL;
++	struct hlist_node *rp = NULL;
+ 	struct net_bridge_port *p;
+ 
+ 	br_tc_skb_miss_set(skb, pkt_type != BR_PKT_BROADCAST);
+ 
++	if (pkt_type == BR_PKT_MULTICAST)
++		rp = br_multicast_get_first_rport_node(brmctx, skb);
++
+ 	list_for_each_entry_rcu(p, &br->port_list, list) {
+ 		/* Do not flood unicast traffic to ports that turn it off, nor
+ 		 * other traffic if flood off, except for traffic we originate
+@@ -215,6 +220,11 @@ void br_flood(struct net_bridge *br, struct sk_buff *skb,
+ 				continue;
+ 			break;
+ 		case BR_PKT_MULTICAST:
++			rport = br_multicast_rport_from_node_skb(rp, skb);
++			if (rport == p) {
++				rp = rcu_dereference(hlist_next_rcu(rp));
++				break;
++			}
+ 			if (!(p->flags & BR_MCAST_FLOOD) && skb->dev != br->dev)
+ 				continue;
+ 			break;
+diff --git a/net/bridge/br_input.c b/net/bridge/br_input.c
+index c729528b5e85..2817d0c785be 100644
+--- a/net/bridge/br_input.c
++++ b/net/bridge/br_input.c
+@@ -207,7 +207,7 @@ int br_handle_frame_finish(struct net *net, struct sock *sk, struct sk_buff *skb
+ 		br_forward(dst->dst, skb, local_rcv, false);
+ 	} else {
+ 		if (!mcast_hit)
+-			br_flood(br, skb, pkt_type, local_rcv, false, vid);
++			br_flood(br, skb, brmctx, pkt_type, local_rcv, false, vid);
+ 		else
+ 			br_multicast_flood(mdst, skb, brmctx, local_rcv, false);
+ 	}
+diff --git a/net/bridge/br_multicast.c b/net/bridge/br_multicast.c
+index 96d1fc78dd39..ab3ee0651ebe 100644
+--- a/net/bridge/br_multicast.c
++++ b/net/bridge/br_multicast.c
+@@ -3771,6 +3771,11 @@ static void br_multicast_err_count(const struct net_bridge *br,
+ 	u64_stats_update_end(&pstats->syncp);
+ }
+ 
++static bool br_flood_mrouters(const struct net_bridge *br)
++{
++	return br_opt_get(br, BROPT_MCAST_FLOOD_ALWAYS) ? false : true;
++}
++
+ static void br_multicast_pim(struct net_bridge_mcast *brmctx,
+ 			     struct net_bridge_mcast_port *pmctx,
+ 			     const struct sk_buff *skb)
+@@ -3817,7 +3822,8 @@ static int br_multicast_ipv4_rcv(struct net_bridge_mcast *brmctx,
+ 
+ 	if (err == -ENOMSG) {
+ 		if (!ipv4_is_local_multicast(ip_hdr(skb)->daddr)) {
+-			BR_INPUT_SKB_CB(skb)->mrouters_only = 1;
++			BR_INPUT_SKB_CB(skb)->mrouters_only =
++				br_flood_mrouters(brmctx->br);
+ 		} else if (pim_ipv4_all_pim_routers(ip_hdr(skb)->daddr)) {
+ 			if (ip_hdr(skb)->protocol == IPPROTO_PIM)
+ 				br_multicast_pim(brmctx, pmctx, skb);
+@@ -3886,7 +3892,8 @@ static int br_multicast_ipv6_rcv(struct net_bridge_mcast *brmctx,
+ 
+ 	if (err == -ENOMSG || err == -ENODATA) {
+ 		if (!ipv6_addr_is_ll_all_nodes(&ipv6_hdr(skb)->daddr))
+-			BR_INPUT_SKB_CB(skb)->mrouters_only = 1;
++			BR_INPUT_SKB_CB(skb)->mrouters_only =
++				br_flood_mrouters(brmctx->br);
+ 		if (err == -ENODATA &&
+ 		    ipv6_addr_is_all_snoopers(&ipv6_hdr(skb)->daddr))
+ 			br_ip6_multicast_mrd_rcv(brmctx, pmctx, skb);
+diff --git a/net/bridge/br_private.h b/net/bridge/br_private.h
+index a63b32c1638e..4798588f15c7 100644
+--- a/net/bridge/br_private.h
++++ b/net/bridge/br_private.h
+@@ -479,6 +479,7 @@ enum net_bridge_opts {
+ 	BROPT_VLAN_BRIDGE_BINDING,
+ 	BROPT_MCAST_VLAN_SNOOPING_ENABLED,
+ 	BROPT_MST_ENABLED,
++	BROPT_MCAST_FLOOD_ALWAYS,
+ };
+ 
+ struct net_bridge {
+@@ -877,8 +878,8 @@ void br_forward(const struct net_bridge_port *to, struct sk_buff *skb,
+ 		bool local_rcv, bool local_orig);
+ int br_forward_finish(struct net *net, struct sock *sk, struct sk_buff *skb);
+ void br_flood(struct net_bridge *br, struct sk_buff *skb,
+-	      enum br_pkt_type pkt_type, bool local_rcv, bool local_orig,
+-	      u16 vid);
++	      struct net_bridge_mcast *brmctx, enum br_pkt_type pkt_type,
++	      bool local_rcv, bool local_orig, u16 vid);
+ 
+ /* return true if both source port and dest port are isolated */
+ static inline bool br_skb_isolated(const struct net_bridge_port *to,
+@@ -1394,6 +1395,19 @@ static inline void br_multicast_flood(struct net_bridge_mdb_entry *mdst,
+ {
+ }
+ 
++static inline struct hlist_node *
++br_multicast_get_first_rport_node(struct net_bridge_mcast *brmctx,
++				  struct sk_buff *skb)
++{
++	return NULL;
++}
++
++static inline struct net_bridge_port *
++br_multicast_rport_from_node_skb(struct hlist_node *rp, struct sk_buff *skb)
++{
++	return NULL;
++}
++
+ static inline bool br_multicast_is_router(struct net_bridge_mcast *brmctx,
+ 					  struct sk_buff *skb)
+ {
+-- 
+2.34.1
+

--- a/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
+++ b/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
@@ -1,0 +1,37 @@
+From 3c48022ab2eda9ab62b680a97c88934a62137ebf Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Tue, 5 Mar 2024 06:44:41 +0100
+Subject: [PATCH 19/19] net: bridge: Ignore router ports when forwarding L2
+ multicast
+Organization: Addiva Elektronik
+
+Multicast router ports are either statically configured or learned from
+control protocol traffic (IGMP/MLD/PIM).  These protocols regulate IP
+multicast -- MAC multicast should always be forwarded through flooding
+of unknown multicast or using permanent MDB entries.
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ net/bridge/br_private.h | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/net/bridge/br_private.h b/net/bridge/br_private.h
+index 4798588f15c7..cac15339ecae 100644
+--- a/net/bridge/br_private.h
++++ b/net/bridge/br_private.h
+@@ -1073,7 +1073,10 @@ br_multicast_get_first_rport_node(struct net_bridge_mcast *brmctx,
+ 	if (skb->protocol == htons(ETH_P_IPV6))
+ 		return rcu_dereference(hlist_first_rcu(&brmctx->ip6_mc_router_list));
+ #endif
+-	return rcu_dereference(hlist_first_rcu(&brmctx->ip4_mc_router_list));
++	if (skb->protocol == htons(ETH_P_IP))
++		return rcu_dereference(hlist_first_rcu(&brmctx->ip4_mc_router_list));
++
++	return NULL;
+ }
+ 
+ static inline struct net_bridge_port *
+-- 
+2.34.1
+

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -1169,7 +1169,7 @@ static int netdag_gen_afspec_add(struct dagger *net, struct lyd_node *dif,
 					     " wrong type or name.", ifname);
 		return -ENOENT;
 	} else {
-		sr_session_set_error_message(net->session, "Unsupported interface type \"%s\"", iftype);
+		sr_session_set_error_message(net->session, "%s: unsupported interface type \"%s\"", ifname, iftype);
 		return -ENOSYS;
 	}
 
@@ -1194,7 +1194,7 @@ static int netdag_gen_afspec_set(struct dagger *net, struct lyd_node *dif,
 	if (!strcmp(iftype, "infix-if-type:veth"))
 		return 0;
 
-	ERROR("unsupported interface type \"%s\" for %s", iftype, ifname);
+	ERROR("%s: unsupported interface type \"%s\"", ifname, iftype);
 	return -ENOSYS;
 }
 

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -1053,7 +1053,8 @@ static int netdag_gen_bridge(struct dagger *net, struct lyd_node *dif,
 	 *             believe this is the only sane way of doing it.
 	 * Issue #310: malplaced 'vlan_default_pvid 0'
 	 */
-	fprintf(ip, "link %s dev %s type bridge group_fwd_mask %d vlan_filtering %d vlan_default_pvid 0",
+	fprintf(ip, "link %s dev %s type bridge group_fwd_mask %d mcast_flood_always 1"
+		" vlan_filtering %d vlan_default_pvid 0",
 		op, brname, fwd_mask, vlan_filtering ? 1 : 0);
 
 	if ((err = bridge_mcast_settings(ip, cif, vlan_mcast)))

--- a/src/confd/yang/infix-if-bridge@2024-02-19.yang
+++ b/src/confd/yang/infix-if-bridge@2024-02-19.yang
@@ -10,6 +10,9 @@ submodule infix-if-bridge {
   import ietf-interfaces {
     prefix if;
   }
+  import ietf-inet-types {
+    prefix inet;
+  }
   import ieee802-dot1q-types {
     prefix dot1q-types;
   }
@@ -143,6 +146,20 @@ submodule infix-if-bridge {
     }
   }
 
+  typedef mdb-state {
+    description "Origin of mdb entry for a given port.";
+    type enumeration {
+      enum temp {
+        value 0;
+        description "Learned from IGMP/MLD snooping.";
+      }
+      enum permanent {
+        value 1;
+        description "Static entry, from configuration.";
+      }
+    }
+  }
+
   /*
    * Shared settings
    */
@@ -198,6 +215,37 @@ submodule infix-if-bridge {
     }
   }
 
+  grouping mdb {
+    container mdb {
+      description "Bridge multicast database.";
+      config false;
+
+      list entry {
+        description "MDB entry.";
+        key "group";
+
+        leaf group {
+          description "IP multicast group.";
+          type inet:ip-address;
+        }
+
+        list ports {
+          description "Port members of group.";
+
+          leaf port {
+            description "Port with static or dynamic membership of group.";
+            type if:interface-ref;
+          }
+
+          leaf state {
+            description "State of membership, permanent or temporary.";
+            type mdb-state;
+          }
+        }
+      }
+    }
+  }
+
   /*
    * Data Nodes
    */
@@ -219,6 +267,7 @@ submodule infix-if-bridge {
       }
 
       uses multicast;
+      uses mdb;
 
       container vlans {
         if-feature "vlan-filtering";
@@ -240,6 +289,7 @@ submodule infix-if-bridge {
           }
 
           uses multicast;
+          uses mdb;
 
           leaf-list untagged {
             type if:interface-ref;

--- a/src/confd/yang/infix-if-bridge@2024-02-19.yang
+++ b/src/confd/yang/infix-if-bridge@2024-02-19.yang
@@ -7,6 +7,9 @@ submodule infix-if-bridge {
   import iana-if-type {
     prefix ianaift;
   }
+  import ietf-routing-types {
+    prefix rt-types;
+  }
   import ietf-interfaces {
     prefix if;
   }
@@ -226,7 +229,7 @@ submodule infix-if-bridge {
 
         leaf group {
           description "IP multicast group.";
-          type inet:ip-address;
+          type rt-types:ip-multicast-group-address;
         }
 
         list ports {

--- a/src/confd/yang/infix-if-bridge@2024-02-19.yang
+++ b/src/confd/yang/infix-if-bridge@2024-02-19.yang
@@ -82,6 +82,7 @@ submodule infix-if-bridge {
   }
 
   typedef stp-state {
+    description "User-friendly enumeration of different bridge port operational states.";
     type enumeration {
       enum disabled {
         value 0;
@@ -104,8 +105,97 @@ submodule infix-if-bridge {
         description "Port is in STP BLOCKING state.";
       }
     }
-    description
-      "User-friendly enumeration of different bridge port operational states.";
+  }
+
+  typedef querier-mode {
+    description "Type of IGMP/MLD querier, recommend using 'auto'.";
+    type enumeration {
+      enum off {
+        value 0;
+        description "Never initiate IGMP/MLD queries.";
+      }
+      enum proxy {
+        value 1;
+        description "Send proxy queries if no better querier IP exists.";
+      }
+      enum auto {
+        value 2;
+        description "Participate in querier elections using the interface's address.";
+      }
+    }
+  }
+
+  typedef mrouter-port {
+    description "Controls forwarding of known multicast on a port, recommend using 'auto'.";
+    type enumeration {
+      enum off {
+        value 0;
+        description "Very rarely needed, disables auto-detect, never forwards know multicast.";
+      }
+      enum auto {
+        value 1;
+        description "Auto detects any PIM- or MRDISC-capable multicast routers.";
+      }
+      enum permanent {
+        value 2;
+        description "Always forward known multicast, regardless of detected multicast routers.";
+      }
+    }
+  }
+
+  /*
+   * Shared settings
+   */
+
+  grouping multicast {
+    container multicast {
+      description "Control multicast filtering and querier options in bridge.";
+
+      leaf snooping {
+        description "Control multicast snooping in bridge.
+
+                   Enabled, IGMP and MLD snooping is used to automatically
+                   handle multicast filtering.  By default all multicast is
+                   forwarded, when an IGMP or MLD membership is received
+                   only those groups are filtered.
+
+                   Disabled, all multicast is treated as broadcast.  Not
+                   even static MDB filters can be used in this mode.";
+        type boolean;
+        default true;
+      }
+
+      leaf querier {
+        description "IGMP/MLD querier role.  Leave default as-is, or read on.
+
+                   The querier role is usually the multicast router(s) on the
+                   LAN.  In networks without a multicast router a switch can
+                   take on this responsibility.
+
+                   For a fully working multicast setup the LAN needs a querier.
+                   If multiple queriers exist, a simple election is made -- the
+                   device with the numerically lowest IP address is the winner,
+                   execpt for source address 0.0.0.0 (IPv4), which is reserved
+                   for 'proxy' queries and must never win an election.  Proxy
+                   queries are like a stand-in for the real thing and mostly
+                   work fine in all setups.
+
+                   Some embedded and industrial devices do not send multicast
+                   membership reports unless they receive a query, even worse,
+                   some do not understand or misbehave with proxy queriers.
+                   Hence the default 'auto' for this option.";
+        type querier-mode;
+        default auto;
+      }
+
+      leaf query-interval {
+        description "Query interval when sending multicast queries.";
+        type uint16 {
+          range "1..1024";
+        }
+        default 125;
+      }
+    }
   }
 
   /*
@@ -128,6 +218,8 @@ submodule infix-if-bridge {
           "List of IEEE link-local protocols to forward, e.g., STP, LLDP";
       }
 
+      uses multicast;
+
       container vlans {
         if-feature "vlan-filtering";
         description "A VLAN filtering bridge has at least one VLAN.";
@@ -146,6 +238,8 @@ submodule infix-if-bridge {
             type dot1q-types:vlanid;
             description "The VLAN identifier to which this entry applies.";
           }
+
+          uses multicast;
 
           leaf-list untagged {
             type if:interface-ref;
@@ -187,6 +281,61 @@ submodule infix-if-bridge {
           }
           mandatory true;
           description "Bridge interface to which this interface is attached.";
+        }
+
+        container flood {
+          description "Control flooding of unknown BUM traffic.";
+
+          leaf broadcast {
+            description "Flood unknown broadcast traffic on this port.";
+            type boolean;
+            default true;
+          }
+
+          leaf unicast {
+            description "Flood unknown unicast traffic on this port.";
+            type boolean;
+            default true;
+          }
+
+          leaf multicast {
+            description "Flood unknown multicast traffic on this port.
+
+                         By default this option is enabled to allow MAC multicast
+                         to coexist unregulated with filtering of IP multicast.
+
+                         Flooding of IP multicast is done as long as the groups
+                         remain 'unknown', i.e., while there are no MDB entries
+                         set manually or automatically by IGMP/MLD.";
+            type boolean;
+            default true;
+          }
+        }
+
+        container multicast {
+          leaf fast-leave {
+            description "Assume this port is attached to an end-device.
+
+                         When enabled the bridge immediately cuts multicast
+                         groups when receiving a membership leave report.
+                         When disabled, group subscriptions linger until the
+                         group specific queries time out.";
+            type boolean;
+          }
+
+          leaf router {
+            description "Forward all known multicast on this port.
+
+                         Enable this for ports connected to a multicast router
+                         that is not PIM or multicast router discovery (mrdisc)
+                         capable.
+
+                         This setting is also useful for legacy equipment that
+                         does not support IGMP/MLD.  However, it is recommended
+                         to instead set up static MDB entries for such ports.";
+            type mrouter-port;
+            default auto;
+          }
         }
 
         leaf stp-state {

--- a/test/.env
+++ b/test/.env
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034,SC2154
 
 # Current container image
-INFIX_TEST=ghcr.io/kernelkit/infix-test:1.2
+INFIX_TEST=ghcr.io/kernelkit/infix-test:1.3
 
 ixdir=$(readlink -f "$testdir/..")
 logdir=$(readlink -f "$testdir/.log")

--- a/test/case/infix_interfaces/all.yaml
+++ b/test/case/infix_interfaces/all.yaml
@@ -7,3 +7,5 @@
 - case: bridge_fwd_sgl_dut.py
 - case: bridge_fwd_dual_dut.py
 - case: bridge_vlan_separation.py
+- case: igmp_basic.py
+- case: igmp_vlan.py

--- a/test/case/infix_interfaces/igmp_basic.py
+++ b/test/case/infix_interfaces/igmp_basic.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#                    10.0.0.1
+#                +--------------+
+#                |    DUT       |
+#                |              |
+#                +----------+---\
+#                |          |    \-
+#               /           |      \
+#               |           |       \
+#              /            |        \-
+#    10.0.0.2 |     10.0.0.3|          \ 10.0.0.4
+#     +-------/       +---+------+      \-------------+
+#     | msend |       | mreceive |      | no join     |
+#     +-------+       +----------+      +-------------+
+
+import infamy
+import time
+import infamy.multicast as mcast
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("1x4"))
+        target = env.attach("target", "mgmt")
+        _, msend = env.ltop.xlate("target", "data0")
+        _, mreceive = env.ltop.xlate("target", "data1")
+        _, nojoin = env.ltop.xlate("target", "data2")
+
+    with test.step("Configure device"):
+        target.put_config_dict("ietf-interfaces",
+                        {
+                            "interfaces": {
+                                "interface": [
+                                    {
+                                        "name": msend,
+                                        "enabled": True,
+                                        "infix-interfaces:bridge-port": {
+                                            "bridge": "br0"
+                                        }
+                                    },
+                                    {
+                                        "name": mreceive,
+                                        "enabled": True,
+                                        "infix-interfaces:bridge-port": {
+                                            "bridge": "br0"
+                                        }
+                                    },
+                                    {
+                                        "name": nojoin,
+                                        "enabled": True,
+                                        "infix-interfaces:bridge-port": {
+                                            "bridge": "br0"
+                                        }
+                                    },
+                                    {
+                                        "name": "br0",
+                                        "enabled": True,
+                                        "type": "infix-if-type:bridge",
+                                        "ipv4": {
+                                            "address": [
+                                                {
+                                                    "ip": "10.0.0.1",
+                                                    "prefix-length": 24
+                                                }
+                                            ]
+                                        },
+
+                                        "bridge": {
+                                            "multicast": {
+                                                "snooping": True
+                                            }
+
+                                        }
+                                    }
+                                ]
+
+                            }
+                        })
+    with test.step("Check multicast receieved on correct port"):
+        _, hport0 = env.ltop.xlate("host", "data0")
+        _, hport1 = env.ltop.xlate("host", "data1")
+        _, hport2 = env.ltop.xlate("host", "data2")
+        with infamy.IsolatedMacVlan(hport0) as ns0, \
+             infamy.IsolatedMacVlan(hport1) as ns1, \
+             infamy.IsolatedMacVlan(hport2) as ns2:
+            ns0.addip("10.0.0.2")
+            ns1.addip("10.0.0.3")
+            ns2.addip("10.0.0.4")
+            ns0.must_reach("10.0.0.1")
+            ns1.must_reach("10.0.0.1")
+            ns2.must_reach("10.0.0.1")
+
+            sender = mcast.MCastSender(ns0, "224.1.1.1")
+            receiver = mcast.MCastReceiver(ns1, "224.1.1.1")
+            snif_nojoin = infamy.Sniffer(ns2, "host 224.1.1.1")
+            snif_receiver = infamy.Sniffer(ns1, "host 224.1.1.1")
+            with sender:
+                time.sleep(20)
+                with snif_nojoin:
+                    time.sleep(5)
+                assert(snif_nojoin.output().stdout != "")
+
+                with snif_receiver:
+                    time.sleep(5)
+                assert(snif_receiver.output().stdout != "")
+                print("Multicast is received on ports without join")
+
+                with receiver:
+                    with snif_receiver:
+                        time.sleep(5)
+                        with snif_nojoin:
+                            time.sleep(5)
+                        assert(snif_nojoin.output().stdout == "")
+                        print("Multicast is NOT received on port when join exist")
+                    assert(snif_receiver.output().stdout != "")
+                    print("Multicast is received after join")
+
+        test.succeed()

--- a/test/case/infix_interfaces/igmp_basic.py
+++ b/test/case/infix_interfaces/igmp_basic.py
@@ -4,13 +4,13 @@
 #                |    DUT       |
 #                |              |
 #                +----------+---\
-#                |          |    \-
-#               /           |      \
-#               |           |       \
-#              /            |        \-
-#    10.0.0.2 |     10.0.0.3|          \ 10.0.0.4
-#     +-------/       +---+------+      \-------------+
-#     | msend |       | mreceive |      | no join     |
+#                |          |    \
+#                |          |     \
+#                |          |      \
+#                |          |       \
+#    10.0.0.2    |  10.0.0.3|        \ 10.0.0.4
+#     +----------+    +---+------+    \ +-------------+
+#     | msend |       | mreceive |      + no join     |
 #     +-------+       +----------+      +-------------+
 
 import infamy
@@ -94,7 +94,7 @@ with infamy.Test() as test:
             snif_nojoin = infamy.Sniffer(ns2, "host 224.1.1.1")
             snif_receiver = infamy.Sniffer(ns1, "host 224.1.1.1")
             with sender:
-                time.sleep(20)
+                time.sleep(5)
                 with snif_nojoin:
                     time.sleep(5)
                 assert(snif_nojoin.output().stdout != "")

--- a/test/case/infix_interfaces/igmp_basic.py
+++ b/test/case/infix_interfaces/igmp_basic.py
@@ -76,42 +76,38 @@ with infamy.Test() as test:
                             }
                         })
     with test.step("Check multicast receieved on correct port"):
-        _, hport0 = env.ltop.xlate("host", "data0")
-        _, hport1 = env.ltop.xlate("host", "data1")
-        _, hport2 = env.ltop.xlate("host", "data2")
-        with infamy.IsolatedMacVlan(hport0) as ns0, \
-             infamy.IsolatedMacVlan(hport1) as ns1, \
-             infamy.IsolatedMacVlan(hport2) as ns2:
-            ns0.addip("10.0.0.2")
-            ns1.addip("10.0.0.3")
-            ns2.addip("10.0.0.4")
-            ns0.must_reach("10.0.0.1")
-            ns1.must_reach("10.0.0.1")
-            ns2.must_reach("10.0.0.1")
+        _, hsend = env.ltop.xlate("host", "data0")
+        _, hreceive = env.ltop.xlate("host", "data1")
+        _, hnojoin = env.ltop.xlate("host", "data2")
+        with infamy.IsolatedMacVlan(hsend) as send_ns, \
+             infamy.IsolatedMacVlan(hreceive) as receive_ns, \
+             infamy.IsolatedMacVlan(hnojoin) as nojoin_ns:
+            send_ns.addip("10.0.0.2")
+            receive_ns.addip("10.0.0.3")
+            nojoin_ns.addip("10.0.0.4")
+            send_ns.must_reach("10.0.0.1")
+            receive_ns.must_reach("10.0.0.1")
+            nojoin_ns.must_reach("10.0.0.1")
 
-            sender = mcast.MCastSender(ns0, "224.1.1.1")
-            receiver = mcast.MCastReceiver(ns1, "224.1.1.1")
-            snif_nojoin = infamy.Sniffer(ns2, "host 224.1.1.1")
-            snif_receiver = infamy.Sniffer(ns1, "host 224.1.1.1")
+            sender = mcast.MCastSender(send_ns, "224.1.1.1")
+            receiver = mcast.MCastReceiver(receive_ns, "224.1.1.1")
+            snif_nojoin = infamy.Sniffer(nojoin_ns, "host 224.1.1.1")
+            snif_receiver = infamy.Sniffer(receive_ns, "host 224.1.1.1")
             with sender:
-                time.sleep(5)
-                with snif_nojoin:
-                    time.sleep(5)
-                assert(snif_nojoin.output().stdout != "")
-
                 with snif_receiver:
                     time.sleep(5)
+                    with snif_nojoin:
+                        time.sleep(5)
                 assert(snif_receiver.output().stdout != "")
-                print("Multicast is received on ports without join")
+                assert(snif_nojoin.output().stdout != "")
+                print("As expected, unregistered multicast is received on both ports")
 
                 with receiver:
-                    with snif_receiver:
-                        time.sleep(5)
-                        with snif_nojoin:
+                    with snif_receiver,snif_nojoin:
                             time.sleep(5)
-                        assert(snif_nojoin.output().stdout == "")
-                        print("Multicast is NOT received on port when join exist")
+                    assert(snif_nojoin.output().stdout == "")
+                    print("As expected, registered multicast is NOT forwarded to non-member port")
                     assert(snif_receiver.output().stdout != "")
-                    print("Multicast is received after join")
+                    print("As expected, registered multicast is forwarded to the member port")
 
         test.succeed()

--- a/test/case/infix_interfaces/igmp_vlan.py
+++ b/test/case/infix_interfaces/igmp_vlan.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+#
+#
+#            VLAN55             VLAN77                          VLAN55              VLAN77
+#           10.0.1.1           10.0.2.1                       10.0.1.2            10.0.2.2
+#             \                    /                           \                     /
+#              \                  /                             \                   /
+#               \                /                               \                 /
+#                \--------------/        VLAN 1,2 T               \---------------/
+#                |    DUT1      +---------------------------------+      DUT2     |
+#                |              |                                 |               |
+#                +--------------+                                 +-----+---------+
+#        VLAN55 U|      VLAN77 U|                              VLAN55 U |        | VLAN77 U
+#                |              |                                       |        |
+#                |              |                                       |        |
+#                |              |                                       |        |
+#                |              |                                       |        |
+#     +-------+  |             +----------+                 +------------+       +--------+
+#     | msend +--+             | mreceive |                 | mreceive   |       | mesend |
+#     +-------+                +----------+                 +------------+       +--------+
+#      10.0.1.11                 10.0.2.11                      10.0.1.22         10.0.2.22
+#
+
+
+
+import infamy
+import time
+import infamy.multicast as mcast
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("2x4"))
+        dut1 = env.attach("dut1", "mgmt")
+        _, d1send = env.ltop.xlate("dut1", "data0")
+        _, d1receiver = env.ltop.xlate("dut1", "data1")
+        _, d1trunk = env.ltop.xlate("dut1", "data2")
+        dut2 = env.attach("dut2", "mgmt")
+        _, d2receive = env.ltop.xlate("dut2", "data0")
+        _, d2sender = env.ltop.xlate("dut2", "data1")
+        _, d2trunk = env.ltop.xlate("dut2", "data2")
+
+
+    with test.step("Configure device"):
+        dut1.put_config_dict("ietf-interfaces",
+                             {
+                                 "interfaces": {
+                                     "interface": [
+                                         {
+                                             "name": d1send,
+                                             "enabled": True,
+                                             "bridge-port": {
+                                                 "bridge": "br0",
+                                                 "pvid": 55
+
+                                             }
+                                         },
+                                         {
+                                             "name": d1receiver,
+                                             "enabled": True,
+                                             "bridge-port": {
+                                                 "bridge": "br0",
+                                                 "pvid": 77
+                                             }
+                                         },
+                                         {
+                                             "name": d1trunk,
+                                             "enabled": True,
+                                             "bridge-port": {
+                                                 "bridge": "br0"
+                                             }
+                                         },
+                                         {
+                                             "name": "vlan55",
+                                             "enabled": True,
+                                             "type": "infix-if-type:vlan",
+                                             "ipv4": {
+                                                 "address": [
+                                                     {
+                                                         "ip": "10.0.1.1",
+                                                         "prefix-length": 24
+                                                     }
+                                                 ]
+                                             },
+                                             "vlan": {
+                                                 "id": 55,
+                                                 "lower-layer-if": "br0"
+                                             }
+
+                                         },
+                                         {
+                                             "name": "vlan77",
+                                             "enabled": True,
+                                             "type": "infix-if-type:vlan",
+                                             "ipv4": {
+                                                 "address": [
+                                                     {
+                                                         "ip": "10.0.2.1",
+                                                         "prefix-length": 24
+                                                     }
+                                                 ]
+                                             },
+                                             "vlan": {
+                                                 "id": 77,
+                                                 "lower-layer-if": "br0"
+                                             }
+
+                                         },
+                                         {
+                                             "name": "br0",
+                                             "enabled": True,
+                                             "type": "infix-if-type:bridge",
+
+                                             "bridge": {
+                                                 "multicast": {
+                                                     "snooping": True
+                                                 },
+                                                 "vlans": {
+                                                     "vlan": [
+                                                         {
+                                                             "vid": 55,
+                                                             "untagged": [ d1send ],
+                                                             "tagged": [ d1trunk, "br0" ]
+                                                         },
+                                                         {
+                                                             "vid": 77,
+                                                             "untagged": [ d1receiver ],
+                                                             "tagged": [ d1trunk, "br0" ]
+                                                         }
+                                                     ]
+                                                 }
+                                             }
+                                         }
+                                     ]
+
+                                 }
+                             })
+        dut1.put_config_dict("ietf-system", {
+            "system": {
+                "hostname": "dut1"
+            }
+        })
+        dut2.put_config_dict("ietf-interfaces",
+                             {
+                                 "interfaces": {
+                                    "interface": [
+                                        {
+                                             "name": d2receive,
+                                             "enabled": True,
+                                             "bridge-port": {
+                                                 "bridge": "br0",
+                                                 "pvid": 55
+                                             }
+                                         },
+                                         {
+                                             "name": d2sender,
+                                             "enabled": True,
+                                             "bridge-port": {
+                                                 "bridge": "br0",
+                                                 "pvid": 77
+                                             }
+                                         },
+                                         {
+                                             "name": d2trunk,
+                                             "enabled": True,
+                                             "bridge-port": {
+                                                 "bridge": "br0"
+                                             }
+                                         },
+                                         {
+                                             "name": "vlan55",
+                                             "enabled": True,
+                                             "type": "infix-if-type:vlan",
+                                             "ipv4": {
+                                                 "address": [
+                                                     {
+                                                         "ip": "10.0.1.2",
+                                                         "prefix-length": 24
+                                                     }
+                                                 ]
+                                             },
+                                             "vlan": {
+                                                 "id": 55,
+                                                 "lower-layer-if": "br0"
+                                             }
+
+                                         },
+                                         {
+                                             "name": "vlan77",
+                                             "enabled": True,
+                                             "type": "infix-if-type:vlan",
+                                             "ipv4": {
+                                                 "address": [
+                                                     {
+                                                         "ip": "10.0.2.2",
+                                                         "prefix-length": 24
+                                                     }
+                                                 ]
+                                             },
+                                             "vlan": {
+                                                 "id": 77,
+                                                 "lower-layer-if": "br0"
+                                             }
+
+                                         },
+                                         {
+                                             "name": "br0",
+                                             "enabled": True,
+                                             "type": "infix-if-type:bridge",
+
+                                             "bridge": {
+                                                 "multicast": {
+                                                     "snooping": True
+                                                 },
+                                                 "vlans": {
+                                                     "vlan": [
+                                                         {
+                                                             "vid": 55,
+                                                             "untagged": [ d2receive ],
+                                                             "tagged": [ d2trunk, "br0" ]
+                                                         },
+                                                         {
+                                                             "vid": 77,
+                                                             "untagged": [ d2sender ],
+                                                             "tagged": [ d2trunk, "br0" ]
+                                                         }
+                                                     ]
+                                                 }
+                                             }
+                                         }
+                                     ]
+
+                                 }
+                        })
+
+        dut2.put_config_dict("ietf-system", {
+            "system": {
+                "hostname": "dut2"
+            }
+        })
+
+    with test.step("Check multicast receieved on correct port and VLAN"):
+        _, hport10 = env.ltop.xlate("host", "data10")
+        _, hport11 = env.ltop.xlate("host", "data11")
+        _, hport20 = env.ltop.xlate("host", "data20")
+        _, hport21 = env.ltop.xlate("host", "data21")
+        with infamy.IsolatedMacVlan(hport10) as ns10, \
+             infamy.IsolatedMacVlan(hport11) as ns11, \
+             infamy.IsolatedMacVlan(hport20) as ns20, \
+             infamy.IsolatedMacVlan(hport21) as ns21:
+            ns10.addip("10.0.1.11")
+            ns11.addip("10.0.2.11")
+            ns20.addip("10.0.1.22")
+            ns21.addip("10.0.2.22")
+
+            ns10.must_reach("10.0.1.1")
+            ns11.must_reach("10.0.2.1")
+
+            vlan55_sender = mcast.MCastSender(ns10, "224.1.1.1")
+            vlan77_sender= mcast.MCastSender(ns11, "224.2.2.2")
+            vlan55_receiver = mcast.MCastReceiver(ns20, "224.1.1.1")
+
+            snif_vlan55_sender_incorrect = infamy.Sniffer(ns10, "host 224.2.2.2")
+            snif_vlan77_receiver_incorrect = infamy.Sniffer(ns11, "host 224.1.1.1")
+            snif_vlan55_receiver_incorrect = infamy.Sniffer(ns20, "host 224.2.2.2")
+            snif_vlan77_sender_incorrect = infamy.Sniffer(ns21, "host 224.1.1.1")
+
+            snif_vlan55_receiver_correct = infamy.Sniffer(ns20, "host 224.1.1.1")
+            snif_vlan77_receiver_correct = infamy.Sniffer(ns11, "host 224.2.2.2")
+
+            with vlan55_sender:
+                with vlan77_sender:
+                    with vlan55_receiver:
+                        # TODO: Here should we check for 224.1.1.1 in mdb, also
+                        # verify that 224.2.2.2 does not exist in mdb
+
+                        with snif_vlan77_sender_incorrect:
+                            time.sleep(5)
+                            assert(snif_vlan77_sender_incorrect.output().stdout == "")
+                        with snif_vlan77_receiver_incorrect:
+                            time.sleep(5)
+                        assert(snif_vlan77_receiver_incorrect.output().stdout == "")
+                        with snif_vlan55_receiver_incorrect:
+                            time.sleep(5)
+                        assert(snif_vlan55_receiver_incorrect.output().stdout == "")
+                        with snif_vlan55_sender_incorrect:
+                            time.sleep(5)
+                        assert(snif_vlan55_sender_incorrect.output().stdout == "")
+                        print("Multicast does not exist on ports/VLANs where they should not be")
+
+                        with snif_vlan55_receiver_correct:
+                            time.sleep(5)
+                        assert(snif_vlan55_receiver_correct.output().stdout != "")
+                        with snif_vlan77_receiver_correct:
+                            time.sleep(5)
+                        assert(snif_vlan77_receiver_correct.output().stdout != "")
+            print("Multicast received on correct port and VLAN")
+
+        test.succeed()

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -19,7 +19,13 @@ RUN apk add --no-cache \
     socat \
     squashfs-tools \
     tcpdump \
-    tshark
+    tshark \
+    make
+
+ARG MTOOL_VERSION="3.0"
+RUN wget https://github.com/troglobit/mtools/releases/download/v3.0/mtools-$MTOOL_VERSION.tar.gz -O /tmp/mtools-$MTOOL_VERSION.tar.gz
+RUN cd /tmp/ && tar zxvf mtools-$MTOOL_VERSION.tar.gz
+RUN cd /tmp/mtools-$MTOOL_VERSION && make && make install
 
 # Alpine's QEMU package does not bundle this for some reason, copied
 # from Ubuntu

--- a/test/env
+++ b/test/env
@@ -141,6 +141,7 @@ done
 if [ "$containerize" ]; then
     # shellcheck disable=SC2016
         exec $(runner) run \
+	 --cap-add=NET_RAW \
 	 --cap-add=NET_ADMIN \
 	 --device=/dev/net/tun \
 	 --env VIRTUAL_ENV_DISABLE_PROMPT=yes \

--- a/test/infamy/multicast.py
+++ b/test/infamy/multicast.py
@@ -1,0 +1,56 @@
+import time
+import subprocess
+import signal
+import sys
+
+class MCastSender:
+    def __init__(self, netns,group):
+        self.group = group
+        self.netns = netns
+
+    def __enter__(self):
+        cmd = f"msend -I iface -g {self.group}"
+        arg = cmd.split(" ")
+
+        self.proc = self.netns.popen(arg, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    def __exit__(self, _, __, ___):
+        if not self.proc:
+            return False
+
+        sys.stdout.flush()
+        self.proc.send_signal(signal.SIGINT)
+        time.sleep(1)
+        if not self.proc.poll():
+            try:
+                self.proc.kill()
+            except OSError:
+                pass
+        self.proc.wait()
+
+class MCastReceiver:
+    def __init__(self, netns, group):
+        self.group = group
+        self.netns = netns
+
+    def __enter__(self):
+        cmd = f"mreceive -I iface -g {self.group}"
+        arg = cmd.split(" ")
+
+        self.proc = self.netns.popen(arg, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    def __exit__(self, _, __, ___):
+        if not self.proc:
+            return False
+
+        sys.stdout.flush()
+        self.proc.send_signal(signal.SIGINT)
+        time.sleep(3)
+        if not self.proc.poll():
+            print("PROC")
+            try:
+                self.proc.kill()
+            except OSError:
+                print("ERR")
+                pass
+        self.proc.wait()

--- a/test/infamy/topologies/1x4.dot
+++ b/test/infamy/topologies/1x4.dot
@@ -1,0 +1,26 @@
+graph "1x4" {
+	layout="neato";
+	overlap="false";
+	esep="+20";
+
+        node [shape=record, fontname="monospace"];
+	edge [color="cornflowerblue", penwidth="2"];
+
+	host [
+	    label="host | { <tgt> tgt | <data0> data0 | <data1>  data1 | <data2>  data2 }",
+	    pos="0,12!",
+	    kind="controller",
+	];
+
+        target [
+	    label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 | <data2> data2 } | target",
+	    pos="10,12!",
+
+	    kind="infix",
+	];
+
+	host:tgt -- target:mgmt [kind=mgmt]
+	host:data0 -- target:data0
+	host:data1 -- target:data1
+	host:data2 -- target:data2
+}

--- a/test/virt/quad/topology.dot.in
+++ b/test/virt/quad/topology.dot.in
@@ -11,7 +11,7 @@ graph "quad" {
 	qn_append="quiet";
 
         host [
-	    label="host | { <d1a> d1a | <d1b> d1b | <d1c> d1c | <d2a> d2a | <d2b> d2b | <d2c> d2c | <d2a> d3a | <d3b> d3b | <d3c> d3c | <d4a> d4a | <d4b> d4b | <d4c> d4c }}",
+	    label="host | { <d1a> d1a | <d1b> d1b | <d1c> d1c | <d1c> d1d | <d2a> d2a | <d2b> d2b | <d2c> d2c | <d2d> d2d | <d2a> d3a | <d3b> d3b | <d3c> d3c | <d3c> d3d |  <d4a> d4a | <d4b> d4b | <d4c> d4c | <d4c> d4d }",
 	    color="grey",fontcolor="grey",pos="0,15!",
 	    kind="controller",
 	];
@@ -53,26 +53,30 @@ graph "quad" {
 	host:d1a -- dut1:eth0 [kind=mgmt]
 	host:d1b -- dut1:eth1
 	host:d1c -- dut1:eth2
+	host:d1d -- dut1:eth3
 
 	host:d2a -- dut2:eth0 [kind=mgmt]
 	host:d2b -- dut2:eth1
 	host:d2c -- dut2:eth2
+	host:d2d -- dut2:eth3
 
 	host:d3a -- dut3:eth0 [kind=mgmt]
 	host:d3b -- dut3:eth1
 	host:d3c -- dut3:eth2
+	host:d3d -- dut3:eth3
 
 	host:d4a -- dut4:eth0 [kind=mgmt]
 	host:d4b -- dut4:eth1
 	host:d4c -- dut4:eth2
+	host:d4d -- dut4:eth3
 
 	# Ring
-	dut1:eth4 -- dut2:eth3
-	dut2:eth4 -- dut3:eth3
-	dut3:eth4 -- dut4:eth3
-	dut4:eth4 -- dut1:eth3
+	dut1:eth4 -- dut2:eth5
+	dut2:eth4 -- dut3:eth5
+	dut3:eth4 -- dut4:eth5
+	dut4:eth4 -- dut1:eth5
 
 	# Cross-links
-	dut3:eth5 -- dut1:eth5
-	dut2:eth5 -- dut4:eth5
+	dut3:eth6 -- dut1:eth6
+	dut2:eth6 -- dut4:eth6
 }


### PR DESCRIPTION
Initial IGMP/MLD filtering support for the Linux bridge model.  This PR brings per-bridge and per-VLAN settings to control basic multicast snooping[^1] settings:

 - Enable multicast snooping on the bridge, or per VLAN
 - Adjust querier mode (off, auto, proxy/NULL-only)
 - Adjust query interval (1-1024 sec)

We have verified that the built-in querier function of the kernel works, in particular in a non-VLAN filtering setup.  However, since it only supports proxy/NULL queries in a per-VLAN setup we've decided against using it at all.  So all querier functionality is handled by a userspace daemon instead.

The upstream kernel support for multicast filtering is still a bit limited.  For example:

 1. the only way to enable filtering of layer-2 (MAC) multicast, is to enable multicast snooping
 2. flooding of unknown multicast stops as soon as the bridge learns of a querier
 3. flooding of unknown layer-2 (MAC) multicast also stops as soon as there's a querier

To that end a couple of kernel patches are added to fix the last two issues.  These patches are also published on our open [kernel repo](https://github.com/kernelkit/linux/tree/kkit-linux-6.5.y) for the currently used kernel, along with any [iproute2 patches](https://github.com/kernelkit/iproute2/tree/kkit-6.1.y) needed to control these features. The idea is to upstream them at a later date. (After the next big customer release.)

[^1]: Unfortunately there is currently no way in the Linux bridge to enable filtering but not snooping.  So when we use the term snooping it may also refer to filtering.  We have discussed submitting kernel patches to address this issue but are time limited atm.

----

The next PR in this series will focus on:

 - MDB, both setting static/permanent entries and reading operational data
 - Per VLAN tests
 - Querier election tests
 - Advanced multicast filtering tests, e.g., mixed mdb entries with dynamic groups
