### PR TITLE
6393 Multi-chip Register Access Improvements

### DIFF
--- a/patches/linux/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
+++ b/patches/linux/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
@@ -1,7 +1,7 @@
 From 79abf7872e35080ca5b519bb4ad2acc1fbd96e8c Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Thu, 25 Jan 2024 21:36:59 +0100
-Subject: [PATCH 01/21] net: phy: add support for PHY LEDs polarity modes
+Subject: [PATCH 01/23] net: phy: add support for PHY LEDs polarity modes
 Organization: Addiva Elektronik
 
 Add support for PHY LEDs polarity modes. Some PHY require LED to be set

--- a/patches/linux/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
+++ b/patches/linux/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
@@ -1,7 +1,7 @@
 From 424ddb5d5d8ce06c578cc08cbedf519c42dd8b69 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Mon, 4 Dec 2023 11:08:11 +0100
-Subject: [PATCH 02/21] net: mvmdio: Support setting the MDC frequency on XSMI
+Subject: [PATCH 02/23] net: mvmdio: Support setting the MDC frequency on XSMI
  controllers
 Organization: Addiva Elektronik
 

--- a/patches/linux/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
+++ b/patches/linux/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
@@ -1,7 +1,7 @@
 From 337cf21833cef6ab456a8562338de88ab1a84ead Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:23 +0100
-Subject: [PATCH 03/21] net: dsa: mv88e6xxx: Create API to read a single stat
+Subject: [PATCH 03/23] net: dsa: mv88e6xxx: Create API to read a single stat
  counter
 Organization: Addiva Elektronik
 

--- a/patches/linux/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
+++ b/patches/linux/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
@@ -1,7 +1,7 @@
 From dbdbfd57998b4f8224146ac94cd5d0a577326087 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:25 +0100
-Subject: [PATCH 04/21] net: dsa: mv88e6xxx: Give each hw stat an ID
+Subject: [PATCH 04/23] net: dsa: mv88e6xxx: Give each hw stat an ID
 Organization: Addiva Elektronik
 
 With the upcoming standard counter group support, we are no longer

--- a/patches/linux/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
+++ b/patches/linux/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
@@ -1,7 +1,7 @@
 From 26815572016d9851ec6362f23746035fb933acf3 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:26 +0100
-Subject: [PATCH 05/21] net: dsa: mv88e6xxx: Add "eth-mac" counter group
+Subject: [PATCH 05/23] net: dsa: mv88e6xxx: Add "eth-mac" counter group
  support
 Organization: Addiva Elektronik
 

--- a/patches/linux/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
+++ b/patches/linux/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
@@ -1,7 +1,7 @@
 From cc5badac76e76692eb516a5c086fcf54a5a93080 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:27 +0100
-Subject: [PATCH 06/21] net: dsa: mv88e6xxx: Limit histogram counters to
+Subject: [PATCH 06/23] net: dsa: mv88e6xxx: Limit histogram counters to
  ingress traffic
 Organization: Addiva Elektronik
 

--- a/patches/linux/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
+++ b/patches/linux/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
@@ -1,7 +1,7 @@
 From 35ecc84237bfccbe5b93c0aef6c07cc506d43070 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:28 +0100
-Subject: [PATCH 07/21] net: dsa: mv88e6xxx: Add "rmon" counter group support
+Subject: [PATCH 07/23] net: dsa: mv88e6xxx: Add "rmon" counter group support
 Organization: Addiva Elektronik
 
 Report the applicable subset of an mv88e6xxx port's counters using

--- a/patches/linux/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
+++ b/patches/linux/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
@@ -1,7 +1,7 @@
 From 7750d0a5bfae46ab783e8e7087b70175860f808c Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 19:44:32 +0100
-Subject: [PATCH 09/21] net: dsa: mv88e6xxx: Add LED infrastructure
+Subject: [PATCH 09/23] net: dsa: mv88e6xxx: Add LED infrastructure
 Organization: Addiva Elektronik
 
 Parse DT for LEDs and register them for devices that support it,

--- a/patches/linux/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
+++ b/patches/linux/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
@@ -1,7 +1,7 @@
 From 63fcd626fdb108d2ac07cb0aa16b91fc43894bff Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 21:59:35 +0100
-Subject: [PATCH 10/21] net: dsa: mv88e6xxx: Add LED support for 6393X
+Subject: [PATCH 10/23] net: dsa: mv88e6xxx: Add LED support for 6393X
 Organization: Addiva Elektronik
 
 Trigger support:

--- a/patches/linux/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
+++ b/patches/linux/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
@@ -1,7 +1,7 @@
 From 0bc6f19d18d7c0e374c824bcc86433b04210a378 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Mar 2024 10:27:24 +0100
-Subject: [PATCH 11/21] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
+Subject: [PATCH 11/23] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
  6393X
 Organization: Addiva Elektronik
 

--- a/patches/linux/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
+++ b/patches/linux/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
@@ -1,7 +1,7 @@
 From fe60e3ad1e3b43a924c311658b15a1106e813661 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 16 Jan 2024 16:00:55 +0100
-Subject: [PATCH 12/21] net: dsa: Support MDB memberships whose L2 addresses
+Subject: [PATCH 12/23] net: dsa: Support MDB memberships whose L2 addresses
  overlap
 Organization: Addiva Elektronik
 

--- a/patches/linux/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
+++ b/patches/linux/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
@@ -1,7 +1,7 @@
 From 5f5bf4a50e98c5aff05fe85994a981253ae85987 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 19 Sep 2023 18:38:10 +0200
-Subject: [PATCH 13/21] net: phy: marvell10g: Support firmware loading on
+Subject: [PATCH 13/23] net: phy: marvell10g: Support firmware loading on
  88X3310
 Organization: Addiva Elektronik
 

--- a/patches/linux/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
+++ b/patches/linux/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
@@ -1,7 +1,7 @@
 From 27d5241d3ddf70d65af5f4dd029f99f0fea866a5 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 21 Nov 2023 20:15:24 +0100
-Subject: [PATCH 14/21] net: phy: marvell10g: Fix power-up when strapped to
+Subject: [PATCH 14/23] net: phy: marvell10g: Fix power-up when strapped to
  start powered down
 Organization: Addiva Elektronik
 

--- a/patches/linux/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
+++ b/patches/linux/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
@@ -1,7 +1,7 @@
 From e389ee690ce56ef20863aeabdf389bed842d7f42 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 15 Nov 2023 20:58:42 +0100
-Subject: [PATCH 15/21] net: phy: marvell10g: Add LED support for 88X3310
+Subject: [PATCH 15/23] net: phy: marvell10g: Add LED support for 88X3310
 Organization: Addiva Elektronik
 
 Pickup the LEDs from the state in which the hardware reset or

--- a/patches/linux/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
+++ b/patches/linux/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
@@ -1,7 +1,7 @@
 From 3113b64290b5b7b20c294535c12ea4c732a02f51 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Dec 2023 09:51:05 +0100
-Subject: [PATCH 16/21] net: phy: marvell10g: Support LEDs tied to a single
+Subject: [PATCH 16/23] net: phy: marvell10g: Support LEDs tied to a single
  media side
 Organization: Addiva Elektronik
 

--- a/patches/linux/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
+++ b/patches/linux/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
@@ -1,7 +1,7 @@
 From 2570c2350d3d614a31e14dd87d0e99e8fcb5096b Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 24 Nov 2023 23:29:55 +0100
-Subject: [PATCH 17/21] nvmem: layouts: onie-tlv: Let device probe even when
+Subject: [PATCH 17/23] nvmem: layouts: onie-tlv: Let device probe even when
  TLV is invalid
 Organization: Addiva Elektronik
 

--- a/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
+++ b/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
@@ -1,7 +1,7 @@
 From 681ce95c15bff94ac83eb26db3c718594f8dfa16 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Mon, 4 Mar 2024 16:47:28 +0100
-Subject: [PATCH 18/21] net: bridge: avoid classifying unknown multicast as
+Subject: [PATCH 18/23] net: bridge: avoid classifying unknown multicast as
  mrouters_only
 Organization: Addiva Elektronik
 

--- a/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
+++ b/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
@@ -1,7 +1,7 @@
 From 2482848726a5b8185a04d90891693a1713f894b5 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Tue, 5 Mar 2024 06:44:41 +0100
-Subject: [PATCH 19/21] net: bridge: Ignore router ports when forwarding L2
+Subject: [PATCH 19/23] net: bridge: Ignore router ports when forwarding L2
  multicast
 Organization: Addiva Elektronik
 

--- a/patches/linux/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
+++ b/patches/linux/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
@@ -1,7 +1,7 @@
 From 25efcdb13ae720ee662f4b6091b270e48ac4d375 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 21 Mar 2024 19:12:15 +0100
-Subject: [PATCH 20/21] net: dsa: Support EtherType based priority overrides
+Subject: [PATCH 20/23] net: dsa: Support EtherType based priority overrides
 Organization: Addiva Elektronik
 
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>

--- a/patches/linux/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
+++ b/patches/linux/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
@@ -1,7 +1,7 @@
 From 213e9a1d9145723897fbba40fc4afc5b5f70c1de Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 22 Mar 2024 16:15:43 +0100
-Subject: [PATCH 21/21] net: dsa: mv88e6xxx: Support EtherType based priority
+Subject: [PATCH 21/23] net: dsa: mv88e6xxx: Support EtherType based priority
  overrides
 Organization: Addiva Elektronik
 

--- a/patches/linux/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
+++ b/patches/linux/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
@@ -1,0 +1,38 @@
+From 1c1c81864c9803831c2d5b7df0d7da28e566f3b2 Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Wed, 27 Mar 2024 10:10:19 +0100
+Subject: [PATCH 22/23] net: phy: Do not resume PHY when attaching
+Organization: Addiva Elektronik
+
+The PHY should not start negotiating with its link-partner until
+explicitly instructed to do so.
+
+Therefore, skip resuming the PHY in the attach phase, deferring it to
+when phy_start() is called from the net_device's open() callback,
+possibly via phylink_start().
+
+Otherwise, drivers that attached to their PHYs during
+probing (e.g. DSA) would end up with a physical link being
+established, even though the corresponding interface was still
+administratively down.
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+---
+ drivers/net/phy/phy_device.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
+index 3741c0c3bf4a..31bd1fac3762 100644
+--- a/drivers/net/phy/phy_device.c
++++ b/drivers/net/phy/phy_device.c
+@@ -1547,7 +1547,6 @@ int phy_attach_direct(struct net_device *dev, struct phy_device *phydev,
+ 	if (err)
+ 		goto error;
+ 
+-	phy_resume(phydev);
+ 	if (!phydev->is_on_sfp_module)
+ 		phy_led_triggers_register(phydev);
+ 
+-- 
+2.34.1
+

--- a/patches/linux/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
+++ b/patches/linux/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
@@ -1,0 +1,216 @@
+From b53e5007cd5be42eb5d9a510d63f89c7c6edd9b6 Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Wed, 27 Mar 2024 15:52:43 +0100
+Subject: [PATCH 23/23] net: dsa: mv88e6xxx: Improve indirect register access
+ perf on 6393
+Organization: Addiva Elektronik
+
+When operating in multi-chip mode, the 6393 family maps a subset of
+commonly used global registers to the outermost address space (in
+which only the SMI command and data registers were available in
+previous families).
+
+Therefore, add a new set of SMI operations which remaps accesses to
+such registers to the corresponding directly addressable register. All
+other accesses use the regular indirect interface.
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c    |  7 +++
+ drivers/net/dsa/mv88e6xxx/global1.h |  3 ++
+ drivers/net/dsa/mv88e6xxx/global2.h |  3 ++
+ drivers/net/dsa/mv88e6xxx/smi.c     | 76 +++++++++++++++++++++++++++++
+ drivers/net/dsa/mv88e6xxx/smi.h     | 30 ++++++++++++
+ 5 files changed, 119 insertions(+)
+
+diff --git a/drivers/net/dsa/mv88e6xxx/chip.c b/drivers/net/dsa/mv88e6xxx/chip.c
+index 5a422c9b533a..76bb8b492ca9 100644
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -6349,6 +6349,13 @@ static int mv88e6xxx_detect(struct mv88e6xxx_chip *chip)
+ 	/* Update the compatible info with the probed one */
+ 	chip->info = info;
+ 
++	/* Now that we know the exact chip in use, we might be able to
++	 * make use of more efficient SMI operations
++	 */
++	err = mv88e6xxx_smi_init(chip, chip->bus, chip->sw_addr);
++	if (err)
++		return err;
++
+ 	dev_info(chip->dev, "switch 0x%x detected: %s, revision %u\n",
+ 		 chip->info->prod_num, chip->info->name, rev);
+ 
+diff --git a/drivers/net/dsa/mv88e6xxx/global1.h b/drivers/net/dsa/mv88e6xxx/global1.h
+index 1095261f5b49..c141cf70364b 100644
+--- a/drivers/net/dsa/mv88e6xxx/global1.h
++++ b/drivers/net/dsa/mv88e6xxx/global1.h
+@@ -218,6 +218,9 @@
+ #define MV88E6390_G1_MONITOR_MGMT_CTL_PTR_CPU_DEST_MGMTPRI	0x00e0
+ #define MV88E6390_G1_MONITOR_MGMT_CTL_DATA_MASK			0x00ff
+ 
++/* Offset 0x1B: Free Queue Size Register */
++#define MV88E6XXX_G1_FREE_Q_SIZE		0x1b
++
+ /* Offset 0x1C: Global Control 2 */
+ #define MV88E6XXX_G1_CTL2			0x1c
+ #define MV88E6185_G1_CTL2_CASCADE_PORT_MASK	0xf000
+diff --git a/drivers/net/dsa/mv88e6xxx/global2.h b/drivers/net/dsa/mv88e6xxx/global2.h
+index 22a2583a31d9..0127902ceafc 100644
+--- a/drivers/net/dsa/mv88e6xxx/global2.h
++++ b/drivers/net/dsa/mv88e6xxx/global2.h
+@@ -144,6 +144,9 @@
+ #define MV88E6XXX_G2_PRIO_OVERRIDE_QFPRIEN	0x0008
+ #define MV88E6XXX_G2_PRIO_OVERRIDE_DATA_MASK	0x0007
+ 
++/* Offset 0x13: IMP Communication/Debug Register */
++#define MV88E6390_G2_IMP_COMM			0x13
++
+ /* Offset 0x14: EEPROM Command */
+ #define MV88E6XXX_G2_EEPROM_CMD			0x14
+ #define MV88E6XXX_G2_EEPROM_CMD_BUSY		0x8000
+diff --git a/drivers/net/dsa/mv88e6xxx/smi.c b/drivers/net/dsa/mv88e6xxx/smi.c
+index a990271b7482..f54bb0e79030 100644
+--- a/drivers/net/dsa/mv88e6xxx/smi.c
++++ b/drivers/net/dsa/mv88e6xxx/smi.c
+@@ -8,6 +8,8 @@
+  */
+ 
+ #include "chip.h"
++#include "global1.h"
++#include "global2.h"
+ #include "smi.h"
+ 
+ /* The switch ADDR[4:1] configuration pins define the chip SMI device address
+@@ -168,6 +170,78 @@ static const struct mv88e6xxx_bus_ops mv88e6xxx_smi_indirect_ops = {
+ 	.init = mv88e6xxx_smi_indirect_init,
+ };
+ 
++static u8 mv88e6393_smi_indirect_remap(int dev, int reg)
++{
++	static const u8 g1_remap[32] = {
++		[MV88E6352_G1_VTU_FID] = MV88E6393_SMI_G1_VTU_FID,
++		[MV88E6352_G1_VTU_SID] = MV88E6393_SMI_G1_VTU_SID,
++		[MV88E6XXX_G1_STS] = MV88E6393_SMI_G1_STS,
++		[MV88E6XXX_G1_VTU_OP] = MV88E6393_SMI_G1_VTU_OP,
++		[MV88E6XXX_G1_VTU_VID] = MV88E6393_SMI_G1_VTU_VID,
++		[MV88E6XXX_G1_VTU_DATA1] = MV88E6393_SMI_G1_VTU_DATA1,
++		[MV88E6XXX_G1_VTU_DATA2] = MV88E6393_SMI_G1_VTU_DATA2,
++		[MV88E6352_G1_ATU_FID] = MV88E6393_SMI_G1_ATU_FID,
++		[MV88E6XXX_G1_ATU_CTL] = MV88E6393_SMI_G1_ATU_CTL,
++		[MV88E6XXX_G1_ATU_OP] = MV88E6393_SMI_G1_ATU_OP,
++		[MV88E6XXX_G1_ATU_DATA] = MV88E6393_SMI_G1_ATU_DATA,
++		[MV88E6XXX_G1_ATU_MAC01] = MV88E6393_SMI_G1_ATU_MAC01,
++		[MV88E6XXX_G1_ATU_MAC23] = MV88E6393_SMI_G1_ATU_MAC23,
++		[MV88E6XXX_G1_ATU_MAC45] = MV88E6393_SMI_G1_ATU_MAC45,
++		[MV88E6XXX_G1_FREE_Q_SIZE] = MV88E6393_SMI_G1_FREE_Q_SIZE,
++		[MV88E6XXX_G1_STATS_OP] = MV88E6393_SMI_G1_STATS_OP,
++		[MV88E6XXX_G1_STATS_COUNTER_32] = MV88E6393_SMI_G1_STATS_COUNTER_32,
++		[MV88E6XXX_G1_STATS_COUNTER_01] = MV88E6393_SMI_G1_STATS_COUNTER_01,
++	};
++
++	static const u8 g2_remap[32] = {
++		[MV88E6390_G2_IMP_COMM] = MV88E6393_SMI_G2_IMP_COMM,
++		[MV88E6352_G2_AVB_CMD] = MV88E6393_SMI_G2_AVB_CMD,
++		[MV88E6352_G2_AVB_DATA] = MV88E6393_SMI_G2_AVB_DATA,
++		[MV88E6XXX_G2_SMI_PHY_CMD] = MV88E6393_SMI_G2_SMI_PHY_CMD,
++		[MV88E6XXX_G2_SMI_PHY_DATA] = MV88E6393_SMI_G2_SMI_PHY_DATA,
++		[MV88E6393X_G2_MACLINK_INT_SRC] = MV88E6393_SMI_G2_MACLINK_INT_SRC,
++	};
++
++	switch (dev) {
++	case 0x1b:
++		return g1_remap[reg];
++	case 0x1c:
++		return g2_remap[reg];
++	}
++
++	return 0;
++}
++
++static int mv88e6393_smi_indirect_read(struct mv88e6xxx_chip *chip,
++				       int dev, int reg, u16 *data)
++{
++	u8 remap = mv88e6393_smi_indirect_remap(dev, reg);
++
++	if (remap)
++		return mv88e6xxx_smi_direct_read(chip, chip->sw_addr,
++						 remap, data);
++
++	return mv88e6xxx_smi_indirect_read(chip, dev, reg, data);
++}
++
++static int mv88e6393_smi_indirect_write(struct mv88e6xxx_chip *chip,
++					int dev, int reg, u16 data)
++{
++	u8 remap = mv88e6393_smi_indirect_remap(dev, reg);
++
++	if (remap)
++		return mv88e6xxx_smi_direct_write(chip, chip->sw_addr,
++						  remap, data);
++
++	return mv88e6xxx_smi_indirect_write(chip, dev, reg, data);
++}
++
++static const struct mv88e6xxx_bus_ops mv88e6393_smi_indirect_ops = {
++	.read = mv88e6393_smi_indirect_read,
++	.write = mv88e6393_smi_indirect_write,
++	.init = mv88e6xxx_smi_indirect_init,
++};
++
+ int mv88e6xxx_smi_init(struct mv88e6xxx_chip *chip,
+ 		       struct mii_bus *bus, int sw_addr)
+ {
+@@ -175,6 +249,8 @@ int mv88e6xxx_smi_init(struct mv88e6xxx_chip *chip,
+ 		chip->smi_ops = &mv88e6xxx_smi_dual_direct_ops;
+ 	else if (sw_addr == 0)
+ 		chip->smi_ops = &mv88e6xxx_smi_direct_ops;
++	else if (chip->info->family == MV88E6XXX_FAMILY_6393)
++		chip->smi_ops = &mv88e6393_smi_indirect_ops;
+ 	else if (chip->info->multi_chip)
+ 		chip->smi_ops = &mv88e6xxx_smi_indirect_ops;
+ 	else
+diff --git a/drivers/net/dsa/mv88e6xxx/smi.h b/drivers/net/dsa/mv88e6xxx/smi.h
+index c6c71d5757f5..788cf68b7b33 100644
+--- a/drivers/net/dsa/mv88e6xxx/smi.h
++++ b/drivers/net/dsa/mv88e6xxx/smi.h
+@@ -31,6 +31,36 @@
+ /* Offset 0x01: SMI Data Register */
+ #define MV88E6XXX_SMI_DATA			0x01
+ 
++/* When using the 6393 in indirect addressing mode, a subset of the
++ * most commonly used registers are directly mapped out to the chip's
++ * top address space, allowing them to be directly accessed.
++ */
++#define MV88E6393_SMI_G1_VTU_FID		0x02
++#define MV88E6393_SMI_G1_VTU_SID		0x03
++#define MV88E6393_SMI_G1_STS			0x04
++#define MV88E6393_SMI_G1_VTU_OP			0x05
++#define MV88E6393_SMI_G1_VTU_VID		0x06
++#define MV88E6393_SMI_G1_VTU_DATA1		0x07
++#define MV88E6393_SMI_G1_VTU_DATA2		0x08
++#define MV88E6393_SMI_G1_ATU_FID		0x09
++#define MV88E6393_SMI_G1_ATU_CTL		0x0a
++#define MV88E6393_SMI_G1_ATU_OP			0x0b
++#define MV88E6393_SMI_G1_ATU_DATA		0x0c
++#define MV88E6393_SMI_G1_ATU_MAC01		0x0d
++#define MV88E6393_SMI_G1_ATU_MAC23		0x0e
++#define MV88E6393_SMI_G1_ATU_MAC45		0x0f
++#define MV88E6393_SMI_G2_IMP_COMM		0x13
++#define MV88E6393_SMI_G2_AVB_CMD		0x16
++#define MV88E6393_SMI_G2_AVB_DATA		0x17
++#define MV88E6393_SMI_G2_SMI_PHY_CMD		0x18
++#define MV88E6393_SMI_G2_SMI_PHY_DATA		0x19
++#define MV88E6393_SMI_G2_MACLINK_INT_SRC	0x1a
++#define MV88E6393_SMI_G1_FREE_Q_SIZE		0x1b
++#define MV88E6393_SMI_G1_STATS_OP		0x1d
++#define MV88E6393_SMI_G1_STATS_COUNTER_32	0x1e
++#define MV88E6393_SMI_G1_STATS_COUNTER_01	0x1f
++
++
+ int mv88e6xxx_smi_init(struct mv88e6xxx_chip *chip,
+ 		       struct mii_bus *bus, int sw_addr);
+ 
+-- 
+2.34.1
+

--- a/utils/kernel-refresh.sh
+++ b/utils/kernel-refresh.sh
@@ -31,7 +31,7 @@ getconfig()
     grep "$1=" .config | sed -e "s/$1=\"\([^\"]\+\)\"/\1/"
 }
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     usage
     exit 1
 fi


### PR DESCRIPTION
With the Amethyst family, the indirect addressing mode used in multi-chip setups was improved by making common global functions (e.g. external MDIO bus, ATU, VTU) directly accessible through previously reserved registers.

Add support for this in `mv88e6xxx`.

Non-scientific measurements show that loading of startup-configs with north of 10 VLANs is roughly twice as fast with this feature in place.

Also, disable the kernel's default behavior of starting up a PHY as soon as a netdev driver attaches to it, avoiding the issue of signaling a physical link up to the link partner while the backing MAC is still disabled.

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
