### PR TITLE
Add reboot test

### DIFF
--- a/test/case/misc/start_from_startup.py
+++ b/test/case/misc/start_from_startup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import infamy
+from infamy.util import wait_boot
+import copy
+
+def remove_config(target):
+    running = target.get_config_dict("/ietf-hardware:hardware")
+    new = copy.deepcopy(running)
+    new["hardware"].clear()
+    target.put_diff_dicts("ietf-hardware",running,new)
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("1x1"))
+        target = env.attach("target", "mgmt")
+
+    with test.step("Configure"):
+        target.put_config_dict("ietf-system", {
+            "system": {
+                "hostname": "test"
+            }
+        })
+        remove_config(target)
+        target.copy("running", "startup")
+    with test.step("Reboot and wait for the unit to come back"):
+        target.copy("running", "startup")
+        target.reboot()
+        if wait_boot(target) == False:
+            test.fail()
+        target = env.attach("target", "mgmt", factory_default = False)
+
+    with test.step("Verify hostname"):
+        data = target.get_dict("/ietf-system:system/hostname")
+        print(data)
+        assert(data["system"]["hostname"] == "test")
+
+    test.succeed()

--- a/test/infamy/util.py
+++ b/test/infamy/util.py
@@ -1,4 +1,6 @@
 import time
+import infamy.neigh
+import infamy.netconf as netconf
 
 def until(fn, attempts=10, interval=1):
     for attempt in range(attempts):
@@ -8,3 +10,16 @@ def until(fn, attempts=10, interval=1):
         time.sleep(interval)
 
     raise Exception("Expected condition did not materialize")
+
+def wait_boot(target):
+    until(lambda: target.reachable() == False, attempts = 100)
+    print("Device is booting..")
+    until(lambda: target.reachable() == True, attempts = 300)
+    iface=target.get_mgmt_iface()
+    if not iface:
+        return False
+    neigh=infamy.neigh.ll6ping(iface)
+    if not neigh:
+        return False
+    until(lambda: netconf.netconf_syn(neigh) == True, attempts = 300)
+    return True


### PR DESCRIPTION
<!--- Please provide a general **summary** of your changes in the title above -->

Add new reboot test to test that units can start from startup config
<!-- A description of changes in the pull request: detailing *why* the changes are made. -->
- Refactor code from test/case/ietf_hardware/usb.py to test/infamy/util, to a function called wait boot
- Added test to be able to verify the existence of #311

<!-- Remember to assign a reviewer, or use @mentions if you are not a member of the org. -->

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation
- [ ] Code style update (formatting, renaming)
- [x ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [x ] Other (please describe):
 Added test
## Other information

<!-- Any other relevant information to the PR, e.g., screenshots of before and after the change. -->

## References

<!-- Please list references to related issue(s) -->
