### PR TITLE
uboot: Support overriding the interface used for netbooting Infix

### DIFF
--- a/board/common/uboot/scripts/ixpreboot.sh
+++ b/board/common/uboot/scripts/ixpreboot.sh
@@ -33,7 +33,7 @@ for tgt in "${boot_targets}"; do
 	setexpr ixmenu_n ${ixmenu_n} + 1
 
 	if load ${devtype} ${devnum}:${auxpart} ${loadaddr} /uboot.env; then
-	    env import -b ${loadaddr} ${filesize} BOOT_ORDER DEBUG
+	    env import -b ${loadaddr} ${filesize} BOOT_ORDER DEBUG ethact
 	fi
 
 	if test -n "${DEBUG}"; then


### PR DESCRIPTION
For systems with multiple paths to the network, different situations may call for different paths to be used. Therefore, allow the user to override the active interface via the environment on the auxiliary partition.

The default (defined the bootloader's device tree) is still used in cases when nothing else is specified in the environment.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

