### PR TITLE
Factory bridge multicast and fix for veth custom mac address

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -19,6 +19,8 @@ All notable changes to the project are documented in this file.
 - Add small delay in U-Boot to allow stopping boot on reference boards
 - Document how to provision the bootloader and Infix on a blank board
 - Use initial hostname from `/etc/os-release` as configuration fallback
+- Issue #454: create bridges in `factory-config` with IGMP/MLD snooping
+  enabled by default
 
 ### Fixes
 - Add missing LICENSE hash for factory reset tool

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -19,6 +19,7 @@ All notable changes to the project are documented in this file.
 - Add small delay in U-Boot to allow stopping boot on reference boards
 - Document how to provision the bootloader and Infix on a blank board
 - Use initial hostname from `/etc/os-release` as configuration fallback
+- Update documentation for use of VETH pairs in containers
 - Issue #454: create bridges in `factory-config` with IGMP/MLD snooping
   enabled by default
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -33,6 +33,8 @@ All notable changes to the project are documented in this file.
 - Fix #428: loss of admin account after upgrade to v24.04
 - Fix #429: failing to load `startup-config` does not trigger the fail
   secure mode, causing the system to end up in an undefined state
+- Fix #453: fix inconsistent behavior of custom MAC address (interface
+  `phys-address` for VETH pairs.  Allows fixed MAC in containers
 
 
 [v24.04.2][] - 2024-05-15

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -4,6 +4,35 @@ Change Log
 All notable changes to the project are documented in this file.
 
 
+[v24.05.0][UNRELEASED]
+----------------------
+
+### Changes
+- Default web landing page refactored into a Buildroot package to make
+  it possible to overload from customer repos.
+- Enable DCB support in aarch64 kernel (for EtherType prio override)
+- Topology mapper improvements, including option for deterministic
+  reproduction of logical to physical mappings
+- New version of `gencert` tool, for self signed HTTPS certificates.
+  This allows dropping dependency on building a host rust toolchain
+- Issue #374: add timestamps to dagger .log files
+- Add small delay in U-Boot to allow stopping boot on reference boards
+- Document how to provision the bootloader and Infix on a blank board
+- Use initial hostname from `/etc/os-release` as configuration fallback
+
+### Fixes
+- Add missing LICENSE hash for factory reset tool
+- Fix #424: regression, root user can log in without password
+- Fix build regressions in `cn9130_crb_boot_defconfig` caused by upgrade
+  to Buildroot v2024.02 and recent multi-key support in RAUC and U-Boot
+- Fix provisioning script after changes to make GRUB loading more robust
+- Fix missing `/etc/resolv.conf`, as noticed by `avahi-daemon`, when a
+  user calls `no system` from the CLI
+- Fix #428: loss of admin account after upgrade to v24.04
+- Fix #429: failing to load `startup-config` does not trigger the fail
+  secure mode, causing the system to end up in an undefined state
+
+
 [v24.04.2][] - 2024-05-15
 -------------------------
 
@@ -881,6 +910,7 @@ Supported YANG models in addition to those used by sysrepo and netopeer:
 
 [buildroot]:  https://buildroot.org/
 [UNRELEASED]: https://github.com/kernelkit/infix/compare/v24.04.0...HEAD
+[v24.05.0]:   https://github.com/kernelkit/infix/compare/v24.04.0...v24.05.0
 [v24.04.2]:   https://github.com/kernelkit/infix/compare/v24.04.1...v24.04.2
 [v24.04.1]:   https://github.com/kernelkit/infix/compare/v24.04.0...v24.04.1
 [v24.04.0]:   https://github.com/kernelkit/infix/compare/v24.02.0...v24.04.0

--- a/src/confd/bin/gen-interfaces
+++ b/src/confd/bin/gen-interfaces
@@ -185,6 +185,13 @@ if [ -n "$bridge" ]; then
         },
         "ietf-ip:ipv6": {
             "enabled": true
+        },
+        "infix-interfaces:bridge": {
+          "multicast": {
+            "snooping": true,
+            "querier": "auto",
+            "query-interval": 125
+          }
         }
 EOF
 fi


### PR DESCRIPTION
## Description

 - Create factory bridges with IGMP/MLD snooping enabled by default
 - Create VETH interfaces with their custom MAC address
 - Update documentation for container around VETH pairs

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [X] Bugfix
  - [ ] Regression tests
  - [X] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [X] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):

