### PR TITLE
Fix USXGMII Auto-negotiation Issue

### DIFF
--- a/board/aarch64/dts/alder/alder.dtsi
+++ b/board/aarch64/dts/alder/alder.dtsi
@@ -354,6 +354,7 @@
 #define XSWP(_n, _label, _mac_offs, _phy) \
 			port@_n { \
 				SWP_COMMON(_n, _label, _mac_offs, "usxgmii", _phy); \
+				managed = "in-band-status"; \
 			}
 
 #define GSWP(_n, _label, _mac_offs, _phy) \

--- a/patches/linux/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
+++ b/patches/linux/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
@@ -1,7 +1,7 @@
 From 79abf7872e35080ca5b519bb4ad2acc1fbd96e8c Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Thu, 25 Jan 2024 21:36:59 +0100
-Subject: [PATCH 01/24] net: phy: add support for PHY LEDs polarity modes
+Subject: [PATCH 01/25] net: phy: add support for PHY LEDs polarity modes
 Organization: Addiva Elektronik
 
 Add support for PHY LEDs polarity modes. Some PHY require LED to be set

--- a/patches/linux/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
+++ b/patches/linux/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
@@ -1,7 +1,7 @@
 From 424ddb5d5d8ce06c578cc08cbedf519c42dd8b69 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Mon, 4 Dec 2023 11:08:11 +0100
-Subject: [PATCH 02/24] net: mvmdio: Support setting the MDC frequency on XSMI
+Subject: [PATCH 02/25] net: mvmdio: Support setting the MDC frequency on XSMI
  controllers
 Organization: Addiva Elektronik
 

--- a/patches/linux/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
+++ b/patches/linux/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
@@ -1,7 +1,7 @@
 From 337cf21833cef6ab456a8562338de88ab1a84ead Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:23 +0100
-Subject: [PATCH 03/24] net: dsa: mv88e6xxx: Create API to read a single stat
+Subject: [PATCH 03/25] net: dsa: mv88e6xxx: Create API to read a single stat
  counter
 Organization: Addiva Elektronik
 

--- a/patches/linux/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
+++ b/patches/linux/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
@@ -1,7 +1,7 @@
 From dbdbfd57998b4f8224146ac94cd5d0a577326087 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:25 +0100
-Subject: [PATCH 04/24] net: dsa: mv88e6xxx: Give each hw stat an ID
+Subject: [PATCH 04/25] net: dsa: mv88e6xxx: Give each hw stat an ID
 Organization: Addiva Elektronik
 
 With the upcoming standard counter group support, we are no longer

--- a/patches/linux/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
+++ b/patches/linux/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
@@ -1,7 +1,7 @@
 From 26815572016d9851ec6362f23746035fb933acf3 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:26 +0100
-Subject: [PATCH 05/24] net: dsa: mv88e6xxx: Add "eth-mac" counter group
+Subject: [PATCH 05/25] net: dsa: mv88e6xxx: Add "eth-mac" counter group
  support
 Organization: Addiva Elektronik
 

--- a/patches/linux/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
+++ b/patches/linux/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
@@ -1,7 +1,7 @@
 From cc5badac76e76692eb516a5c086fcf54a5a93080 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:27 +0100
-Subject: [PATCH 06/24] net: dsa: mv88e6xxx: Limit histogram counters to
+Subject: [PATCH 06/25] net: dsa: mv88e6xxx: Limit histogram counters to
  ingress traffic
 Organization: Addiva Elektronik
 

--- a/patches/linux/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
+++ b/patches/linux/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
@@ -1,7 +1,7 @@
 From 35ecc84237bfccbe5b93c0aef6c07cc506d43070 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:28 +0100
-Subject: [PATCH 07/24] net: dsa: mv88e6xxx: Add "rmon" counter group support
+Subject: [PATCH 07/25] net: dsa: mv88e6xxx: Add "rmon" counter group support
 Organization: Addiva Elektronik
 
 Report the applicable subset of an mv88e6xxx port's counters using

--- a/patches/linux/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
+++ b/patches/linux/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
@@ -1,7 +1,7 @@
 From 7750d0a5bfae46ab783e8e7087b70175860f808c Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 19:44:32 +0100
-Subject: [PATCH 09/24] net: dsa: mv88e6xxx: Add LED infrastructure
+Subject: [PATCH 09/25] net: dsa: mv88e6xxx: Add LED infrastructure
 Organization: Addiva Elektronik
 
 Parse DT for LEDs and register them for devices that support it,

--- a/patches/linux/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
+++ b/patches/linux/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
@@ -1,7 +1,7 @@
 From 63fcd626fdb108d2ac07cb0aa16b91fc43894bff Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 21:59:35 +0100
-Subject: [PATCH 10/24] net: dsa: mv88e6xxx: Add LED support for 6393X
+Subject: [PATCH 10/25] net: dsa: mv88e6xxx: Add LED support for 6393X
 Organization: Addiva Elektronik
 
 Trigger support:

--- a/patches/linux/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
+++ b/patches/linux/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
@@ -1,7 +1,7 @@
 From 0bc6f19d18d7c0e374c824bcc86433b04210a378 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Mar 2024 10:27:24 +0100
-Subject: [PATCH 11/24] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
+Subject: [PATCH 11/25] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
  6393X
 Organization: Addiva Elektronik
 

--- a/patches/linux/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
+++ b/patches/linux/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
@@ -1,7 +1,7 @@
 From fe60e3ad1e3b43a924c311658b15a1106e813661 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 16 Jan 2024 16:00:55 +0100
-Subject: [PATCH 12/24] net: dsa: Support MDB memberships whose L2 addresses
+Subject: [PATCH 12/25] net: dsa: Support MDB memberships whose L2 addresses
  overlap
 Organization: Addiva Elektronik
 

--- a/patches/linux/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
+++ b/patches/linux/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
@@ -1,7 +1,7 @@
 From 5f5bf4a50e98c5aff05fe85994a981253ae85987 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 19 Sep 2023 18:38:10 +0200
-Subject: [PATCH 13/24] net: phy: marvell10g: Support firmware loading on
+Subject: [PATCH 13/25] net: phy: marvell10g: Support firmware loading on
  88X3310
 Organization: Addiva Elektronik
 

--- a/patches/linux/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
+++ b/patches/linux/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
@@ -1,7 +1,7 @@
 From 27d5241d3ddf70d65af5f4dd029f99f0fea866a5 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 21 Nov 2023 20:15:24 +0100
-Subject: [PATCH 14/24] net: phy: marvell10g: Fix power-up when strapped to
+Subject: [PATCH 14/25] net: phy: marvell10g: Fix power-up when strapped to
  start powered down
 Organization: Addiva Elektronik
 

--- a/patches/linux/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
+++ b/patches/linux/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
@@ -1,7 +1,7 @@
 From e389ee690ce56ef20863aeabdf389bed842d7f42 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 15 Nov 2023 20:58:42 +0100
-Subject: [PATCH 15/24] net: phy: marvell10g: Add LED support for 88X3310
+Subject: [PATCH 15/25] net: phy: marvell10g: Add LED support for 88X3310
 Organization: Addiva Elektronik
 
 Pickup the LEDs from the state in which the hardware reset or

--- a/patches/linux/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
+++ b/patches/linux/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
@@ -1,7 +1,7 @@
 From 3113b64290b5b7b20c294535c12ea4c732a02f51 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Dec 2023 09:51:05 +0100
-Subject: [PATCH 16/24] net: phy: marvell10g: Support LEDs tied to a single
+Subject: [PATCH 16/25] net: phy: marvell10g: Support LEDs tied to a single
  media side
 Organization: Addiva Elektronik
 

--- a/patches/linux/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
+++ b/patches/linux/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
@@ -1,7 +1,7 @@
 From 2570c2350d3d614a31e14dd87d0e99e8fcb5096b Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 24 Nov 2023 23:29:55 +0100
-Subject: [PATCH 17/24] nvmem: layouts: onie-tlv: Let device probe even when
+Subject: [PATCH 17/25] nvmem: layouts: onie-tlv: Let device probe even when
  TLV is invalid
 Organization: Addiva Elektronik
 

--- a/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
+++ b/patches/linux/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
@@ -1,7 +1,7 @@
 From 681ce95c15bff94ac83eb26db3c718594f8dfa16 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Mon, 4 Mar 2024 16:47:28 +0100
-Subject: [PATCH 18/24] net: bridge: avoid classifying unknown multicast as
+Subject: [PATCH 18/25] net: bridge: avoid classifying unknown multicast as
  mrouters_only
 Organization: Addiva Elektronik
 

--- a/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
+++ b/patches/linux/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
@@ -1,7 +1,7 @@
 From 2482848726a5b8185a04d90891693a1713f894b5 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Tue, 5 Mar 2024 06:44:41 +0100
-Subject: [PATCH 19/24] net: bridge: Ignore router ports when forwarding L2
+Subject: [PATCH 19/25] net: bridge: Ignore router ports when forwarding L2
  multicast
 Organization: Addiva Elektronik
 

--- a/patches/linux/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
+++ b/patches/linux/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
@@ -1,7 +1,7 @@
 From 25efcdb13ae720ee662f4b6091b270e48ac4d375 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 21 Mar 2024 19:12:15 +0100
-Subject: [PATCH 20/24] net: dsa: Support EtherType based priority overrides
+Subject: [PATCH 20/25] net: dsa: Support EtherType based priority overrides
 Organization: Addiva Elektronik
 
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>

--- a/patches/linux/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
+++ b/patches/linux/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
@@ -1,7 +1,7 @@
 From 213e9a1d9145723897fbba40fc4afc5b5f70c1de Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 22 Mar 2024 16:15:43 +0100
-Subject: [PATCH 21/24] net: dsa: mv88e6xxx: Support EtherType based priority
+Subject: [PATCH 21/25] net: dsa: mv88e6xxx: Support EtherType based priority
  overrides
 Organization: Addiva Elektronik
 

--- a/patches/linux/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
+++ b/patches/linux/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
@@ -1,7 +1,7 @@
 From 1c1c81864c9803831c2d5b7df0d7da28e566f3b2 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 27 Mar 2024 10:10:19 +0100
-Subject: [PATCH 22/24] net: phy: Do not resume PHY when attaching
+Subject: [PATCH 22/25] net: phy: Do not resume PHY when attaching
 Organization: Addiva Elektronik
 
 The PHY should not start negotiating with its link-partner until

--- a/patches/linux/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
+++ b/patches/linux/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
@@ -1,7 +1,7 @@
 From b53e5007cd5be42eb5d9a510d63f89c7c6edd9b6 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 27 Mar 2024 15:52:43 +0100
-Subject: [PATCH 23/24] net: dsa: mv88e6xxx: Improve indirect register access
+Subject: [PATCH 23/25] net: dsa: mv88e6xxx: Improve indirect register access
  perf on 6393
 Organization: Addiva Elektronik
 

--- a/patches/linux/0024-net-bridge-drop-delay-for-applying-strict-multicast-.patch
+++ b/patches/linux/0024-net-bridge-drop-delay-for-applying-strict-multicast-.patch
@@ -1,7 +1,7 @@
 From f53652205b1c044fa00f896d6422c82ac808f16a Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Thu, 4 Apr 2024 16:36:30 +0200
-Subject: [PATCH 24/24] net: bridge: drop delay for applying strict multicast
+Subject: [PATCH 24/25] net: bridge: drop delay for applying strict multicast
  filtering
 Organization: Addiva Elektronik
 
@@ -19,6 +19,7 @@ A proper fix for upstreaming could be to add a knob to disable the delay.
 [2]: https://lore.kernel.org/netdev/20240127175033.9640-1-linus.luessing@c0d3.blue/
 
 Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 ---
  net/bridge/br_multicast.c | 42 +++++++--------------------------------
  net/bridge/br_private.h   |  4 +---

--- a/patches/linux/0025-net-dsa-mv88e6xxx-Honor-ports-being-managed-via-in-b.patch
+++ b/patches/linux/0025-net-dsa-mv88e6xxx-Honor-ports-being-managed-via-in-b.patch
@@ -1,0 +1,48 @@
+From 56208d4cba23496c09f69961a32b1b9662f06aef Mon Sep 17 00:00:00 2001
+From: Tobias Waldekranz <tobias@waldekranz.com>
+Date: Mon, 22 Apr 2024 23:18:01 +0200
+Subject: [PATCH 25/25] net: dsa: mv88e6xxx: Honor ports being managed via
+ in-band-status
+Organization: Addiva Elektronik
+
+Keep all link parameters in their unforced states when the port is
+declared as being managed via in-band-status, and let the MAC
+configure itself, via whatever method is being used (e.g. SGMII or
+USXGMII autoneg)
+
+This state is the default set up by mv88e6xxx_port_setup_mac(), so all
+we have to do is to make the phylink MAC callbacks no-ops in cases
+when in-band-status is being used.
+
+Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/net/dsa/mv88e6xxx/chip.c b/drivers/net/dsa/mv88e6xxx/chip.c
+index 76bb8b492ca9..29691280cff4 100644
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -885,6 +885,9 @@ static void mv88e6xxx_mac_link_down(struct dsa_switch *ds, int port,
+ 	const struct mv88e6xxx_ops *ops;
+ 	int err = 0;
+ 
++	if (mode == MLO_AN_INBAND)
++		return;
++
+ 	ops = chip->info->ops;
+ 
+ 	mv88e6xxx_reg_lock(chip);
+@@ -915,6 +918,9 @@ static void mv88e6xxx_mac_link_up(struct dsa_switch *ds, int port,
+ 	const struct mv88e6xxx_ops *ops;
+ 	int err = 0;
+ 
++	if (mode == MLO_AN_INBAND)
++		return;
++
+ 	ops = chip->info->ops;
+ 
+ 	mv88e6xxx_reg_lock(chip);
+-- 
+2.34.1
+


### PR DESCRIPTION
<!--- **Summarize** your changes in the title above -->

## Description

Even when `managed = "in-band-status";` was specified on a port,
mv88e6xxx would insist on forcing the values that were supposed to be
automatically picked up by the MAC via in-band signaling.

In the case of USXGMII links on 6393X, forcing the link bit would
sometimes, for reasons that are not understood, cause the SERDES to
reset its USXGMII link partner base page (register 4.0xf0a2) to 0,
which it would then interpret as 10M/half-duplex. As a result, the
SERDES would erroneously perform rate-matching to 10M on egress
towards the PHY (which is configured for 10G/full-duplex), leading to
nothing but dropped packets and much sadness.

This can most easily be reproduced by the following setup:

```
.------------.
|        .-----.   .-------.
|        | p9  +---+ 3310P +--.
| 6393X  :-----:   :-------:  | T- or X-Units looped via external cable
|        | p10 +---+ 3310P +--'
|        '-----'   '-------'
'------------'
```
Make sure that neither p9 nor p10 are managed using in-band-status.

1. ip link set dev p9 up; ip link set dev p10 up
2. ip link set dev p9 down
3. ip link set dev p9 up

After step (3), p10 will experience the failure described above in
about 3/4 of the cases. In the cases where the issue does not arise,
simply repeat steps (2) and (3).

## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
