### PR TITLE
test: Fixup permissions of generated files when using docker

### DIFF
--- a/test/.env
+++ b/test/.env
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034,SC2154
 
 # Current container image
-INFIX_TEST=ghcr.io/kernelkit/infix-test:1.4
+INFIX_TEST=ghcr.io/kernelkit/infix-test:1.5
 
 ixdir=$(readlink -f "$testdir/..")
 logdir=$(readlink -f "$testdir/.log")

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -44,3 +44,7 @@ COPY pip-requirements.txt /root
 ADD yang /root/yang
 
 RUN ~/init-venv.sh ~/pip-requirements.txt
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/bin/sh"]

--- a/test/docker/entrypoint.sh
+++ b/test/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+fixup_owner()
+{
+    for dir in $HOST_CHOWN_PATH; do
+	chown -R $HOST_CHOWN_UID:$HOST_CHOWN_GID $dir
+    done
+}
+
+trap fixup_owner EXIT
+
+"$@"

--- a/test/env
+++ b/test/env
@@ -164,6 +164,17 @@ while getopts "cCDf:hiKp:q:t:" opt; do
 done
 
 if [ "$containerize" ]; then
+    volumes="--volume $ixdir:$ixdir --workdir=$ixdir/test"
+    case "$(runner)" in
+	docker)
+	    volumes="$volumes --env HOST_CHOWN_PATH=$ixdir/test"
+	    volumes="$volumes --env HOST_CHOWN_UID=$(id -u)"
+	    volumes="$volumes --env HOST_CHOWN_GID=$(id -g)"
+	    ;;
+	podman)
+	    ;;
+    esac
+
     # shellcheck disable=SC2016
         exec $(runner) run \
 	 --cap-add=NET_RAW \
@@ -181,8 +192,7 @@ if [ "$containerize" ]; then
 	 --security-opt seccomp=unconfined \
 	 $network \
 	 --tty \
-	 --volume "$ixdir":"$ixdir" \
-	 --workdir "$ixdir/test" \
+	 $volumes \
 	 $kvm \
 	 $INFIX_TEST \
 	 "$0" -C "$@"


### PR DESCRIPTION
## Description

Since containers managed by docker runs as root, files created in bind mounted volumes will be owned by `root:root`. This is a problem for files generated during test execution, as the calling user does not have permission to remove them.

Therefore, add a wrapper entrypoint that hooks up an exit handler that will fixup the permissions before exiting the container.

## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

