### PR TITLE
Add support for `ip addr show proto name` & devguide update

### DIFF
--- a/board/common/rootfs/etc/iproute2/rt_addrprotos
+++ b/board/common/rootfs/etc/iproute2/rt_addrprotos
@@ -1,3 +1,7 @@
+0 unspec
+1 kernel_lo
+2 kernel_ra
+3 kernel_ll
 4 static
 5 dhcp
 6 random

--- a/doc/developers-guide.md
+++ b/doc/developers-guide.md
@@ -97,8 +97,10 @@ To see available defconfigs for supported targets, use:
 Development
 -----------
 
-When changing a package, locally kept sources, or when using [`local.mk`](override-package.md),
-you only want to rebuild the parts you have modified:
+Developing with Infix is the same as [developing with Buildroot][4].
+When working with a package, be it locally kept sources, or when using
+[`local.mk`](override-package.md), you only want to rebuild the parts
+you have modified:
 
     make foo-rebuild
 
@@ -106,7 +108,7 @@ or
 
     make foo-reconfigure
 
-or, when nothing seems to bite:
+or, as a last resort when nothing seems to bite:
 
     make foo-dirclean foo-rebuild
 
@@ -203,3 +205,4 @@ $ git submodule update --init
 [1]: https://buildroot.org/downloads/manual/manual.html
 [2]: https://github.com/wkz/qeneth
 [3]: https://netopeer.liberouter.org/doc/sysrepo/master/html/dev_guide.html
+[4]: https://buildroot.org/downloads/manual/manual.html#_developer_guide

--- a/doc/override-package.md
+++ b/doc/override-package.md
@@ -1,50 +1,75 @@
-Package override
+Package Override
 ================
 
-This guide demonstrates how the `local.mk` file is utilized to override 
-a Linux Buildroot package. The example of `tcpdump` serves to illustrate 
+This guide demonstrates how the `local.mk` file is utilized to override
+a Linux Buildroot package.  As an example we use `tcpdump` to illustrate
 this process.
 
-In an instance such as `Infix` using tcpdump, the `local.mk` file is modified 
-as shown below: 
+> For a comprehensive guide to utilizing Buildroot during development,
+> including the `<pkg>_OVERRIDE_SRCDIR` mechanism, shown below, please
+> see [Using Buildroot during development][1] in the official docs.
+
+
+Setup
+-----
+
+Since the `output/` directory is often wiped for rebuilds, make sure you
+keep the file `local.mk` in the top directory and only symlink it to your
+build directory:
+
+    ~$ cd infix/
+    ~/infix(main)$ touch local.mk
+    ~/infix/output(main)$ ln -s ../local.mk .
+    ~/infix/output(main)$ cd ..
+
+
+Override
+--------
+
+Now edit the file:
+
+    ~/infix(main)$ editor local.mk
+
+Add an override for `tcpdump`.  The file is a Makefile snippet so you
+can add a lot of things.  Comment out lines with the UNIX comment `#`
+character if needed:
 
 ```
 TCPDUMP_OVERRIDE_SRCDIR = /path/to/tcpdump/repo
 ```
 
-and stored in the `output/` folder, alongside the `.config` file:
-```
-user@PC:~/infix$ll output/ | grep -e 'local.mk' -e '.config'
--rw-r--r--   1 group user 119936 Nov 10 18:04 .config
--rw-r--r--   1 group user     43 Nov 10 18:25 local.mk
-```
+Building
+--------
 
-The execution of `make tcpdump-rebuild all` triggers a process where 
-Buildroot synchronizes the tcpdump source code from the specified override directory 
-to `output/build/tcpdump-custom`, followed by the rebuilding of the entire project. 
+The execution of `make tcpdump-rebuild all` triggers a process where
+Buildroot synchronizes the tcpdump source code from the specified
+override directory to `output/build/tcpdump-custom`, followed by the
+rebuilding of the entire project.
 
 ```
-user@PC:~/infix$ make tcpdump-rebuild all
+~/infix$(main)$ make tcpdump-rebuild all
 ```
 
+Buildroot follows a process of downloading and processing tarballs:
+extraction, configuration, compilation, and installation.  The source
+for each package is extracted to a temporary build directory:
+
+    output/build/<package>-<version>    # e.g., tcpdump-4.99.4
+
+Let's have a look at what we got:
 
 ```
-user@PC:~/infix$ ll /output/build/ | grep tcpdump
+~/infix$(main)$ ll /output/build/ | grep tcpdump
 drwxr-xr-x   7 group user 20480 Nov 10 18:26 tcpdump-4.99.4/
 drwxr-xr-x   7 group user 12288 Nov 10 18:28 tcpdump-custom/
 ```
 
-Buildroot follows a process of downloading and processing tarballs 
-(extraction, configuration, compilation, and installation). 
-The source code is stored  in a temporary directory:
-`output/build/<package>-<version>` (i.e. `tcpdump-4.99.4/`), 
-which is removed and recreated with each `make` command. That is why 
-the direct modifications in the `output/build` directory are generally 
-**not recommended**. 
+As long as your local override is in place, Buildroot will use your
+custom version.
 
-To manage the development changes more effectively, where the package source code 
-remains untouched, Buildroot incorporates the `<pkg>_OVERRIDE_SRCDIR` feature.
+> **Remember:** the build directory is ephemeral, so be careful to
+> change any of the files therein.  It can be useful though during
+> debugging, but just make sure to learn the difference between the
+> various Buildroot commands to build, clean, reconfigure, etc.
 
-For a comprehensive understanding of utilizing Buildroot during development, 
-including detailed elaboration on the `<pkg>_OVERRIDE_SRCDIR` feature, 
-refer to section 8.13.6 in [Using Buildroot during development](https://nightly.buildroot.org/).
+[1]: https://buildroot.org/downloads/manual/manual.html#_using_buildroot_during_development

--- a/patches/iproute2/6.7.0/0001-iplink_bridge-add-mcast_flood_always-bridge-option.patch
+++ b/patches/iproute2/6.7.0/0001-iplink_bridge-add-mcast_flood_always-bridge-option.patch
@@ -1,3 +1,20 @@
+From 50fafdc63dc3d6152e2494cc693871e9bd04bfe5 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Tue, 5 Mar 2024 09:41:46 +0100
+Subject: [PATCH 1/2] iplink_bridge: add mcast_flood_always bridge option
+Organization: Addiva Elektronik
+
+ - Break out boolopt handling to simplify parsing and setting
+ - Add set/get support for mcast_flood_always
+ - Add get support for mst_enabled
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ include/uapi/linux/if_bridge.h |  1 +
+ ip/iplink_bridge.c             | 75 +++++++++++++++++++++++++---------
+ man/man8/ip-link.8.in          | 12 ++++++
+ 3 files changed, 68 insertions(+), 20 deletions(-)
+
 diff --git a/include/uapi/linux/if_bridge.h b/include/uapi/linux/if_bridge.h
 index adb75f7d..611ab413 100644
 --- a/include/uapi/linux/if_bridge.h
@@ -153,3 +170,6 @@ index 6764a9ad..8f77c5ad 100644
  .BI mcast_snooping " MULTICAST_SNOOPING "
  - turn multicast snooping on
  .RI ( MULTICAST_SNOOPING " > 0) "
+-- 
+2.34.1
+

--- a/patches/iproute2/6.7.0/0002-ipaddress-accept-symbolic-names-also-for-show.patch
+++ b/patches/iproute2/6.7.0/0002-ipaddress-accept-symbolic-names-also-for-show.patch
@@ -1,0 +1,31 @@
+From 226a8b532fc074165ba76d71c4488629daed2625 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Mon, 20 May 2024 21:35:11 +0200
+Subject: [PATCH 2/2] ipaddress: accept symbolic names also for show
+Organization: Addiva Elektronik
+
+This is a follow-up to 709063e, which in turn was a follow-up to
+bdb8d85, to add support for 'ip addr show proto static', where
+'static' is defined in /etc/iproute2/rt_addrprotos.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ ip/ipaddress.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ip/ipaddress.c b/ip/ipaddress.c
+index e536912f..19900157 100644
+--- a/ip/ipaddress.c
++++ b/ip/ipaddress.c
+@@ -2217,7 +2217,7 @@ static int ipaddr_list_flush_or_save(int argc, char **argv, int action)
+ 			__u8 proto;
+ 
+ 			NEXT_ARG();
+-			if (get_u8(&proto, *argv, 0))
++			if (rtnl_addrprot_a2n(&proto, *argv))
+ 				invarg("\"proto\" value is invalid\n", *argv);
+ 			filter.have_proto = true;
+ 			filter.proto = proto;
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description

While working on a customer feature I realized it was not possible to do `ip addr show profinet`.  Turns out that even though a lot has happened with iproute2 v6.7.0, this tiny little thing is still not supported.

Also, while reviewing documentation I cleaned up some grammar and simplified parts of the Devloper's Guide.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [X] Documentation content changes
- [X] Other (please describe): non-visible user change

