### PR TITLE
yanger: Allow manufactering date to be day 1-9

### DIFF
--- a/src/statd/yanger
+++ b/src/statd/yanger
@@ -162,7 +162,7 @@ def get_vpd_data(vpd):
     if vpd.get("data"):
         component["class"] = "infix-hardware:vpd"
         if vpd["data"].get("manufacture-date"):
-            component["mfg-date"]=datetime.strptime(vpd["data"]["manufacture-date"],"%m/%d/%Y %H:%M:%S").strftime("%Y-%m-%-dT%H:%M:%SZ")
+            component["mfg-date"]=datetime.strptime(vpd["data"]["manufacture-date"],"%m/%d/%Y %H:%M:%S").strftime("%Y-%m-%dT%H:%M:%SZ")
         if vpd["data"].get("manufacter"):
             component["mfg-name"]=vpd["data"]["manufacturer"]
         if vpd["data"].get("product-name"):


### PR DESCRIPTION
When the day of month is 1-9 the format did not match the yang model

This fixes #377 
<!--- **Summarize** your changes in the title above -->

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->


## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
