### PR TITLE
board/aarch: styx: Fix SERDES connection to management CPU

### DIFF
--- a/board/aarch64/dts/styx/styx.dtsi
+++ b/board/aarch64/dts/styx/styx.dtsi
@@ -227,10 +227,10 @@
 
 /* ETH1 (Connection to BMC) */
 
-&cp0_eth1 {
+&cp0_eth2 {
 	status = "okay";
 	phy-mode = "sgmii";
-	phys = <&cp0_comphy5 0>;
+	phys = <&cp0_comphy5 2>;
 	managed = "in-band-status";
 
 	nvmem-cells = <&base_mac 0>;


### PR DESCRIPTION
Only port 2 has an SGMII compatible SERDES. When referencing the SERDES (comphy), the second argument must contain the port number in order for the comphy driver to pick the correct configuration.
