### PR TITLE
User scripts

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -22,6 +22,8 @@ All notable changes to the project are documented in this file.
 - Update documentation for use of VETH pairs in containers
 - Issue #454: create bridges in `factory-config` with IGMP/MLD snooping
   enabled by default
+- Add support for optionally running user scripts from
+  `/cfg/user-scripts.d`
 
 ### Fixes
 - Add missing LICENSE hash for factory reset tool

--- a/package/skeleton-init-finit/skeleton/etc/finit.d/available/user-scripts.conf
+++ b/package/skeleton-init-finit/skeleton/etc/finit.d/available/user-scripts.conf
@@ -1,0 +1,1 @@
+task [2] run-parts /cfg/user-scripts.d -- Running user startup scripts

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -226,7 +226,7 @@ sysrepoctl -s $SEARCH							\
 	   -i infix-dhcp-client@2024-04-12.yang -g wheel -p 0660	\
 	   -i infix-shell-type@2023-08-21.yang	-g wheel -p 0660	\
 	   -i infix-system@2024-04-12.yang	-g wheel -p 0660	\
-	   -i infix-services@2024-04-08.yang	-g wheel -p 0660	\
+	   -i infix-services@2024-05-21.yang	-g wheel -p 0660	\
 	   -i ieee802-ethernet-interface@2019-06-21.yang -g wheel -p 0660 \
 	   -i infix-ethernet-interface@2024-02-27.yang -g wheel -p 0660 \
 	   -I "${INIT_DATA}"

--- a/src/confd/yang/infix-services@2024-05-21.yang
+++ b/src/confd/yang/infix-services@2024-05-21.yang
@@ -7,6 +7,10 @@ module infix-services {
   contact      "kernelkit@googlegroups.com";
   description  "Infix services, generic.";
 
+  revision 2024-05-21 {
+    description "Add support for user-scripts.";
+    reference "internal";
+  }
   revision 2024-04-08 {
     description "Initial support for web services.";
     reference "internal";
@@ -29,6 +33,19 @@ module infix-services {
 
     leaf enabled {
       description "Globally enable or disable mDNS/SD on all interfaces.";
+      type boolean;
+    }
+  }
+
+  container user-scripts {
+    description "Run scripts in /cfg/user-scripts.d on system startup
+
+                 CAUTION! Anyone who can write to this directory will be able to
+                 install a permanent backdoor on the system. This could include
+                 a remote attacker with brief window of access.";
+
+    leaf enabled {
+      description "Enable or disable user script execution";
       type boolean;
     }
   }

--- a/test/case/infix_services/user_scripts.py
+++ b/test/case/infix_services/user_scripts.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+#
+
+import random
+import string
+
+import infamy
+
+def attach(env):
+    return (env.attach("target", "mgmt"), env.attach("target", "mgmt", "ssh"))
+
+with infamy.Test() as test:
+    with test.step("Initialize"):
+        env = infamy.Env(infamy.std_topology("1x1"))
+        target, tgtssh = attach(env)
+
+        cookie = "".join((random.choices(string.ascii_lowercase, k=16)))
+        script = f"/cfg/user-scripts.d/infamy-user-script-test.sh"
+        output = f"/tmp/{cookie}.cookie"
+
+    with test.step(f"Install {script}"):
+        tgtssh.runsh(f"""
+        set -e
+
+        mkdir -p $(dirname {script})
+        printf '#!/bin/sh\necho -n {cookie} >{output}\n' >{script}
+        chmod +x {script}
+        """)
+
+    with test.step("Enable user scripts and reboot"):
+        target.put_config_dict("infix-services", {
+            "user-scripts": {
+                "enabled": True
+            }
+        })
+        target.copy("running", "startup")
+        target.reboot()
+        infamy.util.wait_boot(target) or test.fail()
+        target, tgtssh = attach(env)
+
+    with test.step(f"Verify that {script} has run"):
+        cat = tgtssh.runsh(f"cat {output}").stdout
+        assert cat == cookie, f"Read back {repr(cat)}, expected {repr(cookie)}"
+
+    with test.step("Disable user scripts and reboot"):
+        target.put_config_dict("infix-services", {
+            "user-scripts": {
+                "enabled": False
+            }
+        })
+        target.copy("running", "startup")
+        target.reboot()
+        infamy.util.wait_boot(target) or test.fail()
+        target, tgtssh = attach(env)
+
+    with test.step(f"Verify that {script} has not run"):
+        exists = tgtssh.run(["test", "-f", f"{output}"]).returncode == 0
+        assert not exists, f"Unexpectedly found {output}"
+
+    with test.step(f"Remove {script}"):
+        tgtssh.runsh(f"rm {script}")
+
+    test.succeed()


### PR DESCRIPTION
## Description

Add a new service that, when enabled, will execute `run-parts` on `/cfg/user-scripts.d`.

This strikes a balance between two conflicting objectives:

1. There should be no implicit way to schedule arbitrary code execution on the device, i.e. no default run-parts directory.
2. It is very useful to have a way of scheduling arbitrary code execution on the device, e.g. being able to install a debug script on a production image.

With this feature, we still meet :one:, since the feature has to be explicitly enabled in the startup-config; but we also fulfill :two:, since we can easily enable it when needed.

## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [x] YANG model change => revision updated?
  - [x] Regression tests added?
  - [x] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

