### PR TITLE
Run RESTCONF/NETCONF randomly over a testsuite

### DIFF
--- a/board/common/rootfs/etc/finit.d/available/restconf.conf
+++ b/board/common/rootfs/etc/finit.d/available/restconf.conf
@@ -1,3 +1,3 @@
 service name:rousette notify:none log <pid/confd> \
-	[12345] rousette --syslog \
+	[12345] rousette --syslog -t 60 \
 	-- RESTCONF server

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -119,7 +119,7 @@ there is another helper script in Infamy for this:
     $ ./test/console 1
     Trying 127.0.0.1...
     Connected to 127.0.0.1.
-    
+
     Infix -- a Network Operating System v23.11.0-226-g0c144da (console)
     infix-00-00-00 login: admin
     Password:
@@ -127,9 +127,9 @@ there is another helper script in Infamy for this:
     |  . .  | Infix -- a Network Operating System
     |-. v .-| https://kernelkit.github.io
     '-'---'-'
-    
+
     Run the command 'cli' for interactive OAM
-    
+
     admin@infix-00-00-00:~$
 
 From here we can observe `dut1` freely while running tests.
@@ -256,6 +256,13 @@ the whole suite) with identical topology mappings:
 
     $ make PYTHONHASHSEED=3773822171 INFIX_TESTS=case/ietf_system/hostname.py test
 
+### Determinstic use of communication protocol (NETCONF/RESTCONF)
+
+By default the protocol will be chosen randomly. If you supply a
+`PYTHONHASHSEED` as described above, you will get the same protocol
+chosen. If you want to choose the communcation protocol:
+
+    $ make INFAMY_EXTRA_ARGS="--transport=restconf" INFIX_TESTS=case/ietf_system/hostname.py test
 
 [9PM]:    https://github.com/rical/9pm
 [Qeneth]: https://github.com/wkz/qeneth

--- a/package/finit/0012-initctl-extend-initctl-poll-timeout.patch
+++ b/package/finit/0012-initctl-extend-initctl-poll-timeout.patch
@@ -1,0 +1,41 @@
+From 13b107b7b15e6d4823627ea4707a12108fd5a1c7 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Fri, 21 Jun 2024 10:24:35 +0200
+Subject: [PATCH] Fix #407: extend initctl poll timeout
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/client.c | 6 ++++--
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/client.c b/src/client.c
+index c3fd3aef..a8c06ac4 100644
+--- a/src/client.c
++++ b/src/client.c
+@@ -29,6 +29,8 @@
+ #include "client.h"
+ #include "log.h"
+ 
++#define REQUEST_TIMEOUT 15000
++
+ static int sd = -1;
+ 
+ int client_connect(void)
+@@ -85,7 +87,7 @@ int client_request(struct init_request *rq, ssize_t len)
+ 
+ 	pfd.fd     = sd;
+ 	pfd.events = POLLOUT;
+-	if (poll(&pfd, 1, 2000) <= 0) {
++	if (poll(&pfd, 1, REQUEST_TIMEOUT) <= 0) {
+ 		warn("Timed out waiting for Finit, errno %d", errno);
+ 		return -1;
+ 	}
+@@ -107,7 +109,7 @@ int client_request(struct init_request *rq, ssize_t len)
+ 
+ 	pfd.fd = sd;
+ 	pfd.events = POLLIN | POLLERR | POLLHUP;
+-	if ((rc = poll(&pfd, 1, 2000)) <= 0) {
++	if ((rc = poll(&pfd, 1, REQUEST_TIMEOUT)) <= 0) {
+ 		if (rc) {
+ 			if (errno == EINTR) /* shutdown/reboot */
+ 				return -1;

--- a/patches/rousette/0001-Change-systemd-from-a-required-dependency-to-an-opti.patch
+++ b/patches/rousette/0001-Change-systemd-from-a-required-dependency-to-an-opti.patch
@@ -1,7 +1,7 @@
-From 561c28496691fc1ac17e755bcc0ff3ec8c3b1bf0 Mon Sep 17 00:00:00 2001
+From 02ff08f881c726b5b14eb489f4a906ec4b421a6f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Mattias=20Walstr=C3=B6m?= <lazzer@gmail.com>
-Date: Tue, 28 May 2024 09:28:38 +0200
-Subject: [PATCH] Change systemd from a required dependency to an optional
+Date: Tue, 25 Jun 2024 11:17:03 +0200
+Subject: [PATCH 1/2] Change systemd from a required dependency to an optional
  dependency.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -13,23 +13,20 @@ In addition to journal logging, enable logging to syslog and stdout.
 Signed-off-by: Mattias Walström <lazzer@gmail.com>
 Change-Id: I90cb9169e8fdf9103c31bc983a1ec8a5de3dd26c
 ---
- CMakeLists.txt           | 14 +++++++++++---
+ CMakeLists.txt           | 13 +++++++++++--
  README.md                |  3 ++-
  ci/pre.yaml              |  6 ++++++
  src/configure.cmake.h.in |  3 +++
  src/restconf/main.cpp    | 36 ++++++++++++++++++++++++++++++++----
- 5 files changed, 54 insertions(+), 8 deletions(-)
+ 5 files changed, 54 insertions(+), 7 deletions(-)
  create mode 100644 src/configure.cmake.h.in
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 7f82660..43313ba 100644
+index 7f82660..1cd27b2 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -72,11 +72,16 @@ find_package(spdlog REQUIRED)
- find_package(PkgConfig)
- pkg_check_modules(nghttp2 REQUIRED IMPORTED_TARGET libnghttp2_asio>=0.0.90 libnghttp2)
- find_package(Boost REQUIRED COMPONENTS system thread)
--
+@@ -75,8 +75,14 @@ find_package(Boost REQUIRED COMPONENTS system thread)
+ 
  pkg_check_modules(SYSREPO-CPP REQUIRED IMPORTED_TARGET sysrepo-cpp>=1.1.0)
  pkg_check_modules(LIBYANG-CPP REQUIRED IMPORTED_TARGET libyang-cpp>=1.1.0)
 -pkg_check_modules(SYSTEMD REQUIRED IMPORTED_TARGET libsystemd)
@@ -44,7 +41,7 @@ index 7f82660..43313ba 100644
  
  add_library(rousette-http STATIC
      src/http/EventStream.cpp
-@@ -116,7 +121,10 @@ add_executable(watch-operational-ds
+@@ -116,7 +122,10 @@ add_executable(watch-operational-ds
  target_link_libraries(watch-operational-ds PUBLIC rousette-sysrepo)
  
  add_executable(rousette src/restconf/main.cpp)

--- a/patches/rousette/0002-Add-optional-timeout-option.patch
+++ b/patches/rousette/0002-Add-optional-timeout-option.patch
@@ -1,0 +1,248 @@
+commit c83585452819b6e06008aba49237f46977a73a9a
+Author: Mattias Walström <lazzer@gmail.com>
+Date:   Wed Jun 26 11:04:36 2024 +0200
+
+    Add optional timeout option
+    
+    Since rousette will fail applying a new configuration
+    on really slow systems and a lot of sysrepo callbacks.
+    
+    Change-Id: I61d92a1f64e4c3617587e544cfd9d6a4269e0d35
+
+diff --git a/src/restconf/Server.cpp b/src/restconf/Server.cpp
+index 5327b52..685bf78 100644
+--- a/src/restconf/Server.cpp
++++ b/src/restconf/Server.cpp
+@@ -202,14 +202,13 @@ DataFormat chooseDataEncoding(const nghttp2::asio_http2::header_map& headers)
+     return {resContentType, resAccept ? *resAccept : libyang::DataFormat::JSON};
+ }
+ 
+-bool dataExists(sysrepo::Session session, const std::string& path)
++bool dataExists(sysrepo::Session session, const std::string& path, std::chrono::milliseconds timeout)
+ {
+-    if (auto data = session.getData(path)) {
+-        if (data->findPath(path)) {
++  if (auto data = session.getData(path, 0, sysrepo::GetOptions::Default,timeout)) {
++        if (data->findPath(path))
+             return true;
+         }
+-    }
+-    return false;
++  return false;
+ }
+ 
+ /** @brief Checks if node is a key node in a maybeList node list */
+@@ -261,7 +260,7 @@ struct RequestContext {
+     std::string payload;
+ };
+ 
+-void processActionOrRPC(std::shared_ptr<RequestContext> requestCtx)
++void processActionOrRPC(std::shared_ptr<RequestContext> requestCtx, std::chrono::milliseconds timeout)
+ {
+     requestCtx->sess.switchDatastore(sysrepo::Datastore::Operational);
+     auto ctx = requestCtx->sess.getContext();
+@@ -276,7 +275,7 @@ void processActionOrRPC(std::shared_ptr<RequestContext> requestCtx)
+         if (rpcSchemaNode.nodeType() == libyang::NodeType::Action) {
+             // FIXME: This is race-prone: we check for existing action data node but before we send the RPC the node may be gone
+             auto [pathToParent, pathSegment] = asLibyangPathSplit(ctx, requestCtx->req.uri().path);
+-            if (!dataExists(requestCtx->sess, pathToParent)) {
++            if (!dataExists(requestCtx->sess, pathToParent,timeout)) {
+                 throw ErrorResponse(400, "application", "operation-failed", "Action data node '" + requestCtx->lyPathOriginal + "' does not exist.");
+             }
+         }
+@@ -287,7 +286,7 @@ void processActionOrRPC(std::shared_ptr<RequestContext> requestCtx)
+             rpcNode->parseOp(requestCtx->payload, *requestCtx->dataFormat.request, libyang::OperationType::RpcRestconf);
+         }
+ 
+-        auto rpcReply = requestCtx->sess.sendRPC(*rpcNode);
++        auto rpcReply = requestCtx->sess.sendRPC(*rpcNode, timeout);
+ 
+         if (rpcReply.immediateChildren().empty()) {
+             requestCtx->res.write_head(204, {{"access-control-allow-origin", {"*", false}}});
+@@ -330,7 +329,7 @@ void processActionOrRPC(std::shared_ptr<RequestContext> requestCtx)
+     }
+ }
+ 
+-void processPost(std::shared_ptr<RequestContext> requestCtx)
++void processPost(std::shared_ptr<RequestContext> requestCtx, std::chrono::milliseconds timeout)
+ {
+     try {
+         auto ctx = requestCtx->sess.getContext();
+@@ -374,7 +373,7 @@ void processPost(std::shared_ptr<RequestContext> requestCtx)
+         createdNodes.begin()->newMeta(*mod, "operation", "create"); // FIXME: check no other nc:operations in the tree
+ 
+         requestCtx->sess.editBatch(*edit, sysrepo::DefaultOperation::Merge);
+-        requestCtx->sess.applyChanges();
++        requestCtx->sess.applyChanges(timeout);
+ 
+         requestCtx->res.write_head(201,
+                                    {
+@@ -402,7 +401,7 @@ void processPost(std::shared_ptr<RequestContext> requestCtx)
+     }
+ }
+ 
+-void processPut(std::shared_ptr<RequestContext> requestCtx)
++void processPut(std::shared_ptr<RequestContext> requestCtx, std::chrono::milliseconds timeout)
+ {
+     try {
+         auto ctx = requestCtx->sess.getContext();
+@@ -410,7 +409,7 @@ void processPut(std::shared_ptr<RequestContext> requestCtx)
+         // PUT / means replace everything
+         if (requestCtx->lyPathOriginal == "/") {
+             auto edit = ctx.parseData(requestCtx->payload, *requestCtx->dataFormat.request, libyang::ParseOptions::Strict | libyang::ParseOptions::NoState | libyang::ParseOptions::ParseOnly);
+-            requestCtx->sess.replaceConfig(edit);
++            requestCtx->sess.replaceConfig(edit, std::nullopt, timeout);
+ 
+             requestCtx->res.write_head(edit ? 201 : 204,
+                                        {
+@@ -422,7 +421,7 @@ void processPut(std::shared_ptr<RequestContext> requestCtx)
+         }
+ 
+         auto mod = ctx.getModuleImplemented("ietf-netconf");
+-        bool nodeExisted = dataExists(requestCtx->sess, requestCtx->lyPathOriginal);
++        bool nodeExisted = dataExists(requestCtx->sess, requestCtx->lyPathOriginal, timeout);
+         std::optional<libyang::DataNode> edit;
+         std::optional<libyang::DataNode> replacementNode;
+ 
+@@ -471,7 +470,7 @@ void processPut(std::shared_ptr<RequestContext> requestCtx)
+         replacementNode->newMeta(*mod, "operation", "replace"); // FIXME: check no other nc:operations in the tree
+ 
+         requestCtx->sess.editBatch(*edit, sysrepo::DefaultOperation::Merge);
+-        requestCtx->sess.applyChanges();
++        requestCtx->sess.applyChanges(timeout);
+ 
+         requestCtx->res.write_head(nodeExisted ? 204 : 201,
+                                    {
+@@ -551,7 +550,7 @@ Server::~Server()
+     server->join();
+ }
+ 
+-Server::Server(sysrepo::Connection conn, const std::string& address, const std::string& port)
++Server::Server(sysrepo::Connection conn, const std::string& address, const std::string& port, long timeout_seconds)
+     : nacm(conn)
+     , server{std::make_unique<nghttp2::asio_http2::server::http2>()}
+     , dwdmEvents{std::make_unique<sr::OpticalEvents>(conn.sessionStart())}
+@@ -562,6 +561,8 @@ Server::Server(sysrepo::Connection conn, const std::string& address, const std::
+         }
+     }
+ 
++    std::chrono::milliseconds timeout(timeout_seconds * 1000);
++
+     // RFC 8527, we must implement at least ietf-yang-library@2019-01-04 and support operational DS
+     if (auto mod = conn.sessionStart().getContext().getModuleImplemented("ietf-yang-library"); !mod || mod->revision() < "2019-01-04") {
+         throw std::runtime_error("Module ietf-yang-library of revision at least 2019-01-04 is not implemented");
+@@ -627,7 +628,7 @@ Server::Server(sysrepo::Connection conn, const std::string& address, const std::
+     });
+ 
+     server->handle(restconfRoot,
+-        [conn /* intentionally by value, otherwise conn gets destroyed when the ctor returns */, this](const auto& req, const auto& res) mutable {
++        [conn /* intentionally by value, otherwise conn gets destroyed when the ctor returns */, this, timeout](const auto& req, const auto& res) mutable {
+             const auto& peer = http::peer_from_request(req);
+             spdlog::info("{}: {} {}", peer, req.method(), req.uri().raw_path);
+ 
+@@ -665,7 +666,7 @@ Server::Server(sysrepo::Connection conn, const std::string& address, const std::
+ 
+                 case RestconfRequest::Type::GetData:
+                     sess.switchDatastore(restconfRequest.datastore.value_or(sysrepo::Datastore::Operational));
+-                    if (auto data = sess.getData(restconfRequest.path); data) {
++                    if (auto data = sess.getData(restconfRequest.path, 0, sysrepo::GetOptions::Default,timeout); data) {
+                         res.write_head(
+                             200,
+                             {
+@@ -692,16 +693,16 @@ Server::Server(sysrepo::Connection conn, const std::string& address, const std::
+ 
+                     auto requestCtx = std::make_shared<RequestContext>(req, res, dataFormat, sess, restconfRequest.path);
+ 
+-                    req.on_data([requestCtx, restconfRequest /* intentional copy */](const uint8_t* data, std::size_t length) {
++                    req.on_data([requestCtx, restconfRequest /* intentional copy */, timeout](const uint8_t* data, std::size_t length) {
+                         if (length > 0) { // there are still some data to be read
+                             requestCtx->payload.append(reinterpret_cast<const char*>(data), length);
+                             return;
+                         }
+ 
+                         if (restconfRequest.type == RestconfRequest::Type::CreateOrReplaceThisNode) {
+-                            processPut(requestCtx);
++                            processPut(requestCtx, timeout);
+                         } else {
+-                            processPost(requestCtx);
++                            processPost(requestCtx, timeout);
+                         }
+                     });
+                     break;
+@@ -725,7 +726,7 @@ Server::Server(sysrepo::Connection conn, const std::string& address, const std::
+                         }
+ 
+                         sess.editBatch(*edit, sysrepo::DefaultOperation::Merge);
+-                        sess.applyChanges();
++                        sess.applyChanges(timeout);
+                     } catch (const sysrepo::ErrorWithCode& e) {
+                         if (e.code() == sysrepo::ErrorCode::Unauthorized) {
+                             throw ErrorResponse(403, "application", "access-denied", "Access denied.", restconfRequest.path);
+@@ -747,11 +748,11 @@ Server::Server(sysrepo::Connection conn, const std::string& address, const std::
+                 case RestconfRequest::Type::Execute: {
+                     auto requestCtx = std::make_shared<RequestContext>(req, res, dataFormat, sess, restconfRequest.path);
+ 
+-                    req.on_data([requestCtx](const uint8_t* data, std::size_t length) {
++                    req.on_data([requestCtx,timeout](const uint8_t* data, std::size_t length) {
+                         if (length > 0) {
+                             requestCtx->payload.append(reinterpret_cast<const char*>(data), length);
+                         } else {
+-                            processActionOrRPC(requestCtx);
++                            processActionOrRPC(requestCtx,timeout);
+                         }
+                     });
+                     break;
+diff --git a/src/restconf/Server.h b/src/restconf/Server.h
+index bf6fecc..b2c42f4 100644
+--- a/src/restconf/Server.h
++++ b/src/restconf/Server.h
+@@ -24,11 +24,10 @@ class OpticalEvents;
+ namespace restconf {
+ 
+ std::optional<std::string> as_subtree_path(const std::string& path);
+-
+ /** @short A RESTCONF-ish server */
+ class Server {
+ public:
+-    explicit Server(sysrepo::Connection conn, const std::string& address, const std::string& port);
++    explicit Server(sysrepo::Connection conn, const std::string& address, const std::string& port, long timeout);
+     ~Server();
+ 
+ private:
+diff --git a/src/restconf/main.cpp b/src/restconf/main.cpp
+index 2bc9a86..e295f63 100644
+--- a/src/restconf/main.cpp
++++ b/src/restconf/main.cpp
+@@ -27,9 +27,10 @@
+ static const char usage[] =
+   R"(Rousette - RESTCONF server
+ Usage:
+-  rousette [--syslog] [--help]
++  rousette [--syslog] [--timeout <SECONDS>] [--help]
+ Options:
+   -h --help                         Show this screen.
++  -t --timeout <SECONDS>            Change default timeout in sysrepo (if not set, use sysrepo internal).
+   --syslog                          Log to syslog.
+ )";
+ #ifdef HAVE_SYSTEMD
+@@ -74,6 +75,10 @@ public:
+ int main(int argc, char* argv [])
+ {
+     auto args = docopt::docopt(usage, {argv + 1, argv + argc}, true,""/* version */, true);
++    long timeout = 0;
++
++    if (args["--timeout"])
++        timeout = args["--timeout"].asLong();
+ 
+     if (args["--syslog"].asBool()) {
+         auto syslog_sink = std::make_shared<spdlog::sinks::syslog_sink_mt>("rousette", LOG_PID, LOG_USER, true);
+@@ -100,8 +105,7 @@ int main(int argc, char* argv [])
+     }
+ 
+     auto conn = sysrepo::Connection{};
+-    auto server = rousette::restconf::Server{conn, "::1", "10080"};
+-
++    auto server = rousette::restconf::Server{conn, "::1", "10080", timeout};
+     signal(SIGTERM, [](int) {});
+     signal(SIGINT, [](int) {});
+     pause();

--- a/patches/sysrepo-cpp/0001-Add-optional-timeouts-for-calls-to-sr_get_data-and-s.patch
+++ b/patches/sysrepo-cpp/0001-Add-optional-timeouts-for-calls-to-sr_get_data-and-s.patch
@@ -1,0 +1,67 @@
+From 36f2ad3c009f4234d906485439ead42a6fbb7adf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mattias=20Walstr=C3=B6m?= <lazzer@gmail.com>
+Date: Tue, 25 Jun 2024 16:18:07 +0200
+Subject: [PATCH] Add optional timeouts for calls to sr_get_data and
+ sr_get_node
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Organization: Addiva Elektronik
+
+Signed-off-by: Mattias Walström <lazzer@gmail.com>
+
+Change-Id: Ia91eb6823e64322e37e661b60b369dfedc5677fb
+---
+ include/sysrepo-cpp/Session.hpp | 4 ++--
+ src/Session.cpp                 | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/include/sysrepo-cpp/Session.hpp b/include/sysrepo-cpp/Session.hpp
+index 7c5c71c..350df7a 100644
+--- a/include/sysrepo-cpp/Session.hpp
++++ b/include/sysrepo-cpp/Session.hpp
+@@ -88,9 +88,9 @@ public:
+     void discardItems(const std::optional<std::string>& xpath);
+     void moveItem(const std::string& path, const MovePosition move, const std::optional<std::string>& keys_or_value, const std::optional<std::string>& origin = std::nullopt, const EditOptions opts = sysrepo::EditOptions::Default);
+     // TODO: allow timeout argument
+-    std::optional<libyang::DataNode> getData(const std::string& path, int maxDepth = 0, const GetOptions opts = sysrepo::GetOptions::Default) const;
++    std::optional<libyang::DataNode> getData(const std::string& path, int maxDepth = 0, const GetOptions opts = sysrepo::GetOptions::Default, std::chrono::milliseconds timeout = std::chrono::milliseconds{0}) const;
+     // TODO: allow all arguments
+-    libyang::DataNode getOneNode(const std::string& path) const;
++    libyang::DataNode getOneNode(const std::string& path, std::chrono::milliseconds timeout = std::chrono::milliseconds{0}) const;
+     std::optional<const libyang::DataNode> getPendingChanges() const;
+     void applyChanges(std::chrono::milliseconds timeout = std::chrono::milliseconds{0});
+     void discardChanges();
+diff --git a/src/Session.cpp b/src/Session.cpp
+index e9d2976..04b0333 100644
+--- a/src/Session.cpp
++++ b/src/Session.cpp
+@@ -191,10 +191,10 @@ libyang::DataNode wrapSrData(std::shared_ptr<sr_session_ctx_s> sess, sr_data_t*
+  * @param opts GetOptions overriding default behaviour
+  * @returns std::nullopt if no matching data found, otherwise the requested data.
+  */
+-std::optional<libyang::DataNode> Session::getData(const std::string& path, int maxDepth, const GetOptions opts) const
++std::optional<libyang::DataNode> Session::getData(const std::string& path, int maxDepth, const GetOptions opts, std::chrono::milliseconds timeout) const
+ {
+     sr_data_t* data;
+-    auto res = sr_get_data(m_sess.get(), path.c_str(), maxDepth, 0, toGetOptions(opts), &data);
++    auto res = sr_get_data(m_sess.get(), path.c_str(), maxDepth, timeout.count(), toGetOptions(opts), &data);
+ 
+     throwIfError(res, "Session::getData: Couldn't get '"s + path + "'", m_sess.get());
+ 
+@@ -219,10 +219,10 @@ std::optional<libyang::DataNode> Session::getData(const std::string& path, int m
+  * @param path XPath which corresponds to the data that should be retrieved.
+  * @returns the requested data node (as a disconnected node)
+  */
+-libyang::DataNode Session::getOneNode(const std::string& path) const
++libyang::DataNode Session::getOneNode(const std::string& path, std::chrono::milliseconds timeout) const
+ {
+     sr_data_t* data;
+-    auto res = sr_get_node(m_sess.get(), path.c_str(), 0, &data);
++    auto res = sr_get_node(m_sess.get(), path.c_str(), timeout.count(), &data);
+ 
+     throwIfError(res, "Session::getOneNode: Couldn't get '"s + path + "'", m_sess.get());
+ 
+-- 
+2.34.1
+

--- a/test/case/ietf_hardware/usb.py
+++ b/test/case/ietf_hardware/usb.py
@@ -7,12 +7,6 @@ import time
 import infamy.netconf as netconf
 from infamy.util import until,wait_boot
 
-def remove_config(target):
-    running = target.get_config_dict("/ietf-hardware:hardware")
-    new = copy.deepcopy(running)
-    new["hardware"].clear()
-    target.put_diff_dicts("ietf-hardware",running,new)
-
 with infamy.Test() as test:
     with test.step("Initialize"):
         env = infamy.Env(infamy.std_topology("1x1"))
@@ -88,7 +82,7 @@ with infamy.Test() as test:
             until(lambda: usb.get_usb_state(target, available[0]) == "unlocked")
 
     with test.step("Remove all hardware configuration"):
-        remove_config(target)
+        target.delete_xpath("/ietf-hardware:hardware/component")
 
     with test.step("Verify USB ports locked"):
         for port in available:
@@ -118,7 +112,7 @@ with infamy.Test() as test:
             until(lambda: usb.get_usb_state(target, port) == "unlocked")
 
     with test.step("Remove USB configuration, and reboot"):
-        remove_config(target)
+        target.delete_xpath("/ietf-hardware:hardware/component")
         target.copy("running", "startup")
         target.reboot()
         if wait_boot(target) == False:

--- a/test/case/ietf_hardware/usb.py
+++ b/test/case/ietf_hardware/usb.py
@@ -82,10 +82,9 @@ with infamy.Test() as test:
             until(lambda: usb.get_usb_state(target, available[0]) == "unlocked")
 
     with test.step("Remove all hardware configuration"):
-        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB")
-        target.delete_xpath(xpath)
-        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB2")
-        target.delete_xpath(xpath)
+        for port in available:
+            xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", port)
+            target.delete_xpath(xpath)
 
     with test.step("Verify USB ports locked"):
         for port in available:
@@ -115,10 +114,9 @@ with infamy.Test() as test:
             until(lambda: usb.get_usb_state(target, port) == "unlocked")
 
     with test.step("Remove USB configuration, and reboot"):
-        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB")
-        target.delete_xpath(xpath)
-        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB2")
-        target.delete_xpath(xpath)
+        for port in available:
+            xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", port)
+            target.delete_xpath(xpath)
         target.copy("running", "startup")
         target.reboot()
         if wait_boot(target) == False:

--- a/test/case/ietf_hardware/usb.py
+++ b/test/case/ietf_hardware/usb.py
@@ -82,7 +82,10 @@ with infamy.Test() as test:
             until(lambda: usb.get_usb_state(target, available[0]) == "unlocked")
 
     with test.step("Remove all hardware configuration"):
-        target.delete_xpath("/ietf-hardware:hardware/component")
+        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB")
+        target.delete_xpath(xpath)
+        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB2")
+        target.delete_xpath(xpath)
 
     with test.step("Verify USB ports locked"):
         for port in available:
@@ -112,7 +115,10 @@ with infamy.Test() as test:
             until(lambda: usb.get_usb_state(target, port) == "unlocked")
 
     with test.step("Remove USB configuration, and reboot"):
-        target.delete_xpath("/ietf-hardware:hardware/component")
+        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB")
+        target.delete_xpath(xpath)
+        xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", "USB2")
+        target.delete_xpath(xpath)
         target.copy("running", "startup")
         target.reboot()
         if wait_boot(target) == False:

--- a/test/case/ietf_interfaces/iface_phys_address.py
+++ b/test/case/ietf_interfaces/iface_phys_address.py
@@ -30,13 +30,9 @@ with infamy.Test() as test:
         assert mac == cmac
 
     with test.step(f"Remove custom MAC address"):
-        running = target.get_config_dict("/ietf-interfaces:interfaces")
-        new = copy.deepcopy(running)
-        for i in new["interfaces"]["interface"]:
-            if i["name"] == tport:
-                del i["phys-address"]
-                break
-        target.put_diff_dicts("ietf-interfaces", running, new)
+        xpath=target.get_iface_xpath(tport, "phys-address")
+        target.delete_xpath(xpath)
+
         until(lambda: iface.get_phys_address(target, tport) == pmac)
 
     test.succeed()

--- a/test/case/ietf_interfaces/ipv4_address.py
+++ b/test/case/ietf_interfaces/ipv4_address.py
@@ -40,17 +40,8 @@ with infamy.Test() as test:
         until(lambda: iface.address_exist(target, interface_name, new_ip_address, proto='static'))
 
     with test.step(f"Remove IPv4 addresses from {interface_name}"):
-        # Get current interface configuration
-        running = target.get_config_dict("/ietf-interfaces:interfaces")
-
-        new = copy.deepcopy(running)
-        for i in new["interfaces"]["interface"]:
-            if i["name"] == interface_name and "ipv4" in i:
-                del i["ipv4"]
-                break
-
-        target.put_diff_dicts("ietf-interfaces", running, new)
-
+        xpath=target.get_iface_xpath(interface_name, path="ietf-ip:ipv4")
+        target.delete_xpath(xpath)
     with test.step("Get updated IP addresses"):
         until(lambda: iface.address_exist(target, interface_name, new_ip_address) == False)
 

--- a/test/case/ietf_interfaces/vlan_ping.py
+++ b/test/case/ietf_interfaces/vlan_ping.py
@@ -64,10 +64,8 @@ with infamy.Test() as test:
         test_ping(hport,True)
 
     with test.step("Remove VLAN interface, and test again (should not be able to ping)"):
-        running = target.get_config_dict("/ietf-interfaces:interfaces")
-        new = copy.deepcopy(running)
-        new["interfaces"]["interface"] = [d for d in new["interfaces"]["interface"] if not (d["name"] == f"{tport}.10")]
-        target.put_diff_dicts("ietf-interfaces",running,new)
+        xpath=target.get_xpath("/ietf-interfaces:interfaces/interface", "name", f"{tport}.10")
+        target.delete_xpath(xpath)
         _, hport = env.ltop.xlate("host", "data")
         test_ping(hport,False)
 

--- a/test/case/ietf_routing/static_routing.py
+++ b/test/case/ietf_routing/static_routing.py
@@ -183,12 +183,6 @@ def config_target2(target, link):
         }
     })
 
-def config_remove_routes(target):
-    running = target.get_config_dict("/ietf-routing:routing")
-    new = copy.deepcopy(running)
-    new["routing"]["control-plane-protocols"].clear()
-    target.put_diff_dicts("ietf-routing",running,new)
-
 with infamy.Test() as test:
     with test.step("Initialize"):
         env = infamy.Env(infamy.std_topology("2x2"))
@@ -224,7 +218,7 @@ with infamy.Test() as test:
              ns0.must_reach("2001:db8:3c4d:200::1")
 
         with test.step("Remove static routes on dut1"):
-            config_remove_routes(target1);
+            target1.delete_xpath("/ietf-routing:routing/control-plane-protocols")
             parallel(until(lambda: route.ipv4_route_exist(target1, "192.168.200.1/32") == False),
                      until(lambda: route.ipv6_route_exist(target1, "2001:db8:3c4d:200::1/128") == False))
 

--- a/test/case/ietf_system/add_delete_user.py
+++ b/test/case/ietf_system/add_delete_user.py
@@ -55,13 +55,8 @@ with infamy.Test() as test:
         assert user_found, f"User {username} not found"
 
     with test.step(f"Delete user ({username} / {hashed_password})"):
-        running = target.get_config_dict("/ietf-system:system")
-        new = copy.deepcopy(running)
-        for userx in new["system"]["authentication"]["user"]:
-            if userx["name"] == username:
-                del new["system"]["authentication"]["user"][username]
-                break
-        target.put_diff_dicts("ietf-system", running, new)
+        xpath=target.get_xpath("/ietf-system:system/authentication/user", "name", username)
+        target.delete_xpath(xpath)
 
     with test.step(f"Verify erasure of user ({username} / {hashed_password})"):
         running = target.get_config_dict("/ietf-system:system")

--- a/test/case/ietf_system/timezone.py
+++ b/test/case/ietf_system/timezone.py
@@ -19,8 +19,7 @@ with infamy.Test() as test:
           })
 
     with test.step("Verify current time."):
-        root = target.get_dict("/ietf-system:system-state/clock",as_xml=True)
-        current_datetime = root.find('.//{urn:ietf:params:xml:ns:yang:ietf-system}current-datetime').text
+        current_datetime=target.get_current_time_with_offset()
         offset=current_datetime[-6:]
 
         assert(offset == "+08:00")

--- a/test/case/ietf_system/timezone_utc_offset.py
+++ b/test/case/ietf_system/timezone_utc_offset.py
@@ -18,8 +18,7 @@ with infamy.Test() as test:
           })
 
     with test.step("Verify current time."):
-        root = target.get_dict("/ietf-system:system-state/clock",as_xml=True)
-        current_datetime = root.find('.//{urn:ietf:params:xml:ns:yang:ietf-system}current-datetime').text
+        current_datetime=target.get_current_time_with_offset()
         offset=current_datetime[-6:]
 
         assert(offset == "+12:00")

--- a/test/case/ietf_system/user_admin.py
+++ b/test/case/ietf_system/user_admin.py
@@ -16,7 +16,7 @@ with infamy.Test() as test:
         target = env.attach("target", "mgmt")
         tgtssh = env.attach("target", "mgmt", "ssh")
         factory = env.get_password("target")
-        address = target.address()
+        address = target.get_mgmt_ip()
 
     with test.step("Add new user"):
         USER = "jacky"

--- a/test/case/infix_containers/container_basic.py
+++ b/test/case/infix_containers/container_basic.py
@@ -20,7 +20,7 @@ with infamy.Test() as test:
     with test.step("Set up topology and attach to target DUT"):
         env = infamy.Env(infamy.std_topology("1x2"))
         target = env.attach("target", "mgmt")
-        addr = target.address()
+        addr = target.get_mgmt_ip()
 
     with test.step(f"Create {NAME} container from bundled OCI image"):
         target.put_config_dict("infix-containers", {

--- a/test/case/infix_containers/container_basic.py
+++ b/test/case/infix_containers/container_basic.py
@@ -11,7 +11,7 @@ import infamy
 from   infamy.util import until
 
 def _verify(server):
-    url = infamy.Furl(f"http://[{server}]/index.html")
+    url = infamy.Furl(f"http://[{server}]:91/index.html")
     return url.check("It works")
 
 with infamy.Test() as test:
@@ -29,6 +29,7 @@ with infamy.Test() as test:
                     {
                         "name": f"{NAME}",
                         "image": f"oci-archive:{infamy.Container.IMAGE}",
+                        "command": "/usr/sbin/httpd -f -v -p 91",
                         "network": {
                             "host": True
                         }

--- a/test/case/infix_containers/container_basic.py
+++ b/test/case/infix_containers/container_basic.py
@@ -23,11 +23,6 @@ with infamy.Test() as test:
         addr = target.address()
 
     with test.step(f"Create {NAME} container from bundled OCI image"):
-        target.put_config_dict("infix-services", {
-            "web": {
-                "enabled": False
-            }
-        })
         target.put_config_dict("infix-containers", {
             "containers": {
                 "container": [

--- a/test/case/infix_containers/container_bridge.py
+++ b/test/case/infix_containers/container_bridge.py
@@ -24,12 +24,6 @@ with infamy.Test() as test:
     with test.step(f"Create {NAME} container from bundled OCI image"):
         _, ifname = env.ltop.xlate("target", "data")
         enc = base64.b64encode(BODY.encode('utf-8'))
-
-        target.put_config_dict("infix-services", {
-            "web": {
-                "enabled": False
-            }
-        })
         target.put_config_dict("ietf-interfaces", {
             "interfaces": {
                 "interface": [

--- a/test/case/infix_containers/container_bridge.py
+++ b/test/case/infix_containers/container_bridge.py
@@ -56,6 +56,7 @@ with infamy.Test() as test:
                     {
                         "name": f"{NAME}",
                         "image": f"oci-archive:{infamy.Container.IMAGE}",
+                        "command": "/usr/sbin/httpd -f -v -p 91",
                         "mount": [
                             {
                                 "name": "index.html",
@@ -67,7 +68,7 @@ with infamy.Test() as test:
                             "interface": [
                                 { "name": "docker0" }
                             ],
-                            "publish": [ "8080:80" ]
+                            "publish": [ "8080:91" ]
                         }
                     }
                 ]

--- a/test/case/infix_containers/container_phys.py
+++ b/test/case/infix_containers/container_phys.py
@@ -22,11 +22,6 @@ with infamy.Test() as test:
     with test.step(f"Create {NAME} container from bundled OCI image"):
         _, ifname = env.ltop.xlate("target", "data")
 
-        target.put_config_dict("infix-services", {
-            "web": {
-                "enabled": False
-            }
-        })
         target.put_config_dict("ietf-interfaces", {
             "interfaces": {
                 "interface": [

--- a/test/case/infix_containers/container_phys.py
+++ b/test/case/infix_containers/container_phys.py
@@ -13,7 +13,7 @@ with infamy.Test() as test:
     IMAGE = "curios-httpd-edge.tar.gz"
     DUTIP = "10.0.0.2"
     OURIP = "10.0.0.1"
-    URL   = f"http://{DUTIP}/index.html"
+    URL   = f"http://{DUTIP}:91/index.html"
 
     with test.step("Initialize"):
         env = infamy.Env(infamy.std_topology("1x2"))
@@ -44,6 +44,7 @@ with infamy.Test() as test:
                     {
                         "name": f"{NAME}",
                         "image": f"oci-archive:{infamy.Container.IMAGE}",
+                        "command": "/usr/sbin/httpd -f -v -p 91",
                         "network": {
                             "interface": [
                                 { "name": f"{ifname}" }

--- a/test/case/infix_containers/container_veth.py
+++ b/test/case/infix_containers/container_veth.py
@@ -21,12 +21,6 @@ with infamy.Test() as test:
 
     with test.step(f"Create {NAME} container from bundled OCI image"):
         _, ifname = env.ltop.xlate("target", "data")
-
-        target.put_config_dict("infix-services", {
-            "web": {
-                "enabled": False
-            }
-        })
         target.put_config_dict("ietf-interfaces", {
             "interfaces": {
                 "interface": [

--- a/test/case/infix_containers/container_veth.py
+++ b/test/case/infix_containers/container_veth.py
@@ -13,7 +13,7 @@ with infamy.Test() as test:
     IMAGE = "curios-httpd-edge.tar.gz"
     DUTIP = "10.0.0.2"
     OURIP = "10.0.0.1"
-    URL   = f"http://{DUTIP}/index.html"
+    URL   = f"http://{DUTIP}:91/index.html"
 
     with test.step("Initialize"):
         env = infamy.Env(infamy.std_topology("1x2"))
@@ -67,6 +67,7 @@ with infamy.Test() as test:
                     {
                         "name": f"{NAME}",
                         "image": f"oci-archive:{infamy.Container.IMAGE}",
+                        "command": "/usr/sbin/httpd -f -v -p 91",
                         "network": {
                             "interface": [
                                 { "name": f"{NAME}" }

--- a/test/case/meta/wait.py
+++ b/test/case/meta/wait.py
@@ -2,8 +2,12 @@
 
 import socket
 import time
-
+import requests
 import infamy, infamy.neigh
+import infamy.restconf as restconf
+import infamy.netconf as  netconf
+
+from requests.auth import HTTPBasicAuth
 
 def ll6ping(node):
     neigh = None
@@ -44,7 +48,8 @@ with infamy.Test() as test:
             retry = []
             for node in infixen:
                 neigh = ll6ping(node)
-                if neigh and netconf_syn(neigh):
+                password = env.ptop.get_password(node)
+                if neigh and netconf.netconf_syn(neigh) and restconf.restconf_reachable(neigh, password):
                     continue
 
                 retry.append(node)

--- a/test/case/misc/operational_all.py
+++ b/test/case/misc/operational_all.py
@@ -11,6 +11,6 @@ with infamy.Test() as test:
         target = env.attach("target", "mgmt")
 
     with test.step("Get all Operational data"):
-        target.get_data(as_xml=True)
+        target.get_data(parse=False)
 
     test.succeed()

--- a/test/case/misc/start_from_startup.py
+++ b/test/case/misc/start_from_startup.py
@@ -4,12 +4,6 @@ import infamy
 from infamy.util import wait_boot
 import copy
 
-def remove_config(target):
-    running = target.get_config_dict("/ietf-hardware:hardware")
-    new = copy.deepcopy(running)
-    new["hardware"].clear()
-    target.put_diff_dicts("ietf-hardware",running,new)
-
 with infamy.Test() as test:
     with test.step("Initialize"):
         env = infamy.Env(infamy.std_topology("1x1"))
@@ -21,7 +15,7 @@ with infamy.Test() as test:
                 "hostname": "test"
             }
         })
-        remove_config(target)
+        target.delete_xpath("/ietf-hardware:hardware/component")
         target.copy("running", "startup")
     with test.step("Reboot and wait for the unit to come back"):
         target.copy("running", "startup")
@@ -32,7 +26,6 @@ with infamy.Test() as test:
 
     with test.step("Verify hostname"):
         data = target.get_dict("/ietf-system:system/hostname")
-        print(data)
         assert(data["system"]["hostname"] == "test")
 
     test.succeed()

--- a/test/env
+++ b/test/env
@@ -181,6 +181,7 @@ if [ "$containerize" ]; then
 	 --cap-add=NET_ADMIN \
 	 --device=/dev/net/tun \
 	 --env PYTHONHASHSEED=${PYTHONHASHSEED:-$(shuf -i 0-$(((1 << 32) - 1)) -n 1)} \
+	 --env FORCE_PROTOCOL=${FORCE_PROTOCOL} \
 	 --env VIRTUAL_ENV_DISABLE_PROMPT=yes \
 	 --env PROMPT_DIRTRIM="$ixdir" \
 	 --env PS1="$(build_ps1)" \

--- a/test/env
+++ b/test/env
@@ -181,8 +181,8 @@ if [ "$containerize" ]; then
 	 --cap-add=NET_ADMIN \
 	 --device=/dev/net/tun \
 	 --env PYTHONHASHSEED=${PYTHONHASHSEED:-$(shuf -i 0-$(((1 << 32) - 1)) -n 1)} \
-	 --env FORCE_PROTOCOL=${FORCE_PROTOCOL} \
 	 --env VIRTUAL_ENV_DISABLE_PROMPT=yes \
+	 --env INFAMY_EXTRA_ARGS="$INFAMY_EXTRA_ARGS" \
 	 --env PROMPT_DIRTRIM="$ixdir" \
 	 --env PS1="$(build_ps1)" \
 	 --expose 9001-9010 --publish-all \
@@ -220,5 +220,8 @@ INFAMY_ARGS="$INFAMY_ARGS -y $envdir/yangdir"
 start_topology "$qenethdir" "$files"
 [ "$topology" ] && INFAMY_ARGS="$INFAMY_ARGS $topology"
 export INFAMY_ARGS
+if [ -n "$INFAMY_EXTRA_ARGS" ]; then
+	exec "$@" -o="$INFAMY_EXTRA_ARGS"
+fi
 
 exec "$@"

--- a/test/infamy/container.py
+++ b/test/infamy/container.py
@@ -8,7 +8,7 @@ class Container:
         self.system = target
 
     def _find(self, name):
-        oper = self.system.get_data("/infix-containers:containers/container")
+        oper = self.system.get_data("/infix-containers:containers")
         if not oper:
             return None
 
@@ -32,14 +32,5 @@ class Container:
         return False
 
     def action(self, name, act):
-        """Call NETCONF action 'type' on container 'name'"""
-        return self.system.call_action_dict("infix-containers", {
-            "containers": {
-                "container": [
-                    {
-                        "name": f"{name}",
-                        f"{act}": {}
-                    }
-                ]
-            }
-        })
+        xpath=self.system.get_xpath("/infix-containers:containers/container", "name", name, act)
+        return self.system.call_action(xpath)

--- a/test/infamy/env.py
+++ b/test/infamy/env.py
@@ -94,6 +94,7 @@ class Env(object):
                                                               mgmtip,
                                                               password),
                                    mapping=mapping,
+                                   yangdir=self.args.yangdir,
                                    factory_default=factory_default)
 
         raise Exception(f"Unsupported management procotol \"{protocol}\"")

--- a/test/infamy/iface.py
+++ b/test/infamy/iface.py
@@ -2,13 +2,6 @@
 Fetch interface status from remote device.
 """
 
-def _iface_xpath(iface, path=None):
-    """Compose complete XPath to a YANG node in /ietf-interfaces"""
-    xpath = f"/ietf-interfaces:interfaces/interface[name='{iface}']"
-    if path:
-        xpath.join(f"/{path}")
-    return xpath
-
 def _iface_extract_param(json_content, param):
     """Returns (extracted) value for parameter 'param'"""
     interfaces = json_content.get('interfaces')
@@ -24,11 +17,8 @@ def _iface_extract_param(json_content, param):
 
 def _iface_get_param(target, iface, param=None):
     """Fetch target dict for iface and extract param from JSON"""
-    try:
-        content = target.get_data(_iface_xpath(iface, param))
-        return _iface_extract_param(content, param)
-    except:
-        return None
+    content = target.get_data(target.get_iface_xpath(iface, param))
+    return _iface_extract_param(content, param)
 
 def interface_exist(target, iface):
     """Verify that the target interface exists"""
@@ -45,7 +35,14 @@ def address_exist(target, iface, address, prefix_length = 24, proto="dhcp"):
 
 def get_ipv4_address(target, iface):
     """Fetch interface IPv4 addresses from (operational status)"""
-    ipv4 = _iface_get_param(target, iface, "ipv4")
+    # The interface array is different in restconf/netconf, netconf has a keyed list but
+    # restconf has a numbered list, i think i read that this was a bug in rousette, but
+    # have not found it.
+    interface=target.get_iface(iface)
+    if interface is None:
+        raise "Interface not found"
+
+    ipv4 = interface.get("ipv4") or interface.get("ietf-ip:ipv4")
     if ipv4 is None or 'address' not in ipv4:
         return None
     return ipv4['address']
@@ -93,8 +90,18 @@ def print_all(target):
         print(f"Failed to get interfaces' status from target {target}")
 
 def exist_bridge_multicast_filter(target, group, iface, bridge):
-    bridge = _iface_get_param(target, bridge, "bridge")
-    for filter in bridge.get("multicast-filters", {}).get("multicast-filter", {}):
+    # The interface array is different in restconf/netconf, netconf has a keyed list but
+    # restconf has a numbered list, i think i read that this was a bug in rousette, but
+    # have not found it.
+    interface=target.get_iface(bridge)
+    if interface is None:
+        raise "Interface not found"
+
+    brif = interface.get("bridge") or interface.get("infix-interfaces:bridge")
+    if brif is None:
+        return False
+
+    for filter in brif.get("multicast-filters", {}).get("multicast-filter", {}):
         if filter.get("group") == group:
             for p in filter.get("ports"):
                 if p["port"] == iface:

--- a/test/infamy/netconf.py
+++ b/test/infamy/netconf.py
@@ -401,7 +401,7 @@ class Device(Transport):
         if interface is None:
             return None
 
-        # This really not required, it is due a bug in rousette.
+        # Restconf (rousette) address by id and netconf (netopper2) address by name
         return interface[iface]
 
     def delete_xpath(self, xpath):

--- a/test/infamy/restconf.py
+++ b/test/infamy/restconf.py
@@ -33,7 +33,7 @@ class Device(Transport):
         self.location=location
         self.url_base=f"https://[{location.host}]:{location.port}"
         self.restconf_url=f"{self.url_base}/restconf"
-        self.yang_url=f"{self.url_base}/yang/"
+        self.yang_url=f"{self.url_base}/yang"
         self.rpc_url=f"{self.url_base}/restconf/operations"
         self.headers={
             'Content-Type': 'application/yang-data+json',
@@ -66,7 +66,7 @@ class Device(Transport):
     def schema_exist(self, name, revision, yangdir):
         schema_name=f"{name}@{revision}.yang"
         schema_path=f"{yangdir}/{schema_name}"
-        return os.path.exists("{schema_path}")
+        return os.path.exists(schema_path)
 
     def _ly_bootstrap(self, yangdir):
         schemas=self.get_schemas_list()
@@ -80,7 +80,6 @@ class Device(Transport):
 
             if not any("submodule" in x and schema["name"] in x["submodule"] for x in schemas):
                 self.modules.update({schema["name"]: schema})
-            sys.stdout.write(f"Downloading YANG model {schema['name']} ...\r\033[K")
 
         print("YANG models downloaded.")
 
@@ -116,7 +115,6 @@ class Device(Transport):
         path=f"/ds/ietf-datastores:{datastore}"
         if not xpath is None:
             path=f"{path}/{xpath}"
-        path=quote(path)
         url=f"{self.restconf_url}{path}"
         return self._get_raw(url, parse)
 
@@ -256,7 +254,6 @@ class Device(Transport):
     def delete_xpath(self, xpath):
         """Delete XPath from running config"""
         path=f"/ds/ietf-datastores:running/{xpath}"
-        path=quote(path)
         url=f"{self.restconf_url}{path}"
         response=requests.delete(url, headers=self.headers, auth=self.auth, verify=False)
         response.raise_for_status()  # Raise an exception for HTTP errors

--- a/test/infamy/restconf.py
+++ b/test/infamy/restconf.py
@@ -3,11 +3,14 @@ import json
 import warnings
 import os
 import sys
+import libyang
 
 from requests.auth import HTTPBasicAuth
 from urllib.parse import quote
 from urllib3.exceptions import InsecureRequestWarning
 from dataclasses import dataclass
+from lxml import etree
+from infamy.transport import Transport
 
 # We know we have a self-signed certificate, silence warning about it
 warnings.simplefilter('ignore', InsecureRequestWarning)
@@ -20,15 +23,17 @@ class Location:
     username: str = "admin"
     port: int = 443
 
-class Device(object):
+class Device(Transport):
     def __init__(self,
                  location: Location,
                  mapping: dict,
                  yangdir: None | str = None,
                  factory_default = True):
         self.location = location
-        self.url = f"https://[{location.host}]:{location.port}/restconf"
-        self.yang_url = f"https://[{location.host}]:{location.port}/yang/"
+        self.url_base=f"https://[{location.host}]:{location.port}"
+        self.restconf_url = f"{self.url_base}/restconf"
+        self.yang_url = f"{self.url_base}/yang/"
+        self.rpc_url= f"{self.url_base}/restconf/operations"
         self.headers = {
             'Content-Type': 'application/yang-data+json',
             'Accept': 'application/yang-data+json'
@@ -36,132 +41,208 @@ class Device(object):
         self.auth = HTTPBasicAuth(location.username, location.password)
         self.modules = {}
 
+        self.lyctx = libyang.Context(yangdir)
+        self._ly_bootstrap(yangdir)
+        self._ly_init(yangdir)
+
         if factory_default:
             self.factory_default()
 
     def get_schemas_list(self):
-        data=self.get_datastore("operational", "/ietf-yang-library:modules-state")
-        self.modules = { m["name"] : m for m in data["ietf-yang-library:modules-state"]["module"] }
-        return data["ietf-yang-library:modules-state"]["module"]
+        data=self.get_operational("/ietf-yang-library:modules-state").print_dict()
+        return data["modules-state"]["module"]
 
-    def get_schema(self, schema_name, yangdir):
-        schema_url=f"{self.yang_url}/{schema_name}"
-        data=self.do_restconf(self.yang_url,schema_name)
-        # print(type(data))
+    def get_schema(self, name, revision, yangdir):
+        schema_name=f"{name}@{revision}.yang"
+        url=f"{self.yang_url}/{schema_name}"
+        data=self._get_raw(url=url, parse=False)
+
         sys.stdout.write(f"Downloading YANG model {schema_name} ...\r\033[K")
         data=data.decode('utf-8')
         with open(f"{yangdir}/{schema_name}", 'w') as json_file:
             json_file.write(data)
 
-    def schema_exist(self, schema_name, yangdir):
+    def schema_exist(self, name, revision, yangdir):
+        schema_name=f"{name}@{revision}.yang"
         schema_path=f"{yangdir}/{schema_name}"
         return os.path.exists("{schema_path}")
 
-    def get_mgmt_ip(self):
-        return self.location.host
+    def _ly_bootstrap(self, yangdir):
+        schemas = self.get_schemas_list()
+        for schema in schemas:
+            if not self.schema_exist(schema["name"], schema["revision"],yangdir):
+                self.get_schema(schema["name"], schema["revision"], yangdir)
+            if schema.get("submodule"):
+                for submodule in schema["submodule"]:
+                    if not self.schema_exist(submodule["name"], submodule["revision"],yangdir):
+                        self.get_schema(submodule["name"], submodule["revision"], yangdir)
 
-    def get_mgmt_iface(self):
-        return self.location.interface
+            if not any("submodule" in x and schema["name"] in x["submodule"] for x in schemas):
+                self.modules.update({schema["name"]: schema})
+            sys.stdout.write(f"Downloading YANG model {schema['name']} ...\r\033[K")
 
+        print("YANG models downloaded.")
 
-    def address(self):
-        """Return managment IP address used for NETCONF"""
-        return self.location.host
+    def _ly_init(self, yangdir):
+        lib = self.lyctx.load_module("ietf-yang-library")
+        ns = libyang.util.c2str(lib.cdata.ns)
 
-    def reachable(self):
-        neigh = ll6ping(self.location.interface, flags=["-w1", "-c1", "-L", "-n"])
-        return bool(neigh)
+        for ms in self.modules.values():
+            if ms["conformance-type"] != "implement":
+                continue
 
-    def do_restconf(self, url, path):
-        path = quote(path, safe="/:")
-        url = f"{url}/{path}"
-        try:
-            response = requests.get(url, headers=self.headers, auth=self.auth, verify=False)
-            response.raise_for_status()  # Raise an exception for HTTP errors
-            return response.content
-        except requests.exceptions.HTTPError as errh:
-            print("HTTP Error:", errh)
-        except requests.exceptions.ConnectionError as errc:
-            print("Error Connecting:", errc)
-        except requests.exceptions.Timeout as errt:
-            print("Timeout Error:", errt)
-        except Exception as err:
-            print("Unknown error", err)
+            mod = self.lyctx.load_module(ms["name"])
 
-    def get_datastore(self, datastore, xpath="", as_xml=False):
-        path = f"/ds/ietf-datastores:{datastore}/{xpath}"
-        path = quote(path, safe="/:")
-        url = f"{self.url}{path}"
-        try:
-            response = requests.get(url, headers=self.headers, auth=self.auth, verify=False)
-            response.raise_for_status()  # Raise an exception for HTTP errors
+            # TODO: ms["feature"] contains the list of enabled
+            # features, so ideally we should only enable the supported
+            # ones. However, features can depend on each other, so the
+            # naïve looping approach doesn't work.
+            mod.feature_enable_all()
+
+    def _get_raw(self, url, parse=True):
+        """Actually send a GET to RESTCONF server"""
+        response = requests.get(url, headers=self.headers, auth=self.auth, verify=False)
+        response.raise_for_status()  # Raise an exception for HTTP errors
+        if parse:
             data = response.json()
+            data=self.lyctx.parse_data_mem(json.dumps(data), "json", parse_only=True)
             return data
-        except requests.exceptions.HTTPError as errh:
-            print("HTTP Error:", errh)
-        except requests.exceptions.ConnectionError as errc:
-            print("Error Connecting:", errc)
-        except requests.exceptions.Timeout as errt:
-            print("Timeout Error:", errt)
-        except Exception as err:
-            print("Unknown error", err)
+        else:
+            return response.content
+
+    def get_datastore(self, datastore="operational" , xpath=""):
+        """Get a datastore"""
+        path = f"/ds/ietf-datastores:{datastore}"
+        if not xpath is None:
+            path=f"{path}/{xpath}"
+        path = quote(path, safe="/:")
+        url = f"{self.restconf_url}{path}"
+        return self._get_raw(url)
+
+    def get_running(self, xpath=None):
+        """Wrapper function to get running datastore"""
+        return self.get_datastore("running", xpath)
+
+    def get_operational(self, xpath=None):
+        """Wrapper function to get operational datastore"""
+        return self.get_datastore("operational", xpath)
+
+    def get_factory(self, xpath=None):
+        """Wrapper function to get factory defaults"""
+        return self.get_datastore("factory-default", xpath)
+
+    def post_datastore(self, datastore, data):
+        """Actually send a POST to RESTCONF server"""
+        response = requests.post(
+            f"{self.restconf_url}/ds/ietf-datastores:{datastore}/",
+            json=data,  # Directly pass the dictionary without using json.dumps
+            headers=self.headers,
+            auth=self.auth,
+            verify=False
+        )
+        response.raise_for_status()  # Raise an exception for HTTP errors
 
     def put_datastore(self, datastore, data):
-        try:
-            response = requests.put(
-                f"{self.url}/ds/ietf-datastores:{datastore}/",
-                json=data,  # Directly pass the dictionary without using json.dumps
-                headers=self.headers,
-                auth=self.auth,
-                verify=False
-            )
-            response.raise_for_status()  # Raise an exception for HTTP errors
-        except requests.exceptions.HTTPError as errh:
-            print("HTTP Error:", errh)
-        except requests.exceptions.ConnectionError as errc:
-            print("Error Connecting:", errc)
-        except requests.exceptions.Timeout as errt:
-            print("Timeout Error:", errt)
-        except requests.exceptions.RequestException as err:
-            print("Unknown error", err)
+        """Actually send a PUT to RESTCONF server"""
+        response = requests.put(
+            f"{self.restconf_url}/ds/ietf-datastores:{datastore}/",
+            json=data,  # Directly pass the dictionary without using json.dumps
+            headers=self.headers,
+            auth=self.auth,
+            verify=False
+        )
+        response.raise_for_status()  # Raise an exception for HTTP errors
 
     def get_config_dict(self, modname):
-        ds = self.get_datastore("running", modname)
+        """Get all configuration for module @modname as dictionary"""
+        ds=self.get_running(modname)
+        ds=json.loads(ds.print_mem("json", with_siblings=True, pretty=False))
         model, container = modname.split(":")
         for k, v in ds.items():
             return {container: v}
 
-    def merge_dicts(self, dict1, dict2):
-        merged = dict1.copy()  # Start with the first dictionary
-
-        for key, value in dict2.items():
-            if key in merged:
-                if isinstance(merged[key], dict) and isinstance(value, dict):
-                    # If both values are dictionaries, merge them recursively
-                    merged[key] = self.merge_dicts(merged[key], value)
-                else:
-                    # If they are not both dictionaries, overwrite the value from d2
-                    merged[key] = value
-
-        return merged
-
     def put_config_dict(self, modname, edit):
-        new = {}
-        for k, v in edit.items():
-            new[f"{modname}:{k}"] = v
+        """Add @edit to running config and put the whole configuration"""
+        running = self.get_running()
+        mod = self.lyctx.get_module(modname)
+        change = mod.parse_data_dict(edit, no_state=True, validate=False)
+        running.merge_module(change)
 
-        running = self.get_datastore("running")
-        running=self.merge_dicts(running, new)
+        return self.put_datastore("running", json.loads(running.print_mem("json", with_siblings=True, pretty=False)))
 
-        return self.put_datastore("running", running)
+    def call_rpc(self, rpc):
+        url=f"{self.rpc_url}/{rpc}"
+        """Actually send a POST to RESTCONF server"""
+        response = requests.post(
+            url,
+            headers=self.headers,
+            auth=self.auth,
+            verify=False
+        )
+        response.raise_for_status()  # Raise an exception for HTTP errors
+
+    def get_dict(self, xpath=None, as_xml=False):
+        """NETCONF compat function, just wraps get_data"""
+        return self.get_data(xpath, as_xml)
 
     def get_data(self, xpath=None, as_xml=False):
-        data=self.get_datastore("operational", xpath, as_xml)
+        """Get operational data"""
+        data=self.get_operational(xpath)
+        if as_xml:
+            data=data.print_mem("xml", with_siblings=True, pretty=False)
+            return etree.fromstring(data)
+        if xpath is None:
+            return data
+
+        data=json.loads(data.print_mem("json", with_siblings=True, pretty=False))
+
         for k,v in data.items():
             model, container = k.split(":")
-
+            break
         return {container: v}
 
+
+    def copy(self, source, target):
+        factory=self.get_datastore(source)
+        data = factory.print_mem("json", with_siblings=True, pretty=False)
+        self.put_datastore(target, json.loads(data))
+
+    def reboot(self):
+        self.call_rpc("ietf-system:system-restart")
+
     def factory_default(self):
-        factory=self.get_datastore("factory-default")
-        self.put_datastore("running", factory)
+        """Factory reset target"""
+        return self.copy("factory-default", "running")
+
+    def get_xpath(self,  xpath, key, value, path=None):
+        """Compose complete XPath to a YANG node"""
+        xpath=f"{xpath}={value}"
+
+        if not path is None:
+            xpath=f"{xpath}/{path}"
+
+        return xpath
+
+    def get_iface(self, iface):
+        """Fetch target dict for iface and extract param from JSON"""
+        content = self.get_data(self.get_iface_xpath(iface))
+        interface=content.get("interfaces", {}).get("interface", None)
+        if interface is None:
+            return None
+
+        # This is a bug in rousette, should be able to use the same code as NETCONF
+        return interface[0]
+
+    def get_iface_xpath(self, iface, path=None):
+        """Compose complete XPath to a YANG node in /ietf-interfaces"""
+        xpath = f"/ietf-interfaces:interfaces/interface"
+        return self.get_xpath(xpath, "", iface, path)
+
+    def delete_xpath(self, xpath):
+        """Delete XPath from running config"""
+        path = f"/ds/ietf-datastores:running/{xpath}"
+        path = quote(path, safe="/:")
+        url = f"{self.restconf_url}{path}"
+        response = requests.delete(url, headers=self.headers, auth=self.auth, verify=False)
+        response.raise_for_status()  # Raise an exception for HTTP errors
+        return True

--- a/test/infamy/restconf.py
+++ b/test/infamy/restconf.py
@@ -23,6 +23,23 @@ class Location:
     username: str = "admin"
     port: int = 443
 
+
+def restconf_reachable(neigh, password):
+    try:
+        headers={
+            'Content-Type': 'application/yang-data+json',
+            'Accept': 'application/yang-data+json'
+        }
+        url=f"https://[{neigh}]/restconf/data/ietf-system:system/hostname"
+        auth=HTTPBasicAuth("admin", password)
+        response=requests.get(url, headers=headers, auth=auth, verify=False)
+        print(f"{neigh} answers to TCP connections on port 443 (RESTCONF)")
+        if response.status_code==200:
+            return True
+    except:
+        return False
+
+    return False
 class Device(Transport):
     def __init__(self,
                  location: Location,

--- a/test/infamy/restconf.py
+++ b/test/infamy/restconf.py
@@ -290,7 +290,7 @@ class Device(Transport):
         if interface is None:
             return None
 
-        # This is a bug in rousette, should be able to use the same code as NETCONF
+        # Restconf (rousette) address by id and netconf (netopper2) address by name
         return interface[0]
 
     def delete_xpath(self, xpath):

--- a/test/infamy/topology.py
+++ b/test/infamy/topology.py
@@ -122,7 +122,8 @@ class Topology:
         n = self.dotg.get_node(node)
         b = n[0] if n else {}
         password=b.get("password")
-        return qstrip(password) if password is not None else None
+
+        return qstrip(password) if password is not None else "admin"
 
     def get_link(self, src, dst, flt=lambda _: True):
         es = self.g.get_edge_data(src, dst)

--- a/test/infamy/transport.py
+++ b/test/infamy/transport.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+from infamy.neigh import ll6ping
+
+class Transport(ABC):
+    """Common functions for NETCONF/RESTCONF"""
+
+    @abstractmethod
+    def get_data(self, xpath=None, as_xml=False):
+        pass
+    @abstractmethod
+    def get_config_dict(self, modname):
+        pass
+    @abstractmethod
+    def put_config_dict(self, modname, edit):
+        pass
+    @abstractmethod
+    def get_dict(self, xpath=None, as_xml=False):
+        pass
+    @abstractmethod
+    def get_xpath(self,  xpath, key, value, path=None):
+        pass
+    @abstractmethod
+    def get_iface(self, iface):
+        pass
+    @abstractmethod
+    def get_iface_xpath(self, iface, path=None):
+        pass
+    @abstractmethod
+    def delete_xpath(self, xpath):
+        pass
+    @abstractmethod
+    def copy(self, source, target):
+        pass
+    @abstractmethod
+    def reboot(self):
+        pass
+
+    def get_mgmt_ip(self):
+        """Return managment IP address used for RESTCONF"""
+        return self.location.host
+
+    def get_mgmt_iface(self):
+        """Return managment interface used for RESTCONF"""
+        return self.location.interface
+
+    def address(self):
+        """Return managment IP address used for RESTCONF"""
+        return self.location.host
+
+    def reachable(self):
+        """Check if the device reachable on ll6"""
+        neigh = ll6ping(self.location.interface, flags=["-w1", "-c1", "-L", "-n"])
+        return bool(neigh)

--- a/test/infamy/transport.py
+++ b/test/infamy/transport.py
@@ -5,7 +5,7 @@ class Transport(ABC):
     """Common functions for NETCONF/RESTCONF"""
 
     @abstractmethod
-    def get_data(self, xpath=None, as_xml=False):
+    def get_data(self, xpath=None, parse=True):
         pass
     @abstractmethod
     def get_config_dict(self, modname):
@@ -14,16 +14,10 @@ class Transport(ABC):
     def put_config_dict(self, modname, edit):
         pass
     @abstractmethod
-    def get_dict(self, xpath=None, as_xml=False):
+    def get_dict(self, xpath=None):
         pass
     @abstractmethod
     def get_xpath(self,  xpath, key, value, path=None):
-        pass
-    @abstractmethod
-    def get_iface(self, iface):
-        pass
-    @abstractmethod
-    def get_iface_xpath(self, iface, path=None):
         pass
     @abstractmethod
     def delete_xpath(self, xpath):
@@ -33,6 +27,16 @@ class Transport(ABC):
         pass
     @abstractmethod
     def reboot(self):
+        pass
+    @abstractmethod
+    def get_current_time_with_offset(self):
+        # This is needed since libyang is too nice and removes the original offset
+        pass
+    @abstractmethod
+    def get_iface_xpath(self, iface, path=None):
+        pass
+    @abstractmethod
+    def get_iface(self, iface): # Should be common, but is not due to bug in rousette
         pass
 
     def get_mgmt_ip(self):
@@ -51,3 +55,8 @@ class Transport(ABC):
         """Check if the device reachable on ll6"""
         neigh = ll6ping(self.location.interface, flags=["-w1", "-c1", "-L", "-n"])
         return bool(neigh)
+
+    def get_iface_xpath(self, iface, path=None):
+        """Compose complete XPath to a YANG node in /ietf-interfaces"""
+        xpath = f"/ietf-interfaces:interfaces/interface"
+        return self.get_xpath(xpath, "name", iface, path)

--- a/test/infamy/transport.py
+++ b/test/infamy/transport.py
@@ -33,6 +33,9 @@ class Transport(ABC):
         # This is needed since libyang is too nice and removes the original offset
         pass
     @abstractmethod
+    def call_action(self, xpath):
+        pass
+    @abstractmethod
     def get_iface_xpath(self, iface, path=None):
         pass
     @abstractmethod

--- a/test/infamy/transport.py
+++ b/test/infamy/transport.py
@@ -43,16 +43,12 @@ class Transport(ABC):
         pass
 
     def get_mgmt_ip(self):
-        """Return managment IP address used for RESTCONF"""
+        """Return managment IP address used for RESTCONF/NETCONF"""
         return self.location.host
 
     def get_mgmt_iface(self):
-        """Return managment interface used for RESTCONF"""
+        """Return managment interface used for RESTCONF/NETCONF"""
         return self.location.interface
-
-    def address(self):
-        """Return managment IP address used for RESTCONF"""
-        return self.location.host
 
     def reachable(self):
         """Check if the device reachable on ll6"""

--- a/test/infamy/util.py
+++ b/test/infamy/util.py
@@ -2,6 +2,7 @@ import time
 import threading
 import infamy.neigh
 import infamy.netconf as netconf
+import infamy.restconf as restconf
 
 class ParallelFn(threading.Thread):
     def __init__(self, group=None, target=None, name=None,
@@ -50,4 +51,6 @@ def wait_boot(target):
     if not neigh:
         return False
     until(lambda: netconf.netconf_syn(neigh) == True, attempts = 300)
+    until(lambda: restconf.restconf_reachable(neigh, target.location.password) == True, attempts = 300)
+
     return True


### PR DESCRIPTION
## Description
* Implement full netconf  compatibility when using restconf
* A lot of refactor in netconf to be able to include restconf in tests
* testing.md updated
* Add upstream bugfix for finit, rousette and sysrepo-cpp
## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [x] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

