### PR TITLE
Finit: reboot-hang-fix and improved bootstrap log message

### DIFF
--- a/patches/finit/4.7/0003-Fix-397-drop-ttinit-for-PID-1.patch
+++ b/patches/finit/4.7/0003-Fix-397-drop-ttinit-for-PID-1.patch
@@ -1,0 +1,47 @@
+From c1ed3733986486f3255e77dec47ae1d4b2836e2f Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Mon, 11 Mar 2024 15:46:38 +0100
+Subject: [PATCH 3/4] Fix #397: drop ttinit() for PID 1
+Organization: Addiva Elektronik
+
+After reports from the field, see issue #397, of lockups at reboot,
+we've decided to drop this code from PID 1.  It was added before the 4.x
+series, when the current progress output was introduced.  For the older
+style progress it served a purpose since the placement of [OK]/[FAIL]
+was on the right hand side.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/log.c | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/src/log.c b/src/log.c
+index ea49705..b776525 100644
+--- a/src/log.c
++++ b/src/log.c
+@@ -42,8 +42,6 @@ static int loglevel = LOG_INFO;
+ 
+ void log_init(void)
+ {
+-	ttinit();
+-
+ 	if (debug)
+ 		loglevel = LOG_DEBUG;
+ 	else
+@@ -53,13 +51,6 @@ void log_init(void)
+ /* If we enabled terse mode at boot, restore to previous setting at shutdown */
+ void log_exit(void)
+ {
+-	/*
+-	 * Unless in debug mode at shutdown, Reinitialize screen,
+-	 * terminal may have been resized at runtime
+-	 */
+-	if (!debug)
+-		ttinit();
+-
+ 	enable_progress(1);
+ }
+ 
+-- 
+2.34.1
+

--- a/patches/finit/4.7/0004-Fix-398-display-unsupported-initctl-command-number-i.patch
+++ b/patches/finit/4.7/0004-Fix-398-display-unsupported-initctl-command-number-i.patch
@@ -1,0 +1,30 @@
+From 146bf5512208cb906edddb3f0108cf6f7c525044 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Mon, 11 Mar 2024 15:55:39 +0100
+Subject: [PATCH 4/4] Fix #398: display unsupported initctl command (number) in
+ log
+Organization: Addiva Elektronik
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/api.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/api.c b/src/api.c
+index c19c0d8..8d29a23 100644
+--- a/src/api.c
++++ b/src/api.c
+@@ -377,7 +377,9 @@ static void api_cb(uev_t *w, void *arg, int events)
+ 		case INIT_CMD_POWEROFF:
+ 		case INIT_CMD_SUSPEND:
+ 			if (IS_RESERVED_RUNLEVEL(runlevel)) {
+-				warnx("Unsupported command in runlevel S and 6/0.");
++				strterm(rq.data, sizeof(rq.data));
++				warnx("Unsupported command (cmd: %d, data: %s) in runlevel S and 6/0.",
++				      rq.cmd, rq.data);
+ 				goto leave;
+ 			}
+ 		default:
+-- 
+2.34.1
+


### PR DESCRIPTION
Backports of fixes for two issues:

 - Finit sometimes locks-up without input on serial console on reboot
 - Improved logging of unsupported `initctl` commands at bootstrap

The first one is scary, a remote SSH login performed reboot, but Finit hung waiting for someone to press enter on the serial console before initiating the reboot.
