### PR TITLE
Disable flow control

### DIFF
--- a/board/common/rootfs/etc/lldpd.d/disabled-ports.conf
+++ b/board/common/rootfs/etc/lldpd.d/disabled-ports.conf
@@ -1,0 +1,1 @@
+configure ports dsa0 lldp status disabled

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -30,6 +30,9 @@ separate project.  Going forward Infix' focus is entirely on NETCONF.
   set.  Use a VLAN interface on top for that (see above)
 - Container documentation: CLI prompts have been updated to match the
   examples used in other parts of the User Guide
+- As a follow-up to port speed/duplex/autoneg support added in v24.02,
+  this release ensures flow-control is always disabled on all Ethernet
+  ports, as described in the IEEE Ethernet interfaces YANG model
 - Issue #358: translate YANG model's LOWER-LAYER-DOWN -> LINK-DOWN in
   CLI `show interfaces` command
 - Issue #360: document factory-config, startup-config, and the various
@@ -76,9 +79,17 @@ separate project.  Going forward Infix' focus is entirely on NETCONF.
   (firewalled and NAT:ed, hidden from the rest of the network)
 - Fix #385: segfault in helper function when disabling the DHCP client
   using `no dhcp-client` from the CLI
+- Fix #404: `lldpd` should be disabled on internal interface `dsa0`
 - Fix #406: an overly restrictive `when` expression in the bridge YANG
   model prevented users from adding VLAN interfaces as bridge ports.
   E.g., creating interface `eth0.10` and adding that to `br0`
+- Fix #412: after starting up with DHCP client enabled on any interface
+  `set dhcp-client enabled false` does not bite at runtime
+- Fix #414: spelling error in `infix-hardware.yang`, leaf node `coutry`
+- Fix #415: `startup-config` owned by `root` user and group instead of
+  `admin`.  The file ownership is now adjusted on every boot
+- Fix #416: `admin` user cannot perform a factory reset with RPC using
+  `sysrepocfg` tool over SSH
 
 
 [v24.02.0][] - 2024-03-01

--- a/package/confd/confd.conf
+++ b/package/confd/confd.conf
@@ -10,10 +10,11 @@ run name:error :1 log:console norestart if:<run/bootstrap/failure> \
 service name:confd log <run/bootstrap/success> \
 	[S12345] sysrepo-plugind -f -p /run/confd.pid -n -- Configuration daemon
 
-# Bootstrap system with startup-config
+# Bootstrap system with startup-config, ensure correct ownership
 run name:startup log:prio:user.notice norestart <pid/confd> \
 	[S] /usr/libexec/confd/load startup-config \
 	-- Loading startup-config
+task chown admin:wheel /cfg/startup-config.cfg --
 
 # Run if loading startup-config fails for some reason
 run name:failure log:prio:user.critical norestart <pid/confd> if:<run/startup/failure> \

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -245,8 +245,10 @@ sysrepoctl -c ietf-netconf			-g wheel -p 0660	\
 		-e url							\
 		-e xpath						\
 		-e confirmed-commit
-# Allow wheel group users (admin) to modify NACM
-sysrepoctl -c ietf-netconf-acm -g wheel -p 0660
+# Allow wheel group users (admin) to modify NACM and do factory reset
+sysrepoctl -c ietf-netconf-acm     -g wheel -p 0660
+sysrepoctl -c ietf-factory-default -g wheel -p 0660
+sysrepoctl -c sysrepo-plugind      -g wheel -p 0660
 
 # On first boot, install factory-config as startup-config.  Due to a
 # limitation in sysrepo we cannot initialize ietf-netconf-acm, so we

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -214,7 +214,7 @@ sysrepoctl -s $SEARCH							\
 	   -i iana-hardware@2018-03-13.yang     -g wheel -p 0660        \
 	   -i ietf-hardware@2018-03-13.yang     -g wheel -p 0660        \
 	      -e hardware-state                                         \
-	   -i infix-hardware@2024-01-18.yang    -g wheel -p 0660        \
+	   -i infix-hardware@2024-04-25.yang    -g wheel -p 0660        \
 	   -i ieee802-dot1q-types@2022-10-29.yang -g wheel -p 0660	\
 	   -i infix-ip@2023-09-14.yang		-g wheel -p 0660	\
 	   -i infix-if-type@2024-01-29.yang	-g wheel -p 0660	\

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -255,7 +255,6 @@ chgrp wheel /cfg
 chmod g+w   /cfg
 if [ ! -f "$STARTUP_CFG" ]; then
     sysrepocfg -f json -X"$STARTUP_CFG"
-    chown admin:wheel "$STARTUP_CFG"
 fi
 
 # Clear running-config so we can load startup in the next step

--- a/src/confd/src/dagger.c
+++ b/src/confd/src/dagger.c
@@ -127,6 +127,10 @@ int dagger_should_skip_current(struct dagger *d, const char *ifname)
 	return fexistf("%s/%d/skip/%s", d->path, d->current, ifname);
 }
 
+int dagger_is_bootstrap(struct dagger *d)
+{
+	return d->next == 0;
+}
 
 int dagger_claim(struct dagger *d, const char *path)
 {

--- a/src/confd/src/dagger.h
+++ b/src/confd/src/dagger.h
@@ -30,6 +30,7 @@ int dagger_evolve_or_abandon(struct dagger *d);
 void dagger_skip_iface(struct dagger *d, const char *ifname);
 int dagger_should_skip(struct dagger *d, const char *ifname);
 int dagger_should_skip_current(struct dagger *d, const char *ifname);
+int dagger_is_bootstrap(struct dagger *d);
 
 int dagger_claim(struct dagger *d, const char *path);
 

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -698,7 +698,7 @@ static int netdag_gen_ethtool_autoneg(struct dagger *net, struct lyd_node *cif)
 	if (!fp)
 		return -EIO;
 
-	fprintf(fp, "ethtool --change %s  autoneg ", ifname);
+	fprintf(fp, "ethtool --change %s autoneg ", ifname);
 
 	if (!aneg || lydx_is_enabled(aneg, "enable")) {
 		fputs("on\n", fp);

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -775,12 +775,18 @@ static int netdag_gen_ethtool(struct dagger *net, struct lyd_node *cif, struct l
 	if (strcmp(type, "infix-if-type:ethernet"))
 		return 0;
 
-	/* XXX: add configurable flow-control support <<here>> */
-	err = netdag_gen_ethtool_flow_control(net, cif);
-	if (err)
-		return err;
+	if (!eth)
+		return 0;
 
-	if (lydx_get_descendant(lyd_child(eth), "auto-negotiation", "enable", NULL) ||
+	if (dagger_is_bootstrap(net) ||
+	    lydx_get_descendant(lyd_child(eth), "auto-negotiation", "enable", NULL)) {
+		err = netdag_gen_ethtool_flow_control(net, cif);
+		if (err)
+			return err;
+	}
+
+	if (dagger_is_bootstrap(net) ||
+	    lydx_get_descendant(lyd_child(eth), "auto-negotiation", "enable", NULL) ||
 	    lydx_get_child(eth, "speed") ||
 	    lydx_get_child(eth, "duplex")) {
 		err = netdag_gen_ethtool_autoneg(net, cif);

--- a/src/confd/src/infix-dhcp.c
+++ b/src/confd/src/infix-dhcp.c
@@ -312,6 +312,15 @@ static int change(sr_session_ctx_t *session, uint32_t sub_id, const char *module
 		}
 	}
 
+	if (!ena) {
+		LYX_LIST_FOR_EACH(cifs, cif, "client-if") {
+			const char *ifname = lydx_get_cattr(cif, "if-name");
+
+			INFO("DHCP client globally disabled, stopping client on %s ...", ifname);
+			del(ifname);
+		}
+	}
+
 	lyd_free_tree(diff);
 err_release_data:
 	sr_release_data(cfg);

--- a/src/confd/yang/infix-hardware@2024-04-25.yang
+++ b/src/confd/yang/infix-hardware@2024-04-25.yang
@@ -13,10 +13,19 @@ module infix-hardware {
     prefix yang;
   }
 
+  organization "KernelKit";
+  contact      "kernelkit@googlegroups.com";
+  description  "Vital Product Data augmentation of ieee-hardware and deviations.";
+
+  revision 2024-04-25 {
+    description "Spellcheck leaf: coutry-code -> country-code";
+    reference "internal";
+  }
   revision 2024-01-18 {
     description "Initial";
     reference "internal";
   }
+
   typedef country-code {
     type string {
       length 2;
@@ -114,7 +123,7 @@ module infix-hardware {
       leaf manufacturer {
 	type string;
       }
-      leaf coutry-code {
+      leaf country-code {
 	type country-code;
       }
       leaf vendor {


### PR DESCRIPTION
## Description

 - Disable flow control by default on Ethernet ports, both with and without autoneg
 - Disable lldpd on `dsa0` interface, added to `board/common` in case of future devices

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [X] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
