### PR TITLE
Bump libyang, libnetconf2, sysrepo and netopeer2

### DIFF
--- a/patches/netopeer2/2.2.28/0001-Allow-factory-as-copy-from-only-in-rpc-copy-config.patch
+++ b/patches/netopeer2/2.2.28/0001-Allow-factory-as-copy-from-only-in-rpc-copy-config.patch
@@ -1,0 +1,27 @@
+From 1175168ef202c32ce07a674b0c14678c5c130274 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Thu, 22 Jun 2023 10:24:57 +0200
+Subject: [PATCH] Allow 'factory' as copy-from (only) in rpc copy-config
+Organization: Addiva Elektronik
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/netconf.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/netconf.c b/src/netconf.c
+index 840debb..fa778d5 100644
+--- a/src/netconf.c
++++ b/src/netconf.c
+@@ -332,6 +332,8 @@ np2srv_rpc_copyconfig_cb(sr_session_ctx_t *session, uint32_t UNUSED(sub_id), con
+         ds = SR_DS_STARTUP;
+     } else if (!strcmp(nodeset->dnodes[0]->schema->name, "candidate")) {
+         ds = SR_DS_CANDIDATE;
++    } else if (!strcmp(nodeset->dnodes[0]->schema->name, "factory")) {
++        ds = SR_DS_FACTORY_DEFAULT; /* only allowed as copy-from */
+     } else {
+         assert(!strcmp(nodeset->dnodes[0]->schema->name, "url"));
+ #ifdef NP2SRV_URL_CAPAB
+-- 
+2.34.1
+

--- a/patches/netopeer2/2.2.28/0002-disable-local-users.patch
+++ b/patches/netopeer2/2.2.28/0002-disable-local-users.patch
@@ -1,0 +1,27 @@
+diff --git a/scripts/common.sh b/scripts/common.sh
+index c3271de..86c4c44 100644
+--- a/scripts/common.sh
++++ b/scripts/common.sh
+@@ -29,7 +29,7 @@ LN2_MODULES=(
+ "ietf-tcp-server@2023-12-28.yang -e tcp-server-keepalives"
+ "ietf-tcp-client@2023-12-28.yang -e local-binding-supported -e tcp-client-keepalives"
+ "ietf-ssh-common@2023-12-28.yang -e transport-params"
+-"ietf-ssh-server@2023-12-28.yang -e local-users-supported -e local-user-auth-publickey -e local-user-auth-password -e local-user-auth-none"
++"ietf-ssh-server@2023-12-28.yang"
+ "ietf-tls-common@2023-12-28.yang -e tls10 -e tls11 -e tls12 -e tls13 -e hello-params"
+ "ietf-tls-server@2023-12-28.yang -e server-ident-x509-cert -e client-auth-supported -e client-auth-x509-cert"
+ "ietf-netconf-server@2023-12-28.yang -e ssh-listen -e tls-listen -e ssh-call-home -e tls-call-home -e central-netconf-server-supported"
+diff --git a/scripts/merge_config.sh b/scripts/merge_config.sh
+index 4b476d6..e588369 100755
+--- a/scripts/merge_config.sh
++++ b/scripts/merge_config.sh
+@@ -81,9 +81,6 @@ CONFIG="<netconf-server xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-server\
+                                 </public-key>
+                             </host-key>
+                         </server-identity>
+-                        <client-authentication>
+-                            ${USERS_CONFIG}
+-                        </client-authentication>
+                     </ssh-server-parameters>
+                 </ssh>
+             </endpoint>

--- a/patches/netopeer2/2.2.28/0003-UPSTREAM-maain-BUGFIX-clear-url-protocolos.patch
+++ b/patches/netopeer2/2.2.28/0003-UPSTREAM-maain-BUGFIX-clear-url-protocolos.patch
@@ -1,0 +1,20 @@
+commit 2a7478b93b9779b70e5565544c334381947c9e3f
+Author: Michal Vasko <mvasko@cesnet.cz>
+Date:   Mon Jul 1 13:01:35 2024 +0200
+
+    maain BUGFIX clear url protocolos
+    
+    Affects static reinitialization.
+
+diff --git a/src/main.c b/src/main.c
+index 92ab3de..a24f3bf 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -658,6 +658,7 @@ server_destroy(void)
+ 
+     /* free dynamic members */
+     free(np2srv.url_protocols);
++    np2srv.url_protocols = NULL;
+ }
+ 
+ /**

--- a/patches/netopeer2/2.2.28/0004-UPSTREAM-main-UPDATE-zero-the-whole-np2srv-struct.patch
+++ b/patches/netopeer2/2.2.28/0004-UPSTREAM-main-UPDATE-zero-the-whole-np2srv-struct.patch
@@ -1,0 +1,21 @@
+commit d1a99ae9f40e953b8967c83c2812b9d556093a3c
+Author: Michal Vasko <mvasko@cesnet.cz>
+Date:   Mon Jul 1 14:01:39 2024 +0200
+
+    main UPDATE zero the whole np2srv struct
+
+diff --git a/src/main.c b/src/main.c
+index a24f3bf..18d9078 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -658,7 +658,9 @@ server_destroy(void)
+ 
+     /* free dynamic members */
+     free(np2srv.url_protocols);
+-    np2srv.url_protocols = NULL;
++
++    /* zero */
++    memset(&np2srv, sizeof np2srv, 0);
+ }
+ 
+ /**

--- a/patches/netopeer2/2.2.28/0005-UPSTREAM-main-BUGFIX-wrong-param-order.patch
+++ b/patches/netopeer2/2.2.28/0005-UPSTREAM-main-BUGFIX-wrong-param-order.patch
@@ -1,0 +1,19 @@
+commit 7ec275a297ad62964b62fb44634da636fa1ac087
+Author: Michal Vasko <mvasko@cesnet.cz>
+Date:   Mon Jul 1 14:07:00 2024 +0200
+
+    main BUGFIX wrong param order
+
+diff --git a/src/main.c b/src/main.c
+index 18d9078..9baf76e 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -660,7 +660,7 @@ server_destroy(void)
+     free(np2srv.url_protocols);
+ 
+     /* zero */
+-    memset(&np2srv, sizeof np2srv, 0);
++    memset(&np2srv, 0, sizeof np2srv);
+ }
+ 
+ /**

--- a/patches/sysrepo/2.10.1/0001-sysrepo-plugind-add-support-for-running-in-foregroun.patch
+++ b/patches/sysrepo/2.10.1/0001-sysrepo-plugind-add-support-for-running-in-foregroun.patch
@@ -1,0 +1,71 @@
+From dcd594e7c7e2b47b489243ce823e58e6b674bea3 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Tue, 28 Mar 2023 10:37:53 +0200
+Subject: [PATCH 1/6] sysrepo-plugind: add support for running in foreground
+ with syslog
+Organization: Addiva Elektronik
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/executables/sysrepo-plugind.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/executables/sysrepo-plugind.c b/src/executables/sysrepo-plugind.c
+index a6a817cc..5baebec3 100644
+--- a/src/executables/sysrepo-plugind.c
++++ b/src/executables/sysrepo-plugind.c
+@@ -98,6 +98,7 @@ help_print(void)
+             "                       Change verbosity to a level (none, error, warning, info, debug) or\n"
+             "                       number (0, 1, 2, 3, 4).\n"
+             "  -d, --debug          Debug mode - is not daemonized and logs to stderr instead of syslog.\n"
++            "  -n, --foreground     Run in foreground and log to syslog.\n"
+             "  -P, --plugin-install <path>\n"
+             "                       Install a sysrepo-plugind plugin. The plugin is simply copied\n"
+             "                       to the designated plugin directory.\n"
+@@ -201,6 +202,8 @@ daemon_init(int debug, sr_log_level_t log_level)
+ 
+     if (debug) {
+         handle_signals();
++        if (debug < 0)
++            goto done;
+         sr_log_stderr(log_level);
+         return;
+     }
+@@ -241,6 +244,7 @@ daemon_init(int debug, sr_log_level_t log_level)
+         close(fd);
+     }
+ 
++done:
+     /* set verbosity */
+     sr_log_syslog("sysrepo-plugind", log_level);
+ }
+@@ -466,6 +470,7 @@ main(int argc, char **argv)
+         {"version",           no_argument,       NULL, 'V'},
+         {"verbosity",         required_argument, NULL, 'v'},
+         {"debug",             no_argument,       NULL, 'd'},
++        {"foreground",        no_argument,       NULL, 'n'},
+         {"plugin-install",    required_argument, NULL, 'P'},
+         {"pid-file",          required_argument, NULL, 'p'},
+         {"fatal-plugin-fail", no_argument,       NULL, 'f'},
+@@ -474,7 +479,7 @@ main(int argc, char **argv)
+ 
+     /* process options */
+     opterr = 0;
+-    while ((opt = getopt_long(argc, argv, "hVv:dP:p:f", options, NULL)) != -1) {
++    while ((opt = getopt_long(argc, argv, "hVv:dnP:p:f", options, NULL)) != -1) {
+         switch (opt) {
+         case 'h':
+             version_print();
+@@ -506,6 +511,9 @@ main(int argc, char **argv)
+         case 'd':
+             debug = 1;
+             break;
++        case 'n':
++            debug = -1;
++            break;
+         case 'P':
+             /* plugin-install */
+             if (get_plugins_dir(&plugins_dir)) {
+-- 
+2.34.1
+

--- a/patches/sysrepo/2.10.1/0002-Allow-SR_EV_DONE-to-return-any-error-to-sysrepocfg.patch
+++ b/patches/sysrepo/2.10.1/0002-Allow-SR_EV_DONE-to-return-any-error-to-sysrepocfg.patch
@@ -1,0 +1,152 @@
+From 2a826d77d83930b32f2bdcf32ef9c57c616ec526 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Tue, 7 May 2024 15:41:53 +0200
+Subject: [PATCH 2/6] Allow SR_EV_DONE to return any error to sysrepocfg
+Organization: Addiva Elektronik
+
+Importing a system configuration with sysrepocfg the model callbacks do
+their best to validate the configuration and prepare the transaction in
+SR_EV_CHANGE.  In cases when dealing with a complex system, like adding
+a route, address, or other change using iproute2, we may still get into
+trouble when actually sending off the transaction in SR_EV_DONE.
+
+If something does go wrong we'd like to know this by the exit code of
+sysrepocfg, not by inspecting logs or expected system state.
+
+This patch is a clumsy way of forcing the (first) error to bubble up to
+the surface and cause a non-zero exit code from sysrepocfg.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ src/shm_sub.c | 36 ++++++++++++++++++++++++++++--------
+ src/shm_sub.h |  2 +-
+ src/sysrepo.c |  2 +-
+ 3 files changed, 30 insertions(+), 10 deletions(-)
+
+diff --git a/src/shm_sub.c b/src/shm_sub.c
+index 0fbe0f0c..363883ab 100644
+--- a/src/shm_sub.c
++++ b/src/shm_sub.c
+@@ -1718,7 +1718,7 @@ cleanup:
+ 
+ sr_error_info_t *
+ sr_shmsub_change_notify_change_done(struct sr_mod_info_s *mod_info, const char *orig_name, const void *orig_data,
+-        uint32_t timeout_ms)
++        uint32_t timeout_ms, sr_error_info_t **cb_err_info)
+ {
+     sr_error_info_t *err_info = NULL;
+     struct sr_mod_info_mod_s *mod = NULL;
+@@ -1850,12 +1850,19 @@ sr_shmsub_change_notify_change_done(struct sr_mod_info_s *mod_info, const char *
+             sr_rwunlock(&nsub->sub_shm->lock, 0, SR_LOCK_WRITE, cid, __func__);
+             nsub->lock = SR_LOCK_NONE;
+ 
+-            /* we do not care about an error */
+-            sr_errinfo_free(&nsub->cb_err_info);
+-
+             SR_LOG_INF("EV ORIGIN: \"%s\" \"%s\" ID %" PRIu32 " priority %" PRIu32 " succeeded.",
+                     nsub->mod->ly_mod->name, sr_ev2str(SR_SUB_EV_DONE), nsub->mod->request_id, nsub->cur_priority);
+ 
++            /*
++             * unexpected critical error, merge and cleanup, let
++             * sysrepocfg caller handle undefined system state.
++             */
++            if (nsub->cb_err_info) {
++                sr_errinfo_merge(cb_err_info, nsub->cb_err_info);
++                nsub->cb_err_info = NULL;
++                goto cleanup;
++            }
++
+             nsub->pending_event = 0;
+         }
+     } while (1);
+@@ -3330,7 +3337,7 @@ sr_shmsub_change_listen_relock(sr_multi_sub_shm_t *multi_sub_shm, sr_lock_mode_t
+ sr_error_info_t *
+ sr_shmsub_change_listen_process_module_events(struct modsub_change_s *change_subs, sr_conn_ctx_t *conn)
+ {
+-    sr_error_info_t *err_info = NULL;
++    sr_error_info_t *err_info = NULL, *err_tmp;
+     uint32_t i, data_len = 0, valid_subscr_count;
+     char *data = NULL, *shm_data_ptr;
+     int ret = SR_ERR_OK, filter_valid;
+@@ -3458,6 +3465,11 @@ process_event:
+                 }
+                 break;
+             }
++        } else if (sub_info.event == SR_SUB_EV_DONE) {
++            if (ret && err_code == SR_ERR_OK) {
++                /* unexpected, callback actually failed, save for later. */
++                err_code = ret;
++            }
+         }
+ 
+         /* subscription processed this event */
+@@ -3490,6 +3502,11 @@ process_event:
+         }
+         break;
+     case SR_SUB_EV_DONE:
++        if (err_code) {
++            /* prepare unexepected error from session to be written to SHM */
++            sr_errinfo_new(&err_info, err_code, "Oups, error detected in SR_EV_DONE");
++        }
++        break;
+     case SR_SUB_EV_ABORT:
+         /* nothing to do */
+         break;
+@@ -3509,14 +3526,17 @@ process_event:
+ 
+     /* SUB WRITE URGE LOCK */
+     if (sr_shmsub_change_listen_relock(multi_sub_shm, SR_LOCK_WRITE_URGE, &sub_info, change_sub, change_subs->module_name,
+-            ret, filter_valid, ev_sess, &err_info)) {
++            ret,  filter_valid, ev_sess, &err_tmp)) {
++        if (err_tmp)
++            err_info = err_tmp;
+         goto cleanup;
+     }
+     sub_lock = SR_LOCK_WRITE_URGE;
+ 
+     /* finish event */
+-    if ((err_info = sr_shmsub_multi_listen_write_event(multi_sub_shm, valid_subscr_count, err_code, &shm_data_sub, data,
++    if ((err_tmp = sr_shmsub_multi_listen_write_event(multi_sub_shm, valid_subscr_count, err_code, &shm_data_sub, data,
+             data_len, change_subs->module_name, err_code ? "fail" : "success"))) {
++        err_info = err_tmp;
+         goto cleanup;
+     }
+ 
+@@ -4055,7 +4075,7 @@ finish_iter:
+             sr_errinfo_free(&cb_err_info);
+ 
+             /* publish "done" event */
+-            if ((err_info = sr_shmsub_change_notify_change_done(&mod_info, NULL, NULL, SR_CHANGE_CB_TIMEOUT))) {
++            if ((err_info = sr_shmsub_change_notify_change_done(&mod_info, NULL, NULL, SR_CHANGE_CB_TIMEOUT, &cb_err_info))) {
+                 goto cleanup_unlock;
+             }
+ 
+diff --git a/src/shm_sub.h b/src/shm_sub.h
+index 3056e4c5..460ad927 100644
+--- a/src/shm_sub.h
++++ b/src/shm_sub.h
+@@ -144,7 +144,7 @@ sr_error_info_t *sr_shmsub_change_notify_change(struct sr_mod_info_s *mod_info,
+  * @return err_info, NULL on success.
+  */
+ sr_error_info_t *sr_shmsub_change_notify_change_done(struct sr_mod_info_s *mod_info, const char *orig_name,
+-        const void *orig_data, uint32_t timeout_ms);
++        const void *orig_data, uint32_t timeout_ms, sr_error_info_t **cb_err_info);
+ 
+ /**
+  * @brief Notify about (generate) a change "abort" event.
+diff --git a/src/sysrepo.c b/src/sysrepo.c
+index 8778956b..35a1fd8c 100644
+--- a/src/sysrepo.c
++++ b/src/sysrepo.c
+@@ -3898,7 +3898,7 @@ store:
+     }
+ 
+     /* publish "done" event, all changes were applied */
+-    if ((err_info = sr_shmsub_change_notify_change_done(mod_info, orig_name, orig_data, timeout_ms))) {
++    if ((err_info = sr_shmsub_change_notify_change_done(mod_info, orig_name, orig_data, timeout_ms, cb_err_info))) {
+         goto cleanup;
+     }
+ 
+-- 
+2.34.1
+

--- a/patches/sysrepo/2.10.1/0003-Allow-to-copy-from-factory-default.patch
+++ b/patches/sysrepo/2.10.1/0003-Allow-to-copy-from-factory-default.patch
@@ -1,0 +1,26 @@
+From 89fdf6691229f8f0978ca9bb13fa0143e0e79dbd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mattias=20Walstr=C3=B6m?= <lazzer@gmail.com>
+Date: Wed, 8 May 2024 17:00:50 +0200
+Subject: [PATCH 3/6] Allow to copy from factory default
+Organization: Addiva Elektronik
+
+---
+ src/sysrepo.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/sysrepo.c b/src/sysrepo.c
+index 35a1fd8c..c15855e9 100644
+--- a/src/sysrepo.c
++++ b/src/sysrepo.c
+@@ -4146,7 +4146,7 @@ sr_copy_config(sr_session_ctx_t *session, const char *module_name, sr_datastore_
+     struct sr_mod_info_s mod_info;
+     const struct lys_module *ly_mod = NULL;
+ 
+-    SR_CHECK_ARG_APIRET(!session || !SR_IS_CONVENTIONAL_DS(src_datastore) || !SR_IS_CONVENTIONAL_DS(session->ds),
++    SR_CHECK_ARG_APIRET(!session || (!SR_IS_CONVENTIONAL_DS(src_datastore) && (src_datastore != SR_DS_FACTORY_DEFAULT)) || !SR_IS_CONVENTIONAL_DS(session->ds),
+             session, err_info);
+ 
+     if (src_datastore == session->ds) {
+-- 
+2.34.1
+

--- a/patches/sysrepo/2.10.1/0004-Add-z-switch-to-sysrepoctl-to-install-factory-config.patch
+++ b/patches/sysrepo/2.10.1/0004-Add-z-switch-to-sysrepoctl-to-install-factory-config.patch
@@ -1,0 +1,176 @@
+From c7cd85da2831a5c1476e6ebe60431b87382c74c8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mattias=20Walstr=C3=B6m?= <lazzer@gmail.com>
+Date: Mon, 6 May 2024 14:49:32 +0200
+Subject: [PATCH 4/6] Add -z switch to sysrepoctl to install factory config
+ from a json file
+Organization: Addiva Elektronik
+
+This to be able to load the yang modules during build time instead on boot.
+---
+ src/executables/sysrepoctl.c | 20 +++++++++++++--
+ src/lyd_mods.h               |  7 ++++++
+ src/sysrepo.c                | 49 ++++++++++++++++++++++++++++++++++++
+ src/sysrepo.h                | 10 +++++++-
+ 4 files changed, 83 insertions(+), 3 deletions(-)
+
+diff --git a/src/executables/sysrepoctl.c b/src/executables/sysrepoctl.c
+index b9680551..4cdba6a0 100644
+--- a/src/executables/sysrepoctl.c
++++ b/src/executables/sysrepoctl.c
+@@ -647,6 +647,7 @@ main(int argc, char **argv)
+         {"uninstall",       required_argument, NULL, 'u'},
+         {"change",          required_argument, NULL, 'c'},
+         {"update",          required_argument, NULL, 'U'},
++        {"factory-install", no_argument,       NULL, 'z'},
+         {"plugin-list",     no_argument,       NULL, 'L'},
+         {"plugin-install",  required_argument, NULL, 'P'},
+         {"search-dirs",     required_argument, NULL, 's'},
+@@ -671,7 +672,7 @@ main(int argc, char **argv)
+ 
+     /* process options */
+     opterr = 0;
+-    while ((opt = getopt_long(argc, argv, "hVli:u:c:U:LP:s:e:d:r:o:g:p:D:m:I:fv:", options, NULL)) != -1) {
++    while ((opt = getopt_long(argc, argv, "hVli:u:c:U:LP:s:e:d:r:o:g:p:D:m:I:fv:z:", options, NULL)) != -1) {
+         switch (opt) {
+         case 'h':
+             /* help */
+@@ -863,6 +864,15 @@ main(int argc, char **argv)
+                 goto cleanup;
+             }
+             break;
++        case 'z':
++		if (operation) {
++			error_print(0, "Operation already specified");
++			goto cleanup;
++		}
++		/* init-data */
++		operation = 'z';
++		data_path = optarg;
++		break;
+         case 'I':
+             /* init-data */
+             if (operation == 'i') {
+@@ -922,9 +932,15 @@ main(int argc, char **argv)
+             goto cleanup;
+         }
+     }
+-
+     /* perform the operation */
+     switch (operation) {
++    case 'z':
++        /* Install factory config for built-in modules */
++	if ((r = sr_install_factory_config(conn, data_path))) {
++            error_print(r, "Failed to install factory config");
++            goto cleanup;
++	}
++	break;
+     case 'l':
+         /* list */
+         if ((r = srctl_list(conn))) {
+diff --git a/src/lyd_mods.h b/src/lyd_mods.h
+index 1960bc06..a8ca5add 100644
+--- a/src/lyd_mods.h
++++ b/src/lyd_mods.h
+@@ -102,4 +102,11 @@ sr_error_info_t *sr_lydmods_change_chng_feature(const struct ly_ctx *ly_ctx, con
+ sr_error_info_t *sr_lydmods_change_chng_replay_support(const struct lys_module *ly_mod, int enable,
+         struct ly_set *mod_set, sr_conn_ctx_t *conn, struct lyd_node **sr_mods);
+ 
++/**
++ * @brief Add factory default data to built-in modules
++ * @param[in] ly_ctx Context to use for parsing SR data.
++ * @return err_info, NULL on success.
++ */
++sr_error_info_t *sr_lydmods_create_data(const struct ly_ctx *ly_ctx);
++
+ #endif
+diff --git a/src/sysrepo.c b/src/sysrepo.c
+index c15855e9..86d694e5 100644
+--- a/src/sysrepo.c
++++ b/src/sysrepo.c
+@@ -1631,6 +1631,55 @@ sr_free_int_install_mods(sr_int_install_mod_t *new_mods, uint32_t new_mod_count)
+     free(new_mods);
+ }
+ 
++API int
++sr_install_factory_config(sr_conn_ctx_t *conn, const char *factory_file) {
++    sr_error_info_t *err_info = NULL;
++    struct ly_ctx *new_ctx = NULL;
++    struct lyd_node *sr_mods = NULL;
++    int initialized = 0;
++    struct lyd_node *mod_data = NULL;
++    struct sr_data_update_s data_info = {0};
++
++    /* create new temporary context */
++    if ((err_info = sr_ly_ctx_init(conn, &new_ctx))) {
++        goto cleanup;
++    }
++
++    /* use temporary context to load current modules */
++    if ((err_info = sr_shmmod_ctx_load_modules(SR_CONN_MOD_SHM(conn), new_ctx, NULL))) {
++        goto cleanup;
++    }
++
++    if ((err_info = sr_lyd_parse_data(new_ctx, NULL, factory_file, LYD_JSON, LYD_PARSE_ONLY | LYD_PARSE_STRICT, 0, &mod_data))) {
++	    goto cleanup;
++    }
++    if ((err_info = sr_lyd_dup(mod_data, NULL, LYD_DUP_RECURSIVE, 1, &data_info.new.start))) {
++        goto cleanup;
++    }
++    if ((err_info = sr_lyd_dup(mod_data, NULL, LYD_DUP_RECURSIVE, 1, &data_info.new.run))) {
++        goto cleanup;
++    }
++     /* parse SR mods */
++    if ((err_info = sr_lydmods_parse(new_ctx, conn, &initialized, &sr_mods))) {
++            goto cleanup;
++    }
++    data_info.new.fdflt = mod_data;
++    mod_data = NULL;
++    if ((err_info = sr_lycc_store_data_if_differ(conn, new_ctx, sr_mods,  &data_info))) {
++	    goto cleanup;
++    }
++
++    /* update content ID and safely switch the context */
++    SR_CONN_MAIN_SHM(conn)->content_id = ly_ctx_get_modules_hash(new_ctx);
++    sr_conn_ctx_switch(conn, &new_ctx, NULL);
++cleanup:
++    ly_ctx_destroy(new_ctx);
++    sr_lycc_update_data_clear(&data_info);
++    lyd_free_siblings(sr_mods);
++    lyd_free_siblings(mod_data);
++    return sr_api_ret(NULL, err_info);
++}
++
+ API int
+ sr_install_module(sr_conn_ctx_t *conn, const char *schema_path, const char *search_dirs, const char **features)
+ {
+diff --git a/src/sysrepo.h b/src/sysrepo.h
+index 8a6a70b8..41c9e52b 100644
+--- a/src/sysrepo.h
++++ b/src/sysrepo.h
+@@ -34,7 +34,6 @@ extern "C" {
+ ////////////////////////////////////////////////////////////////////////////////
+ // Logging API
+ ////////////////////////////////////////////////////////////////////////////////
+-
+ /**
+  * @defgroup log_api Logging API
+  * @{
+@@ -708,6 +707,15 @@ int sr_get_module_info(sr_conn_ctx_t *conn, sr_data_t **sysrepo_data);
+  */
+ int sr_is_module_internal(const struct lys_module *ly_mod);
+ 
++/**
++ * @brief Install factory config for built-in modules from a JSON file
++ *
++ * @param[in] conn Connection to use.
++ * @param[in] conn File containing factory default data in JSON format
++ * @return Error code (::SR_ERR_OK on success).
++ */
++int sr_install_factory_config(sr_conn_ctx_t *conn, const char *factory_file);
++
+ /** @} schema */
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+-- 
+2.34.1
+

--- a/patches/sysrepo/2.10.1/0005-modinfo-BUGFIX-memory-leak.patch
+++ b/patches/sysrepo/2.10.1/0005-modinfo-BUGFIX-memory-leak.patch
@@ -1,0 +1,28 @@
+From 8181ce6caf5ee49e30a02db9695647bd7bc73838 Mon Sep 17 00:00:00 2001
+From: Michal Vasko <mvasko@cesnet.cz>
+Date: Tue, 2 Jul 2024 12:11:30 +0200
+Subject: [PATCH 5/6] modinfo BUGFIX memory leak
+Organization: Addiva Elektronik
+
+---
+ src/modinfo.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/modinfo.c b/src/modinfo.c
+index 949c321b..9edb4498 100644
+--- a/src/modinfo.c
++++ b/src/modinfo.c
+@@ -1042,6 +1042,10 @@ sr_xpath_oper_data_get(struct sr_mod_info_mod_s *mod, const char *xpath, const c
+ cleanup:
+     lyd_free_tree(parent_dup);
+     free(parent_path);
++    if (err_info) {
++        lyd_free_all(*oper_data);
++        *oper_data = NULL;
++    }
+     return err_info;
+ }
+ 
+-- 
+2.34.1
+

--- a/patches/sysrepo/2.10.1/0006-sub-ntf-BUGFIX-proper-invalid-FD-check.patch
+++ b/patches/sysrepo/2.10.1/0006-sub-ntf-BUGFIX-proper-invalid-FD-check.patch
@@ -1,0 +1,26 @@
+From 3d297a0305e35007c4e16eb729025a0e58a0bcd2 Mon Sep 17 00:00:00 2001
+From: Michal Vasko <mvasko@cesnet.cz>
+Date: Fri, 28 Jun 2024 14:10:25 +0200
+Subject: [PATCH 6/6] sub ntf BUGFIX proper invalid FD check
+Organization: Addiva Elektronik
+
+---
+ src/utils/subscribed_notifications.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/utils/subscribed_notifications.c b/src/utils/subscribed_notifications.c
+index 0055f10a..a0694d04 100644
+--- a/src/utils/subscribed_notifications.c
++++ b/src/utils/subscribed_notifications.c
+@@ -930,7 +930,7 @@ srsn_read_dispatch_add(int fd, void *cb_data)
+ {
+     sr_error_info_t *err_info = NULL;
+ 
+-    SR_CHECK_ARG_APIRET(!fd, NULL, err_info);
++    SR_CHECK_ARG_APIRET(fd < 0, NULL, err_info);
+ 
+     /* add into the pollfd structure */
+     err_info = srsn_dispatch_add(fd, cb_data);
+-- 
+2.34.1
+

--- a/src/confd/yang/confd.inc
+++ b/src/confd/yang/confd.inc
@@ -43,7 +43,6 @@ MODULES=(
 	"ietf-netconf@2013-09-29.yang -e writable-running -e candidate -e rollback-on-error -e validate -e startup -e url -e xpath -e confirmed-commit"
 	"ietf-truststore@2023-12-28.yang -e central-truststore-supported -e certificates"
 	"ietf-keystore@2023-12-28.yang -e central-keystore-supported -e inline-definitions-supported -e asymmetric-keys -e symmetric-keys"
-	"ietf-ssh-server@2023-12-28.yang -e local-user-auth-password -e local-user-auth-publickey"
 	"ietf-tls-server@2023-12-28.yang -e server-ident-raw-public-key -e server-ident-x509-cert"
 	"ietf-restconf@2017-01-26.yang"
 	"infix-interfaces@2024-01-15.yang -e vlan-filtering"


### PR DESCRIPTION
For netopeer2 we need to patch away local-users, since if it is enabled netopeer2 requires all users that should be allowed to use netconf to also be configured in ietf-netconf-server.

Also add some upstream patches.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->


## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

