### PR TITLE
Adding scripting examples relevant for production testing  

### DIFF
--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -751,7 +751,7 @@ An alternative is to write it to a temporary file, and use `sysrepocfg
 
 Infix supports IETF Hardware YANG with augments for ONIE formatted
 production data stored in EEPROMs, if available. See Infix [VPD
-documenation][5], as well as *ietf-hardware* and *infix-hardware* YANG
+documentation][5], as well as *ietf-hardware* and *infix-hardware* YANG
 models for details.
 
 
@@ -852,7 +852,7 @@ admin@example:/>
 #### Creating Bridge and Adding Ports
 
 Example below use Infix documentation on [creating
-bridges](networking.md#bridging). 
+bridges][8]. 
 
 ``` shell
 admin@example:/> configure
@@ -907,7 +907,7 @@ Then we configure VLANs according to plan
 [above](#port-test-intro). We configure default VID for ingress
 (PVID), which is done per port, and egress mode (untagged), which is
 done at the bridge level. See Infix [documentation for VLAN
-bridges](networking.md#vlan-filtering-bridge) for more information.
+bridges][9] for more information.
 
 
 ``` shell
@@ -1147,4 +1147,5 @@ your created configuration.
 [5]: vpd.md
 [6]: https://docs.kernel.org/leds/leds-class.html
 [7]: https://docs.kernel.org/power/power_supply_class.html
-
+[8]: networking.md#bridging
+[9]: networking.md#vlan-filtering-bridge

--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -331,10 +331,10 @@ admin@infix.local%eth0's password: *****
 ~$ 
 ```
 
-### Controlling LEDs (For Production Tests)
+### Controlling LEDs for Production Tests
 
-As part of production tests you wish to verify that LEDs work as
-expected. Infix uses standard [Linux support for LED
+As part of production testing, LED verification is often expected to
+be performed. Infix uses standard [Linux support for LED
 management][6], where LEDs appear in the file system under
 /sys/class/leds and can be controlled using *echo* command. `sudo`
 privileges are required.
@@ -344,39 +344,35 @@ daemon to avoid conflicting LED control.
 
 ```
 ~$ ssh admin@example.local 'initctl stop iitod'
-~$
 ```
 
-Then run your test, e.g., visually controll that a red LED labeled
+Then run the test, e.g., visually control that a red LED labeled
 'LAN' is working.
 
 ```
 ~$ ssh admin@example.local 'echo none | sudo tee /sys/class/leds/red\:lan/trigger'
-~$ ssh admin@example.local 'echo 1 | sudo tee /sys/class/leds/red\:lan/brightness'
-~$ 
+~$ ssh admin@example.local 'echo 1    | sudo tee /sys/class/leds/red\:lan/brightness'
 ```
 
 To turn off the same LED, run the following commands.
 
 ```
 ~$ ssh admin@example.local 'echo none | sudo tee /sys/class/leds/red\:lan/trigger'
-~$ ssh admin@example.local 'echo 0 | sudo tee /sys/class/leds/red\:lan/brightness'
-~$ 
+~$ ssh admin@example.local 'echo 0    | sudo tee /sys/class/leds/red\:lan/brightness'
 ```
 When done with LED testing, enable Infix *iitod* daemon again.
 
 ```
 ~$ ssh admin@example.local 'initctl start iitod'
-~$
 ```
 
-### Reading Power Feed Status (For Production Tests)
+### Reading Power Feed Status for Production Tests
 
-As part of production tests you wish to verify that Power Feed sensors work as
-expected. Infix uses standard [Linux support for Power
-management][7], where power sources appear in the file system under
-/sys/class/power_supply. The following example reads status of two
-power supplies named *pwr1* and *pwr2*. 
+As part of production tests, verification of Power Feed sensors is
+often expected to be performed. Infix uses standard [Linux support for
+Power management][7], where power sources appear in the file system
+under /sys/class/power_supply. The following example reads status of
+two power supplies named *pwr1* and *pwr2*.
 
 ```
 ~$ ssh admin@example 'cat /sys/class/power_supply/pwr1/online' 
@@ -386,9 +382,6 @@ power supplies named *pwr1* and *pwr2*.
 ~$ 
 ```
 Here, only *pwr1* happened to have power. 
-
-
-
 
 
 ## Examples using SSH and sysrepocfg
@@ -405,10 +398,10 @@ See [sysrepocfg][4] for information. Examples below will utilize
 
 
 - `sysrepocfg -I FILE -fjson -d DATABASE` to import/write a JSON
-  formatted configuration file to the specificed database.
+  formatted configuration file to the specified database.
 - `sysrepocfg -E FILE -fjson -d DATABASE` to edit/merge JSON formatted
-  configuration in FILE with the specificed database.
--  `sysrepocfg -R FILE -fjson` to execute remote procdure call (RPC) defined in
+  configuration in FILE with the specified database.
+-  `sysrepocfg -R FILE -fjson` to execute remote procedure call (RPC) defined in
    FILE (JSON formatted). 
 - `sysrepocfg -X -fjson -d DATABASE -x xpath` to read configuration or
   status from specified database.
@@ -419,7 +412,7 @@ configuration. Exporting (-X) could operate on configuration (e.g.,
 `-d running`) or status (`-d operational`).
 
 Some commands require a file as input. In examples below we assume 
-it been transfered to Infix in advance, e.g. using `scp` as shown below.
+it been transferred to Infix in advance, e.g. using `scp` as shown below.
 
 ```
 ~$ cat file.json 
@@ -447,7 +440,7 @@ it been transfered to Infix in advance, e.g. using `scp` as shown below.
 ```
 See [Factory Reset](#factory-reset) for another (simpler) alternative.
 
-If you only wish to copy factory config to running config the
+If it is only wished to copy factory config to running config the
 following RPC is available
 
 ```
@@ -793,14 +786,15 @@ models for details.
 
 ## Miscellaneous
 
-### <a id="port-test-intro"></a> Port Test Configuration Example (For Production Tests) 
+### <a id="port-test-intro"></a> Port Configuration Example for Production Tests 
 
-In production you wish to test that all ports work. A common way is to
-connect a test PC to two ports and send a *ping* traversing all ports.
-This can be achieved by using VLANs on the switch as described in this
-section. The resulting configuration file can be applied to the
-running configuration of the produced unit, e.g, use config file
-restore as described [above](#restore).
+As part of production tests, verification Ethernet ports are expected
+to be performed. A common way is to connect a test PC to two ports and
+send a *ping* traversing all ports.  This can be achieved by using
+VLANs on the switch as described in this section. The resulting
+configuration file can be applied to the running configuration of the
+produced unit, e.g, use config file restore as described
+[above](#restore).
 
 In this example we assume a 10 port switch, with ports e1-e10. 
 
@@ -817,13 +811,10 @@ The following VLAN configuration and cable connections will be used:
 The test PC is connected to e1 and e10 via different interfaces
 (alternatively, two different PCs are used).
 
-> Configuration here is done via console. If you intend to do it via
-> Ethernet and SSH, be careful so that you do not lose
-> connectivity. Either stay in "configuration context" until done, or
-> make sure there is always an IP (IPv6 or IPv4) address available on
-> the switch which you can connect to. Section [Add IP on
-> Switch](#ip-on-switch) gives an example.
-
+> Configuration here is done via console. When configuring remotely
+> over SSH, remember to keep one IP address (the one used for the SSH
+> connection)! I.e., set a static IP address first, then perform the
+> VLAN configuration step."
 
 #### Configuration at Start
 
@@ -851,8 +842,7 @@ admin@example:/>
 
 #### Creating Bridge and Adding Ports
 
-Example below use Infix documentation on [creating
-bridges][8]. 
+The example below uses Infix documentation on [creating bridges][8]. 
 
 ``` shell
 admin@example:/> configure
@@ -871,12 +861,13 @@ admin@example:/config/> set interface e10 bridge-port bridge br0
 admin@example:/config/> 
 ```
 
-If you wish, you can check interface status. But beware that you may
-lose connectivity when leaving *configuration context* if configuring
-via SSH. Then it is better to first assign an IPv6 address to br0
-(`set interface br0 ipv6 enabled`) before leaving. Or skip 'leave' and
-stay in configuration context until done with all sections, including
-the one on [Add IP on Switch](#ip-on-switch).
+The interface status can be viewed using "show interface" after
+leaving configuration context. If configuration via SSH, first assign
+an IP address to br0 before *leaving* configuration context, e.g.,
+`set interface br0 ipv6 enabled` to get auto-configured IPv6
+address. Or skip 'leave' and stay in configuration context until done
+with all sections, including the one on [Add IP on
+Switch](#ip-on-switch).
 
 ``` shell
 admin@example:/config/> leave
@@ -903,11 +894,10 @@ admin@example:/>
 
 #### Assign VLANs to Ports
 
-Then we configure VLANs according to plan
-[above](#port-test-intro). We configure default VID for ingress
-(PVID), which is done per port, and egress mode (untagged), which is
-done at the bridge level. See Infix [documentation for VLAN
-bridges][9] for more information.
+Then configure VLANs as outlined [above](#port-test-intro):
+default VID for ingress (PVID), which is done per port, and egress
+mode (untagged), which is done at the bridge level. See Infix
+[documentation for VLAN bridges][9] for more information.
 
 
 ``` shell
@@ -1096,7 +1086,7 @@ vlan10          ethernet   UP          00:53:00:06:11:01
 admin@example:/> 
 ```
 
-If you now ping "IPv6 all hosts" from the PC, you should get two
+When pinging "IPv6 all hosts" from the PC, there should be two
 responses for every ping, one from the switch and one from the PC
 attached to e10.
 
@@ -1118,7 +1108,7 @@ rtt min/avg/max/mdev = 0.452/0.631/0.968/0.211 ms
 ~ $ 
 ```
 
-Now you can access the switch from the PC via SSH (or NETCONF).
+It should now be possible to access the switch from the PC via SSH (or NETCONF).
 
 ``` shell
 ~ $ ssh admin@fe80::0053:00ff:fe06:1101%eth1
@@ -1135,7 +1125,7 @@ admin@example:~$ exit
 ```
 
 See previous sections on [backup](#backup) and [restore](#restore) of
-your created configuration.
+the created configuration.
 
 
 

--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -872,7 +872,7 @@ admin@example:/config/>
 ```
 
 If you wish, you can check interface status. But beware that you may
-loose connectivity when leaving *configuration context* if configuring
+lose connectivity when leaving *configuration context* if configuring
 via SSH. Then it is better to first assign an IPv6 address to br0
 (`set interface br0 ipv6 enabled`) before leaving. Or skip 'leave' and
 stay in configuration context until done with all sections, including

--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -818,7 +818,7 @@ The test PC is connected to e1 and e10 via different interfaces
 (alternatively, two different PCs are used).
 
 > Configuration here is done via console. If you intend to do it via
-> Ethernet and SSH, be careful so that you do not loose
+> Ethernet and SSH, be careful so that you do not lose
 > connectivity. Either stay in "configuration context" until done, or
 > make sure there is always an IP (IPv6 or IPv4) address available on
 > the switch which you can connect to. Section [Add IP on
@@ -1026,7 +1026,7 @@ PING ff02::1%eth1(ff02::1%eth1) 56 data bytes
 64 bytes from fe80::488a:a35f:9d41:ac9c%eth1: icmp_seq=5 ttl=64 time=0.521 ms
 64 bytes from fe80::488a:a35f:9d41:ac9c%eth1: icmp_seq=6 ttl=64 time=0.495 ms
 64 bytes from fe80::488a:a35f:9d41:ac9c%eth1: icmp_seq=7 ttl=64 time=0.743 ms
-... Disconnecting patch cable, thus loosing packets
+... Disconnecting patch cable, thus losing packets
 ... and reconnecting again. Connectivity resumes.
 64 bytes from fe80::488a:a35f:9d41:ac9c%eth1: icmp_seq=16 ttl=64 time=0.961 ms
 64 bytes from fe80::488a:a35f:9d41:ac9c%eth1: icmp_seq=17 ttl=64 time=0.513 ms

--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -660,7 +660,7 @@ on interface *e0*.
 ~$ 
 ```
 
-### Backup Configuration Using sysrepocfg And scp {#backup}
+### Backup Configuration Using sysrepocfg And scp <a id="backup"></a>
 
 Displaying running or startup configuration is possible with
 `sysrepocfg -X`, as shown below.
@@ -696,7 +696,7 @@ startup configuration (not running).
 ~$
 ```
 
-### Restore Configuration Using sysrepocfg and ssh/scp {#restore}
+### Restore Configuration Using sysrepocfg and ssh/scp <a id="restore"></a>
 
 
 To restore a backup configuration to startup, the simplest way is to
@@ -793,7 +793,7 @@ models for details.
 
 ## Miscellaneous
 
-### Port Test Configuration Example (For Production Tests) {#port-test-intro}
+### Port Test Configuration Example (For Production Tests) <a id="port-test-intro"></a>
 
 In production you wish to test that all ports work. A common way is to
 connect a test PC to two ports and send a *ping* traversing all ports.
@@ -804,27 +804,18 @@ restore as described [above](#restore).
 
 In this example we assume a 10 port switch, with ports e1-e10. 
 
-The following VLAN configuration will be used:
+The following VLAN configuration and cable connections will be used:
 
-| Ports   | VLAN    |
-|:--------|:--------|
-| e1, e2  | VLAN 10 |
-| e3, e4  | VLAN 20 |
-| e5, e6  | VLAN 30 |
-| e7, e8  | VLAN 40 |
-| e9, e10 | VLAN 50 |
+| VLAN & Ports      | Connect   |
+|:------------------|:----------|
+| VLAN 10: e1 & e2  | e2 <=> e3 |
+| VLAN 20: e3 & e4  | e4 <=> e5 |
+| VLAN 30: e5 & e6  | e6 <=> e7 |
+| VLAN 40: e7 & e8  | e8 <=> e9 |
+| VLAN 50: e9 & e10 |           |
 
-Connections will be as follows:
-
-| Connect | Connect |
-|:--------|:--------|
-| PC      | e1      |
-| e2      | e3      |
-| e4      | e5      |
-| e6      | e7      |
-| e8      | e9      |
-| e10     | PC      |
-
+The test PC is connected to e1 and e10 via different interfaces
+(alternatively, two different PCs are used).
 
 > Configuration here is done via console. If you intend to do it via
 > Ethernet and SSH, be careful so that you do not loose

--- a/doc/scripting.md
+++ b/doc/scripting.md
@@ -660,7 +660,7 @@ on interface *e0*.
 ~$ 
 ```
 
-### Backup Configuration Using sysrepocfg And scp <a id="backup"></a>
+### <a id="backup"></a> Backup Configuration Using sysrepocfg And scp 
 
 Displaying running or startup configuration is possible with
 `sysrepocfg -X`, as shown below.
@@ -696,7 +696,7 @@ startup configuration (not running).
 ~$
 ```
 
-### Restore Configuration Using sysrepocfg and ssh/scp <a id="restore"></a>
+### <a id="restore"></a> Restore Configuration Using sysrepocfg and ssh/scp 
 
 
 To restore a backup configuration to startup, the simplest way is to
@@ -793,7 +793,7 @@ models for details.
 
 ## Miscellaneous
 
-### Port Test Configuration Example (For Production Tests) <a id="port-test-intro"></a>
+### <a id="port-test-intro"></a> Port Test Configuration Example (For Production Tests) 
 
 In production you wish to test that all ports work. A common way is to
 connect a test PC to two ports and send a *ping* traversing all ports.
@@ -1040,7 +1040,7 @@ rtt min/avg/max/mdev = 0.448/0.634/0.961/0.156 ms
 ~ $ 
 ```
 
-#### Add IP Address on Switch {#ip-on-switch}
+#### <a id="ip-on-switch"></a> Add IP Address on Switch 
 
 The configuration so far does not provide a means to connect to the
 switch management via SSH or NETCONF, as the switch has no IP


### PR DESCRIPTION
<!--- **Summarize** your changes in the title above -->

## Description

Adding script examples, primarily for production tests
    
 - reading out eeprom/vpd data (sysrepocfg)
 - LED testing (shell/echo)
 - power supply sensor testing (shell/cat)
 - Ethernet port test - example for looping ports (CLI setup)

A reference to a production test script for the first three items would be great extension to this.
    
The 4th item (Ethernet port configuration for looping) should perhaps be documented elsewhere.
Maybe in Networking Lego page?


## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick relevant boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):


## References

<!-- Please list references to related issue(s) -->
