### PR TITLE
Fix race condition in test

### DIFF
--- a/test/infamy/iface.py
+++ b/test/infamy/iface.py
@@ -40,7 +40,7 @@ def address_exist(target, iface, address, proto="dhcp"):
     if not addrs:
         return False
     for addr in addrs:
-        if addr['origin'] == "dhcp" and addr['ip'] == address:
+        if addr['origin'] == proto and addr['ip'] == address:
             return True
 
 def get_ipv4_address(target, iface):


### PR DESCRIPTION
There was a race condition in the test ipv4_autoconf, that appeared on slow hardware (GitHub cloud runner,  a pc with kvm disabled), that locked-up the test forever.

- also fix a little bug in infamy/iface.py