### PR TITLE
statd: add good-octets counters

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     name: Regression Testing
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -228,7 +228,7 @@ sysrepoctl -s $SEARCH							\
 	   -i infix-system@2023-10-19.yang	-g wheel -p 0660	\
 	   -i infix-services@2023-10-16.yang	-g wheel -p 0660	\
 	   -i ieee802-ethernet-interface@2019-06-21.yang -g wheel -p 0660 \
-	   -i infix-ethernet-interface@2024-01-22.yang -g wheel -p 0660 \
+	   -i infix-ethernet-interface@2024-02-27.yang -g wheel -p 0660 \
 	   -I "${INIT_DATA}"
 rc=$?
 

--- a/src/confd/yang/infix-ethernet-interface@2024-02-27.yang
+++ b/src/confd/yang/infix-ethernet-interface@2024-02-27.yang
@@ -9,10 +9,19 @@ module infix-ethernet-interface {
   import ietf-interfaces {
     prefix if;
   }
+  import ietf-yang-types {
+    prefix yang;
+    reference "IETF RFC 6991";
+  }
 
   organization "KernelKit";
   contact      "kernelkit@googlegroups.com";
   description  "Extensions and deviations to ieee802-ethernet-interface.yang";
+
+  revision 2024-02-27 {
+    description "Add augment for in-good-octets and out-good-octets";
+    reference "internal";
+  }
 
   revision 2024-01-22 {
     description "Support ethernet but not negotiation-status";
@@ -27,6 +36,18 @@ module infix-ethernet-interface {
   /*
    * Data Nodes
    */
+  augment "/if:interfaces/if:interface/eth:ethernet/eth:statistics/eth:frame" {
+    leaf out-good-octets {
+      type yang:counter64;
+      units octets;
+      description "A count of data and padding octets of frames that are successfully transmitted.";
+    }
+    leaf in-good-octets {
+      type yang:counter64;
+      units octets;
+      description "A count of data and padding octets in frames that are successfully received.";
+    }
+  }
 
   /* Deviations for config and status */
 

--- a/src/statd/cli-pretty
+++ b/src/statd/cli-pretty
@@ -64,6 +64,12 @@ def get_json_data(default, indata, *args):
 
     return data
 
+def remove_yang_prefix(key):
+    parts = key.split(":", 1)
+    if len(parts) > 1:
+        return parts[1]
+    return key
+
 class Route:
     def __init__(self,data,ip):
         self.data = data
@@ -376,8 +382,9 @@ class Iface:
         frame = get_json_data([], self.data,'ieee802-ethernet-interface:ethernet',
                               'statistics', 'frame')
         if frame:
-            print(f"")
+            print("")
             for key, val in frame.items():
+                key = remove_yang_prefix(key)
                 print(f"eth-{key:<{25}}: {val}")
 
 

--- a/src/statd/yanger
+++ b/src/statd/yanger
@@ -629,6 +629,11 @@ def add_ethtool_groups(ifname, iface_out):
         if "FramesLostDueToIntMACRcvError" in mac_in:
             frame['in-error-mac-internal-frames'] = str(mac_in['FramesLostDueToIntMACRcvError'])
 
+        if "OctetsTransmittedOK" in mac_in:
+            frame['infix-ethernet-interface:out-good-octets'] = str(mac_in['OctetsTransmittedOK'])
+        if "OctetsReceivedOK" in mac_in:
+            frame['infix-ethernet-interface:in-good-octets'] = str(mac_in['OctetsReceivedOK'])
+
         tot = 0
         found = False
         if "FramesReceivedOK" in mac_in:

--- a/test/case/cli/cli-output/show-interface-e0.txt
+++ b/test/case/cli/cli-output/show-interface-e0.txt
@@ -18,5 +18,7 @@ eth-in-frames                : 418
 eth-in-multicast-frames      : 336
 eth-in-broadcast-frames      : 46
 eth-in-error-fcs-frames      : 0
+eth-out-good-octets          : 129130
+eth-in-good-octets           : 72571
 eth-in-total-frames          : 418
 eth-in-error-oversize-frames : 0

--- a/test/case/cli/cli-output/show-interface-e1.txt
+++ b/test/case/cli/cli-output/show-interface-e1.txt
@@ -18,5 +18,7 @@ eth-in-frames                : 418
 eth-in-multicast-frames      : 336
 eth-in-broadcast-frames      : 46
 eth-in-error-fcs-frames      : 0
+eth-out-good-octets          : 129130
+eth-in-good-octets           : 72571
 eth-in-total-frames          : 418
 eth-in-error-oversize-frames : 0


### PR DESCRIPTION
This PR adds out-good-octets and in-good-octets as augment in the infix-ethernet-interface yang model. These counters represents OctetsTransmittedOK and OctetsReceivedOK from ethtool.

Example CLI output:
```
root@infix-06-10-00:/> show interfaces name x10
...
eth-out-good-octets          : 4414
eth-in-good-octets           : 1897
....
```
