### PR TITLE
Fix VLAN inference of traditional ifname.vid syntax

### DIFF
--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -149,36 +149,36 @@ static int ifchange_cand_infer_vlan(sr_session_ctx_t *session, const char *path)
 		goto out_free_ifname;
 
 	err = srx_nitems(session, &cnt,
-			 "%s/infix-if-vlan:vlan"
+			 "%s/infix-interfaces:vlan"
 			 "/lower-layer-if", xpath);
 	if (!err && !cnt) {
 		inferred.data.string_val = ifname;
 		err = srx_set_item(session, &inferred, 0,
-				   "%s/infix-if-vlan:vlan"
+				   "%s/infix-interfaces:vlan"
 				   "/lower-layer-if", xpath);
 		if (err)
 			goto out_free_ifname;
 	}
 
 	err = srx_nitems(session, &cnt,
-			 "%s/infix-if-vlan:vlan"
+			 "%s/infix-interfaces:vlan"
 			 "/tag-type", xpath);
 	if (!err && !cnt) {
 		inferred.data.string_val = "ieee802-dot1q-types:c-vlan";
 		err = srx_set_item(session, &inferred, 0,
-				   "%s/infix-if-vlan:vlan"
+				   "%s/infix-interfaces:vlan"
 				   "/tag-type", xpath);
 		if (err)
 			goto out_free_ifname;
 	}
 
 	err = srx_nitems(session, &cnt,
-			 "%s/infix-if-vlan:vlan"
+			 "%s/infix-interfaces:vlan"
 			 "/id", xpath);
 	if (!err && !cnt) {
 		inferred.data.string_val = vidstr;
 		err = srx_set_item(session, &inferred, 0,
-				   "%s/infix-if-vlan:vlan"
+				   "%s/infix-interfaces:vlan"
 				   "/id", xpath);
 		if (err)
 			goto out_free_ifname;


### PR DESCRIPTION
Fix VLAN inferring when using interface name IFNAME.VID to naming the interface.

Then set all VLAN settings properly as well

This fixes #329

<!--- **Summarize** your changes in the title above -->

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->


## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
