### PR TITLE
Fix redistribute default naming

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -19,7 +19,8 @@ All notable changes to the project are documented in this file.
 - Reduced syslog errors for accesses no non-existing xpaths
 - Fix bogus warning about not properly updating `/etc/motd` in new
   `motd-banner` setting, introduced in v24.02.0
-
+- infix-routing model: For OSPF, the configuration setting in `default-route-advertise`, `enable`
+  has been obsoleted and replaced by `enabled`
 
 [v24.02.0][] - 2024-03-01
 -------------------------

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
@@ -1,3 +1,3 @@
 # Locally calculated
 sha256  9d9d33b873917ca5d0bdcc47a36d2fd385971ab0c045d1472fcadf95ee5bcf5b  LICENCE
-sha256  c06a369147ae1071c0c309c0bd9d49d8ae0ff5dd1e804e2009b1a18f7fc12b5c  klish-plugin-sysrepo-909cbfb1253a3c3c3abfdc72de9db7aaf3a08de2-br1.tar.gz
+sha256  e18a45b35ade84201d9d59918e0743c0d9b5451cfe89ec1f7f0f6de2dc343a42  klish-plugin-sysrepo-364f7c7b9c61f2cfd51dfd8d94a8c67449ee439f-br1.tar.gz

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KLISH_PLUGIN_SYSREPO_VERSION = 909cbfb1253a3c3c3abfdc72de9db7aaf3a08de2
+KLISH_PLUGIN_SYSREPO_VERSION = 364f7c7b9c61f2cfd51dfd8d94a8c67449ee439f
 KLISH_PLUGIN_SYSREPO_SITE = https://github.com/kernelkit/klish-plugin-sysrepo.git
 #KLISH_PLUGIN_SYSREPO_VERSION = cdd3eb51a7f7ee0ed5bd925fa636061d3b1b85fb
 #KLISH_PLUGIN_SYSREPO_SITE = https://src.libcode.org/pkun/klish-plugin-sysrepo.git

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -218,7 +218,7 @@ sysrepoctl -s $SEARCH							\
 	   -i ieee802-dot1q-types@2022-10-29.yang -g wheel -p 0660	\
 	   -i infix-ip@2023-09-14.yang		-g wheel -p 0660	\
 	   -i infix-if-type@2024-01-29.yang	-g wheel -p 0660	\
-	   -i infix-routing@2024-01-09.yang     -g wheel -p 0660        \
+	   -i infix-routing@2024-03-06.yang     -g wheel -p 0660        \
 	   -i infix-interfaces@2024-01-15.yang	-g wheel -p 0660	\
 		-e vlan-filtering					\
 	   -i ieee802-dot1ab-lldp@2022-03-15.yang -g wheel -p 0660	\

--- a/src/confd/src/ietf-routing.c
+++ b/src/confd/src/ietf-routing.c
@@ -127,7 +127,8 @@ int parse_ospf(sr_session_ctx_t *session, struct lyd_node *ospf)
 	parse_ospf_redistribute(session, lydx_get_child(ospf, "redistribute"), fp);
 	default_route = lydx_get_child(ospf, "default-route-advertise");
 	if (default_route) {
-		if (lydx_get_bool(default_route, "enable")) {
+		/* enable is obsolete in favor for enabled. */
+		if ((lydx_get_child(default_route, "enable") && lydx_get_bool(default_route, "enable")) || lydx_get_bool(default_route, "enabled")) {
 			fputs("  default-information originate", fp);
 			if (lydx_get_bool(default_route, "always"))
 				fputs(" always", fp);

--- a/src/confd/yang/infix-routing@2024-01-09.yang
+++ b/src/confd/yang/infix-routing@2024-01-09.yang
@@ -185,6 +185,11 @@ module infix-routing {
     container default-route-advertise {
       description "Distribute default route to network";
       leaf enable {
+        status obsolete;
+        description "Legacy, replaced by 'enabled'.";
+        type boolean;
+      }
+      leaf enabled {
         description "Distribute default route";
         type boolean;
       }

--- a/src/confd/yang/infix-routing@2024-03-06.yang
+++ b/src/confd/yang/infix-routing@2024-03-06.yang
@@ -24,6 +24,10 @@ module infix-routing {
   import ietf-routing-types {
     prefix rt-types;
   }
+  revision 2024-03-06 {
+    description "Obsolete leaf enable in favor for enabled in default-route-advertise";
+    reference "internal";
+  }
   revision 2024-01-09 {
     description "Add operational, area, bfd support
                  and other minor features";


### PR DESCRIPTION
Fix issue #331, inconsistent naming 'enable' the terminology we use is 'enabled'
## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->


## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [x] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
