### PR TITLE
Run regression tests only once, either push or pull-request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [aarch64, x86_64]
-        variant: [netconf, classic]
+        variant: [netconf]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     name: Regression Testing
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v4
         with:

--- a/test/env
+++ b/test/env
@@ -156,7 +156,7 @@ if [ "$containerize" ]; then
 	 --tty \
 	 --volume "$ixdir":"$ixdir" \
 	 --workdir "$ixdir/test" \
-	 "$kvm" \
+	 $kvm \
 	 $INFIX_TEST \
 	 "$0" -C "$@"
 else


### PR DESCRIPTION
## Description

Currently the regression tests runs twice when branches and PR:s originate from the same repo.  This commit adopts a fix suggested at

https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

