### PR TITLE
Fix #473: bridges never get IPv6 autoconf enabled

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -48,6 +48,7 @@ All notable changes to the project are documented in this file.
   cause was buggy Augeas library, replaced with plain C API.
 - Fix #469: non-admin users added to *any* group get administrator
   privileges (added to UNIX `wheel` group)
+- Fix #473: bridge interface with IPv6 SLAAC never get global prefix
 - Fix locking issue with standard counter groups on `mv88e6xxx`
 - Fix MDB/ATU synchronization issue from IGMPv3/MLDv2 reports on
   `mv88e6xxx` systems

--- a/src/confd/bin/gen-interfaces
+++ b/src/confd/bin/gen-interfaces
@@ -184,7 +184,10 @@ if [ -n "$bridge" ]; then
             }
         },
         "ietf-ip:ipv6": {
-            "enabled": true
+            "enabled": true,
+            "autoconf": {
+                "create-global-addresses": true
+            }
         },
         "infix-interfaces:bridge": {
           "multicast": {

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -519,7 +519,8 @@ static int netdag_gen_ipv6_autoconf(struct dagger *net, struct lyd_node *cif,
 		valid_lft     = lydx_get_cattr(node, "temporary-valid-lifetime");
 	}
 
-	fp = dagger_fopen_next(net, "init", ifname, 45, "init.sysctl");
+	/* 51: must run after interfaces have been created (think: bridge, veth) */
+	fp = dagger_fopen_next(net, "init", ifname, 51, "init.sysctl");
 	if (fp) {
 		/* Autoconfigure addresses using Prefix Information in Router Advertisements */
 		fprintf(fp, "net.ipv6.conf.%s.autoconf = %d\n", ifname, global);

--- a/test/case/ietf_interfaces/all.yaml
+++ b/test/case/ietf_interfaces/all.yaml
@@ -1,6 +1,7 @@
 ---
 - case: vlan_ping.py
 - case: ipv4_address.py
+- case: ipv6_address.py
 - case: iface_phys_address.py
 - case: iface_status.py
 - case: routing_basic.py

--- a/test/case/ietf_interfaces/ipv6_address.py
+++ b/test/case/ietf_interfaces/ipv6_address.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Verify IPv6 autoconf on a bridge is properly set up for global prefix.
+# See issue #473 for details.
+
+import infamy
+
+with infamy.Test() as test:
+    with test.step("Initializing ..."):
+        env = infamy.Env(infamy.std_topology("1x2"))
+        target = env.attach("target", "mgmt")
+        tgtssh = env.attach("target", "mgmt", "ssh")
+
+    with test.step("Setting up bridge with IPv6 SLAAC for global prefix ..."):
+        _, tport = env.ltop.xlate("target", "data")
+
+        target.put_config_dict("ietf-interfaces", {
+            "interfaces": {
+                "interface": [
+                    {
+                        "name": "br0",
+                        "type": "infix-if-type:bridge",
+                        "enabled": True,
+                        "ipv6": {
+                            "enabled": True,
+                            "autoconf": {
+                                    "create-global-addresses": True
+                            }
+                        }
+                    },
+                    {
+                        "name": tport,
+                        "enabled": True,
+                        "infix-interfaces:bridge-port": {
+                            "bridge": "br0"
+                        }
+                    },
+                ]
+            }
+        })
+
+    with test.step("Verifying sysctl autoconf setting ..."):
+        out = tgtssh.runsh("sysctl net.ipv6.conf.br0.autoconf").stdout
+        print(out)
+        if "autoconf = 1" not in out:
+            test.fail()
+
+    test.succeed()


### PR DESCRIPTION
## Description

Fix ordering of dagger script execution for dynamic interfaces such as bridges, VETH pairs, etc.

Also included, a minor change for end-customers with bridges in their `factory-config`.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [X] Bugfix
  - [X] Regression tests
  - [X] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

