### PR TITLE
infamy: Refactor xpath handling between restconf and netconf implment…

### DIFF
--- a/test/case/ietf_hardware/usb.py
+++ b/test/case/ietf_hardware/usb.py
@@ -83,8 +83,7 @@ with infamy.Test() as test:
 
     with test.step("Remove all hardware configuration"):
         for port in available:
-            xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", port)
-            target.delete_xpath(xpath)
+            target.delete_xpath(f"/ietf-hardware:hardware/component[name='{port}']")
 
     with test.step("Verify USB ports locked"):
         for port in available:
@@ -115,8 +114,7 @@ with infamy.Test() as test:
 
     with test.step("Remove USB configuration, and reboot"):
         for port in available:
-            xpath=target.get_xpath("/ietf-hardware:hardware/component", "name", port)
-            target.delete_xpath(xpath)
+            target.delete_xpath(f"/ietf-hardware:hardware/component[name='{port}']")
         target.copy("running", "startup")
         target.reboot()
         if wait_boot(target) == False:

--- a/test/case/ietf_interfaces/iface_phys_address.py
+++ b/test/case/ietf_interfaces/iface_phys_address.py
@@ -30,7 +30,7 @@ with infamy.Test() as test:
         assert mac == cmac
 
     with test.step(f"Remove custom MAC address"):
-        xpath=target.get_iface_xpath(tport, "phys-address")
+        xpath=iface.get_iface_xpath(tport, "phys-address")
         target.delete_xpath(xpath)
 
         until(lambda: iface.get_phys_address(target, tport) == pmac)

--- a/test/case/ietf_interfaces/ipv4_address.py
+++ b/test/case/ietf_interfaces/ipv4_address.py
@@ -40,8 +40,7 @@ with infamy.Test() as test:
         until(lambda: iface.address_exist(target, interface_name, new_ip_address, proto='static'))
 
     with test.step(f"Remove IPv4 addresses from {interface_name}"):
-        xpath=target.get_iface_xpath(interface_name, path="ietf-ip:ipv4")
-        target.delete_xpath(xpath)
+        target.delete_xpath(f"/ietf-interfaces:interfaces/interface[name='{interface_name}']/ietf-ip:ipv4")
     with test.step("Get updated IP addresses"):
         until(lambda: iface.address_exist(target, interface_name, new_ip_address) == False)
 

--- a/test/case/ietf_interfaces/vlan_ping.py
+++ b/test/case/ietf_interfaces/vlan_ping.py
@@ -64,8 +64,7 @@ with infamy.Test() as test:
         test_ping(hport,True)
 
     with test.step("Remove VLAN interface, and test again (should not be able to ping)"):
-        xpath=target.get_xpath("/ietf-interfaces:interfaces/interface", "name", f"{tport}.10")
-        target.delete_xpath(xpath)
+        target.delete_xpath(f"/ietf-interfaces:interfaces/interface[name='{tport}.10']")
         _, hport = env.ltop.xlate("host", "data")
         test_ping(hport,False)
 

--- a/test/case/ietf_system/add_delete_user.py
+++ b/test/case/ietf_system/add_delete_user.py
@@ -55,8 +55,7 @@ with infamy.Test() as test:
         assert user_found, f"User {username} not found"
 
     with test.step(f"Delete user ({username} / {hashed_password})"):
-        xpath=target.get_xpath("/ietf-system:system/authentication/user", "name", username)
-        target.delete_xpath(xpath)
+        target.delete_xpath(f"/ietf-system:system/authentication/user[name='{username}']")
 
     with test.step(f"Verify erasure of user ({username} / {hashed_password})"):
         running = target.get_config_dict("/ietf-system:system")

--- a/test/infamy/container.py
+++ b/test/infamy/container.py
@@ -32,5 +32,4 @@ class Container:
         return False
 
     def action(self, name, act):
-        xpath=self.system.get_xpath("/infix-containers:containers/container", "name", name, act)
-        return self.system.call_action(xpath)
+        return self.system.call_action(f"/infix-containers:containers/container[name='{name}']/{act}")

--- a/test/infamy/iface.py
+++ b/test/infamy/iface.py
@@ -2,6 +2,13 @@
 Fetch interface status from remote device.
 """
 
+def get_iface_xpath(iface, path=None):
+    """Compose complete XPath to a YANG node in /ietf-interfaces"""
+    xpath=f"/ietf-interfaces:interfaces/interface[name='{iface}']"
+    if not path is None:
+        xpath=f"{xpath}/{path}"
+    return xpath
+
 def _iface_extract_param(json_content, param):
     """Returns (extracted) value for parameter 'param'"""
     interfaces = json_content.get('interfaces')
@@ -17,7 +24,7 @@ def _iface_extract_param(json_content, param):
 
 def _iface_get_param(target, iface, param=None):
     """Fetch target dict for iface and extract param from JSON"""
-    content = target.get_data(target.get_iface_xpath(iface, param))
+    content = target.get_data(get_iface_xpath(iface, param))
     return _iface_extract_param(content, param)
 
 def interface_exist(target, iface):

--- a/test/infamy/netconf.py
+++ b/test/infamy/netconf.py
@@ -15,6 +15,7 @@ import libyang
 import lxml
 import netconf_client.connect
 import netconf_client.ncclient
+import infamy.iface as iface
 from infamy.transport import Transport
 from netconf_client.error import RpcError
 
@@ -381,31 +382,19 @@ class Device(Transport):
         with open(outdir+"/"+schema["filename"], "w") as f:
             f.write(data.schema)
 
-    def get_xpath(self, xpath, key, value, path=None):
-        """Compose complete XPath to a YANG node in /ietf-interfaces"""
-        xpath = f"{xpath}[{key}='{value}']"
-        if not path is None:
-            xpath=f"{xpath}/{path}"
-        return xpath
-
-    def get_iface_xpath(self, iface, path=None):
-        """Compose complete XPath to a YANG node in /ietf-interfaces"""
-        xpath = f"/ietf-interfaces:interfaces/interface"
-        return self.get_xpath(xpath, "name", iface, path)
-
-    def get_iface(self, iface):
+    def get_iface(self, name):
         """Fetch target dict for iface and extract param from JSON"""
-        content = self.get_data(self.get_iface_xpath(iface))
+        content = self.get_data(iface.get_iface_xpath(name))
         interface=content.get("interfaces", {}).get("interface", None)
 
         if interface is None:
             return None
 
         # Restconf (rousette) address by id and netconf (netopper2) address by name
-        return interface[iface]
+        return interface[name]
 
     def delete_xpath(self, xpath):
-        # Split out the model and the container from xpath
+        # Split out the model and the container from xpath'
         pattern = r"^/(?P<module>[^:]+):(?P<path>[^/]+)"
         match = re.search(pattern, xpath)
         module = match.group('module')

--- a/test/infamy/transport.py
+++ b/test/infamy/transport.py
@@ -17,9 +17,6 @@ class Transport(ABC):
     def get_dict(self, xpath=None):
         pass
     @abstractmethod
-    def get_xpath(self,  xpath, key, value, path=None):
-        pass
-    @abstractmethod
     def delete_xpath(self, xpath):
         pass
     @abstractmethod
@@ -34,9 +31,6 @@ class Transport(ABC):
         pass
     @abstractmethod
     def call_action(self, xpath):
-        pass
-    @abstractmethod
-    def get_iface_xpath(self, iface, path=None):
         pass
     @abstractmethod
     def get_iface(self, iface): # Should be common, but is not due to bug in rousette
@@ -54,8 +48,3 @@ class Transport(ABC):
         """Check if the device reachable on ll6"""
         neigh = ll6ping(self.location.interface, flags=["-w1", "-c1", "-L", "-n"])
         return bool(neigh)
-
-    def get_iface_xpath(self, iface, path=None):
-        """Compose complete XPath to a YANG node in /ietf-interfaces"""
-        xpath = f"/ietf-interfaces:interfaces/interface"
-        return self.get_xpath(xpath, "name", iface, path)


### PR DESCRIPTION
Previous xpath may or may not been an xpath, we still called it xpath. Remove the obscure function get_xpath() and instead transform to a URI in restconf.py

This fix issue #490

All tests run with restconf:
<pre>

o Execution
`-- o 0001-all.yaml
    |-- o 0002-reproducible.py
    |-- o 0003-wait.py
    |-- o 0004-Misc tests
    |   `-- o 0005-operational_all.py
    |-- o 0006-ietf-system
    |   |-- o 0007-hostname.py
    |   |-- o 0008-add_delete_user.py
    |   |-- o 0009-user_admin.py
    |   |-- o 0010-timezone.py
    |   `-- o 0011-timezone_utc_offset.py
    |-- o 0012-ietf-interfaces
    |   |-- o 0013-vlan_ping.py
    |   |-- o 0014-ipv4_address.py
    |   |-- o 0015-ipv6_address.py
    |   |-- o 0016-iface_phys_address.py
    |   |-- o 0017-iface_status.py
    |   `-- o 0018-routing_basic.py
    |-- o 0019-infix-interfaces
    |   |-- o 0020-bridge_basic.py
    |   |-- o 0021-bridge_veth.py
    |   |-- o 0022-dual_bridge.py
    |   |-- o 0023-bridge_vlan.py
    |   |-- o 0024-ipv4_autoconf.py
    |   |-- o 0025-bridge_fwd_sgl_dut.py
    |   |-- o 0026-bridge_fwd_dual_dut.py
    |   |-- o 0027-bridge_vlan_separation.py
    |   |-- o 0028-igmp_basic.py
    |   |-- o 0029-igmp_vlan.py
    |   |-- o 0030-static_multicast_filters.py
    |   `-- o 0031-vlan_qos.py
    |-- o 0032-ietf-routing
    |   |-- o 0033-static_routing.py
    |   |-- o 0034-ospf_basic.py
    |   |-- o 0035-ospf_unnumbered_interface.py
    |   `-- o 0036-ospf_multiarea.py
    |-- o 0037-infix-containers
    |   |-- o 0038-container_basic.py
    |   |-- o 0039-container_bridge.py
    |   |-- o 0040-container_phys.py
    |   `-- o 0041-container_veth.py
    |-- o 0042-infix-dhcp
    |   |-- o 0043-dhcp_basic.py
    |   |-- o 0044-dhcp_router.py
    |   `-- o 0045-dhcp_routes.py
    `-- o 0046-ietf-hardware
        `-- o 0047-usb.py
</pre>
All tests with netconf:
<pre>
o Execution
`-- o 0001-all.yaml
    |-- o 0002-reproducible.py
    |-- o 0003-wait.py
    |-- o 0004-Misc tests
    |   `-- o 0005-operational_all.py
    |-- o 0006-ietf-system
    |   |-- o 0007-hostname.py
    |   |-- o 0008-add_delete_user.py
    |   |-- o 0009-user_admin.py
    |   |-- o 0010-timezone.py
    |   `-- o 0011-timezone_utc_offset.py
    |-- o 0012-ietf-interfaces
    |   |-- o 0013-vlan_ping.py
    |   |-- o 0014-ipv4_address.py
    |   |-- o 0015-ipv6_address.py
    |   |-- o 0016-iface_phys_address.py
    |   |-- o 0017-iface_status.py
    |   `-- o 0018-routing_basic.py
    |-- o 0019-infix-interfaces
    |   |-- o 0020-bridge_basic.py
    |   |-- o 0021-bridge_veth.py
    |   |-- o 0022-dual_bridge.py
    |   |-- o 0023-bridge_vlan.py
    |   |-- o 0024-ipv4_autoconf.py
    |   |-- o 0025-bridge_fwd_sgl_dut.py
    |   |-- o 0026-bridge_fwd_dual_dut.py
    |   |-- o 0027-bridge_vlan_separation.py
    |   |-- o 0028-igmp_basic.py
    |   |-- o 0029-igmp_vlan.py
    |   |-- o 0030-static_multicast_filters.py
    |   `-- o 0031-vlan_qos.py
    |-- o 0032-ietf-routing
    |   |-- o 0033-static_routing.py
    |   |-- o 0034-ospf_basic.py
    |   |-- o 0035-ospf_unnumbered_interface.py
    |   `-- o 0036-ospf_multiarea.py
    |-- o 0037-infix-containers
    |   |-- o 0038-container_basic.py
    |   |-- o 0039-container_bridge.py
    |   |-- o 0040-container_phys.py
    |   `-- o 0041-container_veth.py
    |-- o 0042-infix-dhcp
    |   |-- o 0043-dhcp_basic.py
    |   |-- o 0044-dhcp_router.py
    |   `-- o 0045-dhcp_routes.py
    `-- o 0046-ietf-hardware
        `-- o 0047-usb.py
</pre>
