### PR TITLE
kernel: import drop initial multicast filtering delay

### DIFF
--- a/patches/linux/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
+++ b/patches/linux/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
@@ -1,7 +1,7 @@
 From 79abf7872e35080ca5b519bb4ad2acc1fbd96e8c Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Thu, 25 Jan 2024 21:36:59 +0100
-Subject: [PATCH 01/23] net: phy: add support for PHY LEDs polarity modes
+Subject: [PATCH 01/24] net: phy: add support for PHY LEDs polarity modes
 Organization: Addiva Elektronik
 
 Add support for PHY LEDs polarity modes. Some PHY require LED to be set

--- a/patches/linux/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
+++ b/patches/linux/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
@@ -1,7 +1,7 @@
 From 424ddb5d5d8ce06c578cc08cbedf519c42dd8b69 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Mon, 4 Dec 2023 11:08:11 +0100
-Subject: [PATCH 02/23] net: mvmdio: Support setting the MDC frequency on XSMI
+Subject: [PATCH 02/24] net: mvmdio: Support setting the MDC frequency on XSMI
  controllers
 Organization: Addiva Elektronik
 

--- a/patches/linux/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
+++ b/patches/linux/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
@@ -1,7 +1,7 @@
 From 337cf21833cef6ab456a8562338de88ab1a84ead Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:23 +0100
-Subject: [PATCH 03/23] net: dsa: mv88e6xxx: Create API to read a single stat
+Subject: [PATCH 03/24] net: dsa: mv88e6xxx: Create API to read a single stat
  counter
 Organization: Addiva Elektronik
 

--- a/patches/linux/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
+++ b/patches/linux/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
@@ -1,7 +1,7 @@
 From dbdbfd57998b4f8224146ac94cd5d0a577326087 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:25 +0100
-Subject: [PATCH 04/23] net: dsa: mv88e6xxx: Give each hw stat an ID
+Subject: [PATCH 04/24] net: dsa: mv88e6xxx: Give each hw stat an ID
 Organization: Addiva Elektronik
 
 With the upcoming standard counter group support, we are no longer

--- a/patches/linux/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
+++ b/patches/linux/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
@@ -1,7 +1,7 @@
 From 26815572016d9851ec6362f23746035fb933acf3 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:26 +0100
-Subject: [PATCH 05/23] net: dsa: mv88e6xxx: Add "eth-mac" counter group
+Subject: [PATCH 05/24] net: dsa: mv88e6xxx: Add "eth-mac" counter group
  support
 Organization: Addiva Elektronik
 

--- a/patches/linux/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
+++ b/patches/linux/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
@@ -1,7 +1,7 @@
 From cc5badac76e76692eb516a5c086fcf54a5a93080 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:27 +0100
-Subject: [PATCH 06/23] net: dsa: mv88e6xxx: Limit histogram counters to
+Subject: [PATCH 06/24] net: dsa: mv88e6xxx: Limit histogram counters to
  ingress traffic
 Organization: Addiva Elektronik
 

--- a/patches/linux/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
+++ b/patches/linux/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
@@ -1,7 +1,7 @@
 From 35ecc84237bfccbe5b93c0aef6c07cc506d43070 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:28 +0100
-Subject: [PATCH 07/23] net: dsa: mv88e6xxx: Add "rmon" counter group support
+Subject: [PATCH 07/24] net: dsa: mv88e6xxx: Add "rmon" counter group support
 Organization: Addiva Elektronik
 
 Report the applicable subset of an mv88e6xxx port's counters using

--- a/patches/linux/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
+++ b/patches/linux/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
@@ -1,7 +1,7 @@
 From 7750d0a5bfae46ab783e8e7087b70175860f808c Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 19:44:32 +0100
-Subject: [PATCH 09/23] net: dsa: mv88e6xxx: Add LED infrastructure
+Subject: [PATCH 09/24] net: dsa: mv88e6xxx: Add LED infrastructure
 Organization: Addiva Elektronik
 
 Parse DT for LEDs and register them for devices that support it,

--- a/patches/linux/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
+++ b/patches/linux/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
@@ -1,7 +1,7 @@
 From 63fcd626fdb108d2ac07cb0aa16b91fc43894bff Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 21:59:35 +0100
-Subject: [PATCH 10/23] net: dsa: mv88e6xxx: Add LED support for 6393X
+Subject: [PATCH 10/24] net: dsa: mv88e6xxx: Add LED support for 6393X
 Organization: Addiva Elektronik
 
 Trigger support:

--- a/patches/linux/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
+++ b/patches/linux/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
@@ -1,7 +1,7 @@
 From 0bc6f19d18d7c0e374c824bcc86433b04210a378 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Mar 2024 10:27:24 +0100
-Subject: [PATCH 11/23] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
+Subject: [PATCH 11/24] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
  6393X
 Organization: Addiva Elektronik
 

--- a/patches/linux/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
+++ b/patches/linux/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
@@ -1,7 +1,7 @@
 From fe60e3ad1e3b43a924c311658b15a1106e813661 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 16 Jan 2024 16:00:55 +0100
-Subject: [PATCH 12/23] net: dsa: Support MDB memberships whose L2 addresses
+Subject: [PATCH 12/24] net: dsa: Support MDB memberships whose L2 addresses
  overlap
 Organization: Addiva Elektronik
 

--- a/patches/linux/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
+++ b/patches/linux/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
@@ -1,7 +1,7 @@
 From 5f5bf4a50e98c5aff05fe85994a981253ae85987 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 19 Sep 2023 18:38:10 +0200
-Subject: [PATCH 13/23] net: phy: marvell10g: Support firmware loading on
+Subject: [PATCH 13/24] net: phy: marvell10g: Support firmware loading on
  88X3310
 Organization: Addiva Elektronik
 

--- a/patches/linux/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
+++ b/patches/linux/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
@@ -1,7 +1,7 @@
 From 27d5241d3ddf70d65af5f4dd029f99f0fea866a5 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 21 Nov 2023 20:15:24 +0100
-Subject: [PATCH 14/23] net: phy: marvell10g: Fix power-up when strapped to
+Subject: [PATCH 14/24] net: phy: marvell10g: Fix power-up when strapped to
  start powered down
 Organization: Addiva Elektronik
 

--- a/patches/linux/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
+++ b/patches/linux/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
@@ -1,7 +1,7 @@
 From e389ee690ce56ef20863aeabdf389bed842d7f42 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 15 Nov 2023 20:58:42 +0100
-Subject: [PATCH 15/23] net: phy: marvell10g: Add LED support for 88X3310
+Subject: [PATCH 15/24] net: phy: marvell10g: Add LED support for 88X3310
 Organization: Addiva Elektronik
 
 Pickup the LEDs from the state in which the hardware reset or

--- a/patches/linux/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
+++ b/patches/linux/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
@@ -1,7 +1,7 @@
 From 3113b64290b5b7b20c294535c12ea4c732a02f51 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Dec 2023 09:51:05 +0100
-Subject: [PATCH 16/23] net: phy: marvell10g: Support LEDs tied to a single
+Subject: [PATCH 16/24] net: phy: marvell10g: Support LEDs tied to a single
  media side
 Organization: Addiva Elektronik
 

--- a/patches/linux/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
+++ b/patches/linux/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
@@ -1,7 +1,7 @@
 From 2570c2350d3d614a31e14dd87d0e99e8fcb5096b Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 24 Nov 2023 23:29:55 +0100
-Subject: [PATCH 17/23] nvmem: layouts: onie-tlv: Let device probe even when
+Subject: [PATCH 17/24] nvmem: layouts: onie-tlv: Let device probe even when
  TLV is invalid
 Organization: Addiva Elektronik
 

--- a/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
+++ b/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
@@ -1,7 +1,7 @@
 From 681ce95c15bff94ac83eb26db3c718594f8dfa16 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Mon, 4 Mar 2024 16:47:28 +0100
-Subject: [PATCH 18/23] net: bridge: avoid classifying unknown multicast as
+Subject: [PATCH 18/24] net: bridge: avoid classifying unknown multicast as
  mrouters_only
 Organization: Addiva Elektronik
 

--- a/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
+++ b/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
@@ -1,7 +1,7 @@
 From 2482848726a5b8185a04d90891693a1713f894b5 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Tue, 5 Mar 2024 06:44:41 +0100
-Subject: [PATCH 19/23] net: bridge: Ignore router ports when forwarding L2
+Subject: [PATCH 19/24] net: bridge: Ignore router ports when forwarding L2
  multicast
 Organization: Addiva Elektronik
 

--- a/patches/linux/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
+++ b/patches/linux/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
@@ -1,7 +1,7 @@
 From 25efcdb13ae720ee662f4b6091b270e48ac4d375 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 21 Mar 2024 19:12:15 +0100
-Subject: [PATCH 20/23] net: dsa: Support EtherType based priority overrides
+Subject: [PATCH 20/24] net: dsa: Support EtherType based priority overrides
 Organization: Addiva Elektronik
 
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>

--- a/patches/linux/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
+++ b/patches/linux/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
@@ -1,7 +1,7 @@
 From 213e9a1d9145723897fbba40fc4afc5b5f70c1de Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 22 Mar 2024 16:15:43 +0100
-Subject: [PATCH 21/23] net: dsa: mv88e6xxx: Support EtherType based priority
+Subject: [PATCH 21/24] net: dsa: mv88e6xxx: Support EtherType based priority
  overrides
 Organization: Addiva Elektronik
 

--- a/patches/linux/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
+++ b/patches/linux/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
@@ -1,7 +1,7 @@
 From 1c1c81864c9803831c2d5b7df0d7da28e566f3b2 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 27 Mar 2024 10:10:19 +0100
-Subject: [PATCH 22/23] net: phy: Do not resume PHY when attaching
+Subject: [PATCH 22/24] net: phy: Do not resume PHY when attaching
 Organization: Addiva Elektronik
 
 The PHY should not start negotiating with its link-partner until

--- a/patches/linux/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
+++ b/patches/linux/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
@@ -1,7 +1,7 @@
 From b53e5007cd5be42eb5d9a510d63f89c7c6edd9b6 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 27 Mar 2024 15:52:43 +0100
-Subject: [PATCH 23/23] net: dsa: mv88e6xxx: Improve indirect register access
+Subject: [PATCH 23/24] net: dsa: mv88e6xxx: Improve indirect register access
  perf on 6393
 Organization: Addiva Elektronik
 

--- a/patches/linux/0024-net-bridge-drop-delay-for-applying-strict-multicast-.patch
+++ b/patches/linux/0024-net-bridge-drop-delay-for-applying-strict-multicast-.patch
@@ -1,0 +1,190 @@
+From f53652205b1c044fa00f896d6422c82ac808f16a Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Thu, 4 Apr 2024 16:36:30 +0200
+Subject: [PATCH 24/24] net: bridge: drop delay for applying strict multicast
+ filtering
+Organization: Addiva Elektronik
+
+This *local* patch drops the initial delay before applying strict multicast
+filtering, introduced in [1] and recently updated in [2].
+
+The main reason for this patch is RFC conformance and customer expectations.
+At power on we assume the querier role by default and are expected to stop
+unknown flooding as soon as we have a membership report in place, not after
+10 seconds.
+
+A proper fix for upstreaming could be to add a knob to disable the delay.
+
+[1]: https://lore.kernel.org/netdev/1375311980-25575-1-git-send-email-linus.luessing@web.de/
+[2]: https://lore.kernel.org/netdev/20240127175033.9640-1-linus.luessing@c0d3.blue/
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ net/bridge/br_multicast.c | 42 +++++++--------------------------------
+ net/bridge/br_private.h   |  4 +---
+ 2 files changed, 8 insertions(+), 38 deletions(-)
+
+diff --git a/net/bridge/br_multicast.c b/net/bridge/br_multicast.c
+index 994dacaaab7e..8fcd8faf99f3 100644
+--- a/net/bridge/br_multicast.c
++++ b/net/bridge/br_multicast.c
+@@ -1761,10 +1761,6 @@ static void br_ip6_multicast_querier_expired(struct timer_list *t)
+ }
+ #endif
+ 
+-static void br_multicast_query_delay_expired(struct timer_list *t)
+-{
+-}
+-
+ static void br_multicast_select_own_querier(struct net_bridge_mcast *brmctx,
+ 					    struct br_ip *ip,
+ 					    struct sk_buff *skb)
+@@ -3197,12 +3193,8 @@ int br_multicast_dump_querier_state(struct sk_buff *skb,
+ 
+ static void
+ br_multicast_update_query_timer(struct net_bridge_mcast *brmctx,
+-				struct bridge_mcast_other_query *query,
+-				unsigned long max_delay)
++				struct bridge_mcast_other_query *query)
+ {
+-	if (!timer_pending(&query->timer))
+-		mod_timer(&query->delay_timer, jiffies + max_delay);
+-
+ 	mod_timer(&query->timer, jiffies + brmctx->multicast_querier_interval);
+ }
+ 
+@@ -3393,13 +3385,12 @@ static void
+ br_ip4_multicast_query_received(struct net_bridge_mcast *brmctx,
+ 				struct net_bridge_mcast_port *pmctx,
+ 				struct bridge_mcast_other_query *query,
+-				struct br_ip *saddr,
+-				unsigned long max_delay)
++				struct br_ip *saddr)
+ {
+ 	if (!br_multicast_select_querier(brmctx, pmctx, saddr))
+ 		return;
+ 
+-	br_multicast_update_query_timer(brmctx, query, max_delay);
++	br_multicast_update_query_timer(brmctx, query);
+ 	br_ip4_multicast_mark_router(brmctx, pmctx);
+ }
+ 
+@@ -3408,13 +3399,12 @@ static void
+ br_ip6_multicast_query_received(struct net_bridge_mcast *brmctx,
+ 				struct net_bridge_mcast_port *pmctx,
+ 				struct bridge_mcast_other_query *query,
+-				struct br_ip *saddr,
+-				unsigned long max_delay)
++				struct br_ip *saddr)
+ {
+ 	if (!br_multicast_select_querier(brmctx, pmctx, saddr))
+ 		return;
+ 
+-	br_multicast_update_query_timer(brmctx, query, max_delay);
++	br_multicast_update_query_timer(brmctx, query);
+ 	br_ip6_multicast_mark_router(brmctx, pmctx);
+ }
+ #endif
+@@ -3468,7 +3458,7 @@ static void br_ip4_multicast_query(struct net_bridge_mcast *brmctx,
+ 
+ 		br_ip4_multicast_query_received(brmctx, pmctx,
+ 						&brmctx->ip4_other_query,
+-						&saddr, max_delay);
++						&saddr);
+ 		goto out;
+ 	}
+ 
+@@ -3556,7 +3546,7 @@ static int br_ip6_multicast_query(struct net_bridge_mcast *brmctx,
+ 
+ 		br_ip6_multicast_query_received(brmctx, pmctx,
+ 						&brmctx->ip6_other_query,
+-						&saddr, max_delay);
++						&saddr);
+ 		goto out;
+ 	} else if (!group) {
+ 		goto out;
+@@ -4064,8 +4054,6 @@ void br_multicast_ctx_init(struct net_bridge *br,
+ 		    br_ip4_multicast_local_router_expired, 0);
+ 	timer_setup(&brmctx->ip4_other_query.timer,
+ 		    br_ip4_multicast_querier_expired, 0);
+-	timer_setup(&brmctx->ip4_other_query.delay_timer,
+-		    br_multicast_query_delay_expired, 0);
+ 	timer_setup(&brmctx->ip4_own_query.timer,
+ 		    br_ip4_multicast_query_expired, 0);
+ #if IS_ENABLED(CONFIG_IPV6)
+@@ -4073,8 +4061,6 @@ void br_multicast_ctx_init(struct net_bridge *br,
+ 		    br_ip6_multicast_local_router_expired, 0);
+ 	timer_setup(&brmctx->ip6_other_query.timer,
+ 		    br_ip6_multicast_querier_expired, 0);
+-	timer_setup(&brmctx->ip6_other_query.delay_timer,
+-		    br_multicast_query_delay_expired, 0);
+ 	timer_setup(&brmctx->ip6_own_query.timer,
+ 		    br_ip6_multicast_query_expired, 0);
+ #endif
+@@ -4209,12 +4195,10 @@ static void __br_multicast_stop(struct net_bridge_mcast *brmctx)
+ {
+ 	del_timer_sync(&brmctx->ip4_mc_router_timer);
+ 	del_timer_sync(&brmctx->ip4_other_query.timer);
+-	del_timer_sync(&brmctx->ip4_other_query.delay_timer);
+ 	del_timer_sync(&brmctx->ip4_own_query.timer);
+ #if IS_ENABLED(CONFIG_IPV6)
+ 	del_timer_sync(&brmctx->ip6_mc_router_timer);
+ 	del_timer_sync(&brmctx->ip6_other_query.timer);
+-	del_timer_sync(&brmctx->ip6_other_query.delay_timer);
+ 	del_timer_sync(&brmctx->ip6_own_query.timer);
+ #endif
+ }
+@@ -4642,8 +4626,6 @@ EXPORT_SYMBOL_GPL(br_multicast_router);
+ 
+ int br_multicast_set_querier(struct net_bridge_mcast *brmctx, unsigned long val)
+ {
+-	unsigned long max_delay;
+-
+ 	val = !!val;
+ 
+ 	spin_lock_bh(&brmctx->br->multicast_lock);
+@@ -4654,19 +4636,9 @@ int br_multicast_set_querier(struct net_bridge_mcast *brmctx, unsigned long val)
+ 	if (!val)
+ 		goto unlock;
+ 
+-	max_delay = brmctx->multicast_query_response_interval;
+-
+-	if (!timer_pending(&brmctx->ip4_other_query.timer))
+-		mod_timer(&brmctx->ip4_other_query.delay_timer,
+-			  jiffies + max_delay);
+-
+ 	br_multicast_start_querier(brmctx, &brmctx->ip4_own_query);
+ 
+ #if IS_ENABLED(CONFIG_IPV6)
+-	if (!timer_pending(&brmctx->ip6_other_query.timer))
+-		mod_timer(&brmctx->ip6_other_query.delay_timer,
+-			  jiffies + max_delay);
+-
+ 	br_multicast_start_querier(brmctx, &brmctx->ip6_own_query);
+ #endif
+ 
+diff --git a/net/bridge/br_private.h b/net/bridge/br_private.h
+index eb68fd5e0b86..e7c3c36f3cb9 100644
+--- a/net/bridge/br_private.h
++++ b/net/bridge/br_private.h
+@@ -78,7 +78,6 @@ struct bridge_mcast_own_query {
+ /* other querier */
+ struct bridge_mcast_other_query {
+ 	struct timer_list		timer;
+-	struct timer_list		delay_timer;
+ };
+ 
+ /* selected querier */
+@@ -1153,8 +1152,7 @@ __br_multicast_querier_exists(struct net_bridge_mcast *brmctx,
+ 		own_querier_enabled = false;
+ 	}
+ 
+-	return !timer_pending(&querier->delay_timer) &&
+-	       (own_querier_enabled || timer_pending(&querier->timer));
++	return own_querier_enabled || timer_pending(&querier->timer);
+ }
+ 
+ static inline bool br_multicast_querier_exists(struct net_bridge_mcast *brmctx,
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description

This kernel patch drops the initial delay to switch from flooding to strict filtering.

The main reason for this patch is RFC conformance and customer expectations.  At power on we assume the querier role by default and are expected to stop unknown flooding as soon as we have a membership report in place, not after 10 seconds.

A proper fix for upstreaming could be to add a knob to disable the delay.

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [X] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

 - #334 
