### PR TITLE
Improve container network detection

### DIFF
--- a/src/confd/src/cni.c
+++ b/src/confd/src/cni.c
@@ -361,10 +361,10 @@ static int iface_gen_cni(const char *ifname, struct lyd_node *cif)
 	}
 
 	if (!strcmp(type, "host"))
-		return cni_host(net, ifname);
+		return cni_host(net, ifname) ?: 1;
 
 	if (!strcmp(type, "bridge"))
-		return cni_bridge(net, ifname);
+		return cni_bridge(net, ifname) ?: 1;
 
 	ERROR("Unknown container network type %s, skipping.", type);
 	return 0;


### PR DESCRIPTION
## Description

This PR fixes a bug in confd and silences bogus error messages from statd for interfaces currently being used by containers.

 - confd: cni_netdag_gen_iface() fails to return "is CNI interface" to netdag_gen_iface()
 - statd: skip interface status for interfaces not in current namespace

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [X] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
