### PR TITLE
Multiple trusted keys in U-Boot

### DIFF
--- a/board/common/uboot/uboot.mk
+++ b/board/common/uboot/uboot.mk
@@ -1,26 +1,27 @@
-# This is a bit awkward. If you know about a more straight forward way
-# of doing this, please simplify.
-#
-# U-Boot needs the public part of the signing key to be preprocessed
-# and then inserted into its control DT. mkimage(1) can perform this
-# conversion, but only as a side-effect of building/signing an FIT
-# image. Since we might not always be doing that, e.g. when only
-# building a hardware specific bootloader, we build a dummy FIT just
-# to get the key information into a DTB, which we then convert back to
-# a .dtsi and install in the U-Boot build tree. This will then be
-# built in to the final U-Boot image's control DT via the
-# CONFIG_DEVICE_TREE_INCLUDES option (see extras.config).
+define uboot-add-pubkey
+	$(call IXMSG,"Installing trusted key $1")
+	$(HOST_DIR)/bin/fdt_add_pubkey \
+		-a sha256,rsa$(shell \
+			openssl x509 -text -noout -in $1 | \
+			grep 'Public-Key: ' | \
+			sed -e 's/.*(\(.*\) bit)/\1/') \
+		-k $(dir $1) \
+		-n $(notdir $(basename $1)) \
+		-r image \
+		$2
+endef
+
+# U-Boot has its own public key format which has to be stored in its
+# control DT. So we collect all of the trusted keys, convert them to
+# the required format, and write the result to infix-key.dtb in the
+# U-Boot build tree. This will then be built in to the final U-Boot
+# image's control DT via the CONFIG_DEVICE_TREE_INCLUDES option (see
+# extras.config).
 define UBOOT_PRE_BUILD_INSTALL_KEY
-	@$(call IXMSG,"Installing Infix signing key ($(SIGN_KEY))")
 	$(HOST_DIR)/bin/dtc <(echo '/dts-v1/; / { signature {}; };') >$(@D)/infix-key.dtb
-	$(HOST_DIR)/bin/mkimage \
-		-k $(SIGN_KEY) \
-		-f $(BR2_EXTERNAL_INFIX_PATH)/board/common/uboot/key-dummy.its \
-		-K $(@D)/infix-key.dtb \
-		$(if $(SIGN_SRC_PKCS11),-N pkcs11) \
-		-r \
-		$(@D)/key-dummy.itb
-	rm $(@D)/key-dummy.itb
+	$(foreach key, \
+		$(call qstrip,$(TRUSTED_KEYS_DEVELOPMENT_PATH)) $(call qstrip,$(TRUSTED_KEYS_EXTRA_PATH)),\
+		$(call uboot-add-pubkey,$(key),$(@D)/infix-key.dtb))
 	$(HOST_DIR)/bin/dtc -I dtb -O dts \
 		<$(@D)/infix-key.dtb \
 	| sed -e 's:/dts-v[0-9]\+/;::' >$(@D)/arch/$(UBOOT_ARCH)/dts/infix-key.dtsi


### PR DESCRIPTION
## Description

Now that RAUC can have multiple keys in its keyring, make sure that the same keys are built in to any U-Boot image as well.

## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
