### PR TITLE
Run tests using bootloader (grub)

### DIFF
--- a/board/common/qemu/Config.in.in
+++ b/board/common/qemu/Config.in.in
@@ -54,11 +54,10 @@ choice
 
 config QEMU_CONSOLE_VIRTIO
      bool "Virtio (hvc0)"
-     depends on QEMU_LOADER_KERNEL
 
 config QEMU_CONSOLE_SERIAL
      bool "Serial (ttyS0/ttyAMA0)"
-
+     depends on !QEMU_LOADER_OVMF
 endchoice
 
 config QEMU_MACHINE

--- a/board/common/qemu/qemu.sh
+++ b/board/common/qemu/qemu.sh
@@ -117,7 +117,7 @@ rootfs_args()
 	echo -n "-device sd-card,drive=mmc "
 	echo -n "-drive id=mmc,file=$CONFIG_QEMU_ROOTFS,if=none,format=raw "
     elif [ "$CONFIG_QEMU_ROOTFS_VSCSI" = "y" ]; then
-	echo -n "-drive file=$CONFIG_QEMU_ROOTFS,if=virtio,format=raw,bus=0,unit=0 "
+	echo -n "-drive file=$CONFIG_QEMU_ROOTFS.qcow2,if=virtio,format=qcow2,bus=0,unit=0 "
     fi
 }
 
@@ -148,14 +148,14 @@ usb_args()
 	dd if=/dev/zero of=${USBSTICK} bs=8M count=1 >/dev/null 2>&1
 	mkfs.vfat $USBSTICK >/dev/null 2>&1
     fi
-    echo -n "-drive if=none,id=usbstick,format=raw,file=${USBSTICK} "
+    echo -n "-drive if=none,id=usbstick,format=raw,file=$USBSTICK "
     echo -n "-usb "
     echo -n "-device usb-ehci,id=ehci "
     echo -n "-device usb-storage,bus=ehci.0,drive=usbstick "
 }
 rw_args()
 {
-    [ "$CONFIG_QEMU_RW" ] || return
+    [ "$CONFIG_QEMU_RW" ] ||  return
 
     if ! [ -f "$CONFIG_QEMU_RW" ]; then
 	dd if=/dev/zero of="$CONFIG_QEMU_RW" bs=16M count=1 >/dev/null 2>&1
@@ -251,6 +251,9 @@ wdt_args()
 
 run_qemu()
 {
+    if [ "$CONFIG_QEMU_ROOTFS_VSCSI" = "y" ]; then
+	 qemu-img create -f qcow2 -o backing_file=$CONFIG_QEMU_ROOTFS -F raw $CONFIG_QEMU_ROOTFS.qcow2 > /dev/null
+    fi
     local qemu
     read qemu <<EOF
 	$CONFIG_QEMU_MACHINE -m $CONFIG_QEMU_MACHINE_RAM \

--- a/board/x86_64/board.mk
+++ b/board/x86_64/board.mk
@@ -3,7 +3,9 @@ INFIX_TESTS ?= $(test-dir)/case/all.yaml
 
 test-env = $(test-dir)/env \
 	-f $(BINARIES_DIR)/infix-x86_64.img \
-	-p $(BINARIES_DIR)/infix-x86_64.pkg \
+	-f $(BINARIES_DIR)/infix-x86_64-disk.img \
+	-f $(BINARIES_DIR)/OVMF.fd \
+        -p $(BINARIES_DIR)/infix-x86_64.pkg \
 	$(1) $(2)
 
 test-env-qeneth = $(call test-env,-q $(test-dir)/virt/quad,$(1))

--- a/board/x86_64/grub.cfg
+++ b/board/x86_64/grub.cfg
@@ -42,14 +42,14 @@ export secondary
 
 submenu "primary" "$log" {
     set slot="$1"
-    set append="console=ttyS0 root=PARTLABEL=$slot $2"
+    set append="console=hvc0 root=PARTLABEL=$slot $2"
     set root="($primary)"
     source /boot/grub/grub.cfg
 }
 
 submenu "secondary" "$log"  {
     set slot="$1"
-    set append="console=ttyS0 root=PARTLABEL=$slot $2"
+    set append="console=hvc0 root=PARTLABEL=$slot $2"
     set root="($secondary)"
     source /boot/grub/grub.cfg
 }
@@ -63,7 +63,7 @@ submenu "net" "$log"  {
 	set root=(initrd)
 
 	set slot="$1"
-	set append="console=ttyS0 root=/dev/ram0 ramdisk_size=65536 $2"
+	set append="console=hvc0 root=/dev/ram0 ramdisk_size=65536 $2"
 	source /boot/grub/grub.cfg
     else
 	if [ -z "$net_efinet0_dhcp_next_server" ]; then

--- a/test/env
+++ b/test/env
@@ -7,7 +7,7 @@ testdir=$(dirname "$(readlink -f "$0")")
 usage()
 {
     cat <<EOF
-usage: test/env [<OPTS>]    -f <IMAGE> -q <QENETH-DIR> <COMMAND> [<ARGS>...]
+usage: test/env [<OPTS>] -f <IMAGE> -q <QENETH-DIR> <COMMAND> [<ARGS>...]
        test/env [<OPTS>] -C -t <TOPOLOGY>   <COMMAND> [<ARGS>...]
 
   Run <COMMAND> in a pre-packaged container with all the packages
@@ -24,8 +24,9 @@ usage: test/env [<OPTS>]    -f <IMAGE> -q <QENETH-DIR> <COMMAND> [<ARGS>...]
       namespaces
 
     -f <IMAGE>
-      Infix image to test. When starting a qeneth network, this image is
-      used on all nodes.
+       Specify images required for test, squashfs image is required
+       if testing with kernel. bios and disk image is required if
+       testing with bios.
 
     -h
       Show this help message
@@ -54,18 +55,19 @@ EOF
 start_topology()
 {
     qenethdir="$1"
-    imgfile="$2"
+    files="$*"
 
+    [ "$files" ] || { true && return; }
     [ "$qenethdir" ] || { true && return; }
 
     rm -rf "$envdir/qeneth"
     cp -a "$qenethdir" "$envdir/qeneth"
-    if [ "$imgfile" ]; then
-	imgname="$(basename "$imgfile")"
-	imgfile=$(readlink -f "$imgfile")
-
-	ln -sf "$imgfile" "$envdir/qeneth/$imgname"
-    fi
+    # Map files in to qeneth
+    for f in $files; do
+	filename="$(basename "$f")"
+	file=$(readlink -f "$f")
+	ln -sf "$file" "$envdir/qeneth/$filename"
+    done
 
     (cd "$envdir/qeneth/" && $qeneth generate && $qeneth start)
     INFAMY_ARGS="$INFAMY_ARGS $envdir/qeneth/topology.dot"
@@ -107,6 +109,7 @@ name()
 # Global options
 containerize=yes
 [ -c /dev/kvm ] && kvm="--device=/dev/kvm"
+files=
 
 while getopts "cCf:hiKp:q:t:" opt; do
     case ${opt} in
@@ -120,7 +123,7 @@ while getopts "cCf:hiKp:q:t:" opt; do
 	    containerize=
 	    ;;
 	f)
-	    imgfile="$OPTARG"
+	    files="$files $OPTARG"
 	    ;;
 	h)
 	    usage && exit 0
@@ -190,7 +193,7 @@ fi
 . "$envdir/bin/activate"
 export PYTHONPATH="$testdir"
 INFAMY_ARGS="$INFAMY_ARGS -y $envdir/yangdir"
-start_topology "$qenethdir" "$imgfile"
+start_topology "$qenethdir" "$files"
 [ "$topology" ] && INFAMY_ARGS="$INFAMY_ARGS $topology"
 export INFAMY_ARGS
 

--- a/test/virt/quad/topology.dot.in
+++ b/test/virt/quad/topology.dot.in
@@ -7,7 +7,7 @@ graph "quad" {
         node [shape=record, fontname="monospace"];
 	edge [color="cornflowerblue", penwidth="2"];
 
-	qn_template="infix-x86_64";
+	qn_template="infix-bios-x86_64";
 	qn_append="quiet";
 
         host [


### PR DESCRIPTION
*  Stop testing on raw images, create qcow2 instead
*  Use same console for Qemu and make test-sh (hvc0)
*  Change so the tests by default now use BIOS boot, 
    this can be changed by change in the topology 
    to use infix-kernel-x86_64 template instead of infix-bios-x86_64
## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->


## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
