### PR TITLE
Fixes for kernel logging to console, and more ...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build Infix ${{ matrix.platform }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       matrix:
         platform: [aarch64, x86_64]
@@ -27,11 +27,6 @@ jobs:
           target=${{ matrix.platform }}
           echo "dir=infix-$target"        >> $GITHUB_OUTPUT
           echo "tgz=infix-$target.tar.gz" >> $GITHUB_OUTPUT
-          if [ "$target" = x86_64 ]; then
-              echo "out=$PWD/output"      >> $GITHUB_OUTPUT
-          else
-              echo "out=/mnt/x-$target"   >> $GITHUB_OUTPUT
-          fi
       - name: Restore Cache of dl/
         uses: actions/cache@v4
         with:
@@ -51,31 +46,27 @@ jobs:
         run: |
           target=${{ matrix.platform }}_defconfig
           echo "Building $target ..."
-          sudo mkdir ${{ steps.vars.outputs.out }}
-          sudo chown $(id -un):$(id -gn) ${{ steps.vars.outputs.out }}
-          export O=${{ steps.vars.outputs.out }}
           make $target
           make
       - name: Prepare Artifact
         run: |
-          cd ${{ steps.vars.outputs.out }}
+          cd output/
           mv images ${{ steps.vars.outputs.dir }}
           ln -s ${{ steps.vars.outputs.dir }} images
           tar chfz ${{ steps.vars.outputs.tgz }} ${{ steps.vars.outputs.dir }}
       - name: Test
         if: matrix.platform == 'x86_64'
         run: |
-          export O=${{ steps.vars.outputs.out }}
-          make test-qeneth
+          make test
       - uses: actions/upload-artifact@v4
         with:
-          path: ${{ steps.vars.outputs.out }}/${{ steps.vars.outputs.tgz }}
+          path: output/${{ steps.vars.outputs.tgz }}
           name: artifact-${{ matrix.platform }}
   release:
     if: ${{github.repository_owner == 'kernelkit' && github.ref_name == 'main'}}
     name: Upload Latest Build
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
     steps:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   coverity:
     if: ${{github.repository_owner == 'kernelkit'}}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: Fetch latest Coverity Scan MD5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     if: github.repository == 'kernelkit/infix' && startsWith(github.ref, 'refs/tags/')
     name: Build Infix ${{ github.ref_name }} [${{ matrix.platform }}]
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       matrix:
         platform: [aarch64, x86_64]
@@ -92,7 +92,7 @@ jobs:
   release:
     name: Release Infix ${{ github.ref_name }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
     steps:

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -76,6 +76,9 @@ separate project.  Going forward Infix' focus is entirely on NETCONF.
   (firewalled and NAT:ed, hidden from the rest of the network)
 - Fix #385: segfault in helper function when disabling the DHCP client
   using `no dhcp-client` from the CLI
+- Fix #406: an overly restrictive `when` expression in the bridge YANG
+  model prevented users from adding VLAN interfaces as bridge ports.
+  E.g., creating interface `eth0.10` and adding that to `br0`
 
 
 [v24.02.0][] - 2024-03-01

--- a/package/execd/execd.mk
+++ b/package/execd/execd.mk
@@ -22,7 +22,7 @@ EXECD_CONF_OPTS = --prefix= --disable-silent-rules
 define EXECD_INSTALL_EXTRA
 	cp $(EXECD_PKGDIR)/execd.conf  $(FINIT_D)/available/
 	ln -sf ../available/execd.conf $(FINIT_D)/enabled/execd.conf
-	cp $(EXECD_PKGDIR)/tmpfiles.conf $(TARGET_DIR)/etc/tmpfiles.d/execd.conf
+	cp $(EXECD_PKGDIR)/tmpfiles.conf $(TARGET_DIR)/lib/tmpfiles.d/execd.conf
 endef
 EXECD_TARGET_FINALIZE_HOOKS += EXECD_INSTALL_EXTRA
 

--- a/package/finit/0010-Fix-405-parsing-1-active-consoles-in-tty-console-set.patch
+++ b/package/finit/0010-Fix-405-parsing-1-active-consoles-in-tty-console-set.patch
@@ -1,0 +1,117 @@
+From 6a89e60fc84b90e5f09f61d37892f3b17bd14631 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Wed, 24 Apr 2024 11:33:35 +0200
+Subject: [PATCH 10/11] Fix #405: parsing >1 active consoles in tty @console
+ setups
+Organization: Addiva Elektronik
+
+Systems that have the following tty setup and multiple consoles listed
+in /sys/class/tty/console/active misbehave:
+
+    tty [12345789] @console 0 xterm noclear passenv
+
+Only the first listed console is started properly, the remaining ones
+were registered using the wrong :ID and no arguments to getty.
+
+This patch fixes the parsing and re-use of the base paramenters for
+all consoles listed in the active file.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/service.c | 45 +++++++++++++++++++++++----------------------
+ 1 file changed, 23 insertions(+), 22 deletions(-)
+
+diff --git a/src/service.c b/src/service.c
+index eca9ed0..95a04b8 100644
+--- a/src/service.c
++++ b/src/service.c
+@@ -1633,10 +1633,16 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
+ 
+ 	if (type == SVC_TYPE_TTY) {
+ 		size_t i, len = 0;
++		char *ptr;
+ 
+ 		if (tty_parse_args(&tty, cmd, &args))
+ 			return errno;
+ 
++		if (tty_isatcon(tty.dev))
++			dev = tty_atcon();
++		else
++			dev = tty.dev;
++	next:
+ 		if (tty.cmd)
+ 			len += strlen(tty.cmd);
+ 		else
+@@ -1659,14 +1665,22 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
+ 		if (!cmd)
+ 			return errno;
+ 
+-		if (tty_isatcon(tty.dev))
+-			dev = tty_atcon();
+-		else
+-			dev = tty.dev;
+-
+ 		/* tty's always respawn, never incr. restart_cnt */
+ 		respawn = 1;
+-	next:
++
++		/* Create name:id tuple for identity, e.g., tty:S0 */
++		ptr = strrchr(dev, '/');
++		if (ptr)
++			ptr++;
++		else
++			ptr = dev;
++		if (!strncmp(ptr, "tty", 3))
++			ptr += 3;
++
++		name = "tty";
++		if (!id || id[0] == 0)
++			id = ptr;
++
+ 		svc = svc_find_by_tty(dev);
+ 	} else
+ 		svc = svc_find(name, id);
+@@ -1722,8 +1736,6 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
+ 	conf_parse_cond(svc, cond);
+ 
+ 	if (type == SVC_TYPE_TTY) {
+-		char *ptr;
+-
+ 		if (dev)
+ 			strlcpy(svc->dev, dev, sizeof(svc->dev));
+ 		if (tty.baud)
+@@ -1738,19 +1750,6 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
+ 
+ 		/* TTYs cannot be redirected */
+ 		log = NULL;
+-
+-		/* Create name:id tuple for identity, e.g., tty:S0 */
+-		ptr = strrchr(svc->dev, '/');
+-		if (ptr)
+-			ptr++;
+-		else
+-			ptr = svc->dev;
+-		if (!strncmp(ptr, "tty", 3))
+-			ptr += 3;
+-		if (!id || id[0] == 0)
+-			id = ptr;
+-		strlcpy(svc->name, "tty", sizeof(svc->name));
+-		strlcpy(svc->id, id, sizeof(svc->id));
+ 	}
+ 
+ 	parse_cmdline_args(svc, cmd, &args);
+@@ -1870,8 +1869,10 @@ int service_register(int type, char *cfg, struct rlimit rlimit[], char *file)
+ 	/* continue expanding any 'tty @console ...' */
+ 	if (tty_isatcon(tty.dev)) {
+ 		dev = tty_atcon();
+-		if (dev)
++		if (dev) {
++			id = NULL; /* reset for next tty:ID */
+ 			goto next;
++		}
+ 	}
+ 
+ 	return 0;
+-- 
+2.34.1
+

--- a/package/finit/0011-Change-default-behavior-allow-kernel-logs-to-console.patch
+++ b/package/finit/0011-Change-default-behavior-allow-kernel-logs-to-console.patch
@@ -1,0 +1,89 @@
+From 340cae4afd0d11979322a6c2f4d40a12ea59817b Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Wed, 24 Apr 2024 12:46:59 +0200
+Subject: [PATCH 11/11] Change default behavior, allow kernel logs to console
+Organization: Addiva Elektronik
+
+A Linux system booted with the kernel command line option 'quiet' only
+logs error (and above) severity messages to the console.  For embedded
+systems, which is the primary target for Finit, this is what you want
+to see.
+
+Hence, and after careful consideration, this patch changes the default
+behavior of Finit to allow kernel logs to the console.  A build-time
+configure flags, --disable-kernel-logging, has been added to restore
+legacy behavior.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ configure.ac |  9 +++++++++
+ src/finit.c  | 14 +++++++++++---
+ 2 files changed, 20 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index a4470d0..31f4cff 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -71,6 +71,10 @@ AC_ARG_ENABLE(redirect,
+         AS_HELP_STRING([--disable-redirect], [Disable redirection of service output to /dev/null]),,[
+ 	enable_redirect=yes])
+ 
++AC_ARG_ENABLE(kernel_logging,
++        AS_HELP_STRING([--disable-kernel-logging], [Disable kernel logging to console (use 'quiet' instead!]),,[
++	enable_kernel_logging=yes])
++
+ AC_ARG_ENABLE(logrotate,
+         AS_HELP_STRING([--disable-logrotate], [Disable built-in rotation of /var/log/wtmp]),,[
+ 	enable_logrotate=yes])
+@@ -181,6 +185,9 @@ AS_IF([test "x$enable_auto_reload" = "xyes"], [
+ AS_IF([test "x$enable_kernel_cmdline" = "xyes"], [
+         AC_DEFINE(KERNEL_CMDLINE, 1, [Dumpster diving after init args from /proc/cmdline])])
+ 
++AS_IF([test "x$enable_kernel_logging" = "xyes"], [
++        AC_DEFINE(KERNEL_LOGGING, 1, [Keep kernel warn/err logs to console])])
++
+ AS_IF([test "x$enable_fastboot" = "xyes"], [
+ 	AC_DEFINE(FAST_BOOT, 1, [Skip fsck check on filesystems listed in /etc/fstab])])
+ 
+@@ -382,6 +389,8 @@ Optional features:
+   Built-in sulogin......: $with_sulogin $sulogin
+   Built-in watchdogd....: $with_watchdog $watchdog
+   Built-in logrotate....: $enable_logrotate
++  Parse kernel cmdline..: $enable_kernel_cmdline
++  Keep kernel logging...: $enable_kernel_logging
+   Skip fsck check.......: $enable_fastboot
+   Run fsck fix mode.....: $enable_fsckfix
+   Redirect output.......: $enable_redirect
+diff --git a/src/finit.c b/src/finit.c
+index 27b81e9..38b1278 100644
+--- a/src/finit.c
++++ b/src/finit.c
+@@ -87,14 +87,22 @@ svc_t *wdog     = NULL;		/* No watchdog by default */
+  */
+ static void banner(void)
+ {
++#ifndef KERNEL_LOGGING
+ 	/*
+ 	 * Silence kernel logs, assuming users have sysklogd or
+-	 * similar enabled to start emptying /dev/kmsg, but for
+-	 * our progress we want to own the console.
++	 * similar enabled to start emptying /dev/kmsg.
++	 *
++	 * Instead of using `configure --disable-kernel-logging`, we
++	 * recommend adjusting the kernel log level in the kernel's
++	 * menuconfig, or using sysctl kernel.printk, or setting the
++	 * desired log level, on the kernel cmdline, e.g. 'quiet'.
++	 *
++	 * By default KERNEL_LOGGING is enabled so you can see any
++	 * warnings/errors or higher on your system console.
+ 	 */
+ 	if (!debug && !kerndebug)
+ 		klogctl(6, NULL, 0);
+-
++#endif
+ 	/*
+ 	 * First level hooks, if you want to run here, you're
+ 	 * pretty much on your own.  Nothing's up yet ...
+-- 
+2.34.1
+

--- a/package/finit/Config.in
+++ b/package/finit/Config.in
@@ -51,6 +51,17 @@ config BR2_PACKAGE_FINIT_INITCTL_GROUP
 	  to their shared UNIX group, usually "wheel", to allow
 	  them to start/stop services and reboot the system.
 
+config BR2_PACKAGE_FINIT_SILENCE_KERNEL
+	bool "Silence kernel logs to console"
+	default n
+	help
+	  By default, Finit >= 4.8 no longer disable kernel logging
+	  to console.  This option can be used to re-enable legacy
+	  klogctl() code to silence the kernel output.
+
+	  Please note, sysklogd has a similar command line option to
+	  keep kernel logging, which needs to be disabled as well.
+
 config BR2_PACKAGE_FINIT_KEVENTD
 	bool "finit-keventd"
 	default n

--- a/package/finit/finit.mk
+++ b/package/finit/finit.mk
@@ -42,6 +42,12 @@ FINIT_CONF_OPTS += --without-fstab
 endif
 endif
 
+ifeq ($(BR2_PACKAGE_FINIT_SILENCE_KERNEL),y)
+FINIT_CONF_OPTS += --disable-kernel-logging
+else
+FINIT_CONF_OPTS += --enable-kernel-logging
+endif
+
 ifeq ($(BR2_PACKAGE_FINIT_KEVENTD),y)
 FINIT_CONF_OPTS += --with-keventd
 else

--- a/package/skeleton-init-finit/skeleton/etc/default/sysklogd
+++ b/package/skeleton-init-finit/skeleton/etc/default/sysklogd
@@ -1,5 +1,5 @@
+# -l      :: Keep kernel looging to console
 # -m0     :: Disable periodic syslog MARK entries
 # -s      :: Enable secure mode, don't listen to remote logs
 # -r 1M:5 :: Log rotation every 1 MiB and keep 5 rotated ones
-SYSLOGD_ARGS="-m0 -s -r 1M:5"
-
+SYSLOGD_ARGS="-l -m0 -s -r 1M:10"

--- a/patches/sysklogd/2.5.2/0001-Fix-72-loss-of-raw-kernel-log-messages-to-console.patch
+++ b/patches/sysklogd/2.5.2/0001-Fix-72-loss-of-raw-kernel-log-messages-to-console.patch
@@ -1,0 +1,117 @@
+From 1727f7a5ea142ab923ca07f23b2457cf8db94d1d Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Wed, 24 Apr 2024 13:19:09 +0200
+Subject: [PATCH 1/1] Fix #72: loss of raw kernel log messages to console
+Organization: Addiva Elektronik
+
+This patch adds a command line flag `-l` to keep kernel logs to console.
+A feature requested by embedded Linux users which often navigate issues
+by console output.
+
+With properly configured kernel logging, e.g., `quiet`, only error and
+above in severity is logged by the kernel directly to the console.  So
+for most users this would be a useful behavior.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ man/syslogd.8 | 18 +++++++++++++++++-
+ src/syslogd.c | 10 +++++++++-
+ src/syslogd.h |  4 ++--
+ 3 files changed, 28 insertions(+), 4 deletions(-)
+
+diff --git a/man/syslogd.8 b/man/syslogd.8
+index dcfb564..70f1b8b 100644
+--- a/man/syslogd.8
++++ b/man/syslogd.8
+@@ -38,7 +38,7 @@
+ .Nd log systems messages
+ .Sh SYNOPSIS
+ .Nm
+-.Op Fl ?468AcdFHKknsTtv
++.Op Fl ?468AcdFHKklnsTtv
+ .Op Fl a Ar addr[/len][:port]
+ .Op Fl a Ar name[:port]
+ .Op Fl b Ar addr[:port]
+@@ -292,6 +292,22 @@ Usually the
+ .Dq kern
+ facility is reserved for messages read directly from
+ .Pa /dev/kmsg .
++.It Fl l
++Keep kernel console logging.  By default
++.Nm
++call
++.Xr klogctl 2
++to disable the kernel's logging to console after having opened
++.Pa /dev/kmsg .
++With this option the kernel's log level can be adjusted using
++.Xr sysctl 8 ,
++or the kernel command line, to suit your logging needs to the console.
++.Pp
++Please note, this does not affect logging of kernel messages, see
++.Fl K ,
++only what the kernel logs to
++.Pa /dev/console .
++Also, this is only applicable to Linux.
+ .It Fl m Ar interval
+ Select the number of minutes between
+ .Dq mark
+diff --git a/src/syslogd.c b/src/syslogd.c
+index e7b05b0..68040fe 100644
+--- a/src/syslogd.c
++++ b/src/syslogd.c
+@@ -154,6 +154,7 @@ static int	  RemoteHostname;	  /* Log remote hostname from the message */
+ static int	  KernLog = 1;		  /* Track kernel logs by default */
+ static int	  KeepKernFac;		  /* Keep remotely logged kernel facility */
+ static int	  KeepKernTime;		  /* Keep kernel timestamp, evern after initial read */
++static int	  KeepKernConsole;	  /* Keep kernel logging to console */
+ 
+ static off_t	  RotateSz = 0;		  /* Max file size (bytes) before rotating, disabled by default */
+ static int	  RotateCnt = 5;	  /* Max number (count) of log files to keep, set with -c <NUM> */
+@@ -363,6 +364,9 @@ int usage(int code)
+ 	       "  -H        Use hostname from message instead of address for remote messages\n"
+ 	       "  -K        Disable kernel logging, useful in container use-cases\n"
+ 	       "  -k        Allow logging with facility 'kernel', otherwise remapped to 'user'\n"
++#ifdef __linux__
++	       "  -l        Keep kernel logging to console, use sysctl to adjust kernel.printk\n"
++#endif
+ 	       "  -m MINS   Interval between MARK messages, 0 to disable, default: 20 min\n"
+ 	       "  -n        Disable DNS query for every request\n"
+ 	       "  -P FILE   File to store the process ID, default: %s\n"
+@@ -397,7 +401,7 @@ int main(int argc, char *argv[])
+ 	char *ptr;
+ 	int ch;
+ 
+-	while ((ch = getopt(argc, argv, "468Aa:b:C:cdHFf:Kkm:nP:p:r:sTtv?")) != EOF) {
++	while ((ch = getopt(argc, argv, "468Aa:b:C:cdHFf:Kklm:nP:p:r:sTtv?")) != EOF) {
+ 		switch ((char)ch) {
+ 		case '4':
+ 			family = PF_INET;
+@@ -464,6 +468,10 @@ int main(int argc, char *argv[])
+ 			KeepKernFac = 1;
+ 			break;
+ 
++		case 'l':
++			KeepKernConsole = 1;
++			break;
++
+ 		case 'm': /* mark interval */
+ 			MarkInterval = atoi(optarg) * 60;
+ 			break;
+diff --git a/src/syslogd.h b/src/syslogd.h
+index 68ceafb..1703df2 100644
+--- a/src/syslogd.h
++++ b/src/syslogd.h
+@@ -169,8 +169,8 @@
+ #define SYSLOG_ACTION_CONSOLE_ON  7
+ 
+ #ifdef __linux__
+-#define kern_console_off() klogctl(SYSLOG_ACTION_CONSOLE_OFF, NULL, 0)
+-#define kern_console_on()  klogctl(SYSLOG_ACTION_CONSOLE_ON, NULL, 0)
++#define kern_console_off() if (!KeepKernConsole) klogctl(SYSLOG_ACTION_CONSOLE_OFF, NULL, 0)
++#define kern_console_on()  if (!KeepKernConsole) klogctl(SYSLOG_ACTION_CONSOLE_ON, NULL, 0)
+ #else
+ #define kern_console_off() do { } while (0)
+ #define kern_console_on()  do { } while (0)
+-- 
+2.34.1
+

--- a/src/confd/yang/infix-if-bridge@2024-03-28.yang
+++ b/src/confd/yang/infix-if-bridge@2024-03-28.yang
@@ -416,6 +416,7 @@ submodule infix-if-bridge {
     when "derived-from-or-self(if:type,'ianaift:bridge') or "+
          "derived-from-or-self(if:type,'ianaift:ethernetCsmacd') or "+
          "derived-from-or-self(if:type,'ianaift:ieee8023adLag') or "+
+         "derived-from-or-self(if:type,'ianaift:l2vlan') or "+
          "derived-from-or-self(if:type,'ianaift:ilan')" {
       description "Applies when a Bridge interface exists.";
     }


### PR DESCRIPTION
## Description

The bulk of this PR concerns how Finit and sysklogd now allow kernel logging errors (and above) to the console directly.  On of the patches adjust a tmpfiles.d entry, fixing a missing directory, which was lost in the line noise before previous kernel logging changes.

The reminder is a fix to #406 

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [X] Bugfix
  - [X] Regression tests
  - [X] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): kernel logging to console

