### PR TITLE
Increase robustness of operational datastore

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -256,13 +256,20 @@ the whole suite) with identical topology mappings:
 
     $ make PYTHONHASHSEED=3773822171 INFIX_TESTS=case/ietf_system/hostname.py test
 
-### Determinstic use of communication protocol (NETCONF/RESTCONF)
+### Deterministic Transport Protocol
 
-By default the protocol will be chosen randomly. If you supply a
-`PYTHONHASHSEED` as described above, you will get the same protocol
-chosen. If you want to choose the communcation protocol:
+By default, the communication transport protocol (NETCONF/RESTCONF) is
+chosen randomly.  If you supply a `PYTHONHASHSEED` as described above,
+you get the same protocol used for that hash.  But if you want to choose
+the protocol, add extra arguments to Infamy:
 
     $ make INFAMY_EXTRA_ARGS="--transport=restconf" INFIX_TESTS=case/ietf_system/hostname.py test
+
+or, when running interactively:
+
+    $ make test-sh
+    09:08:17 infamy0:test # ./9pm/9pm.py -o "--transport=restconf" case/ietf_system/hostname.py
+
 
 [9PM]:    https://github.com/rical/9pm
 [Qeneth]: https://github.com/wkz/qeneth

--- a/src/statd/python/yanger/yanger.py
+++ b/src/statd/python/yanger/yanger.py
@@ -528,7 +528,7 @@ def add_container(containers):
 
 
 def get_brport_multicast(ifname):
-    data = run_json_cmd(['mctl', 'show', 'igmp', 'json'], "bridge-mdb.json")
+    data = run_json_cmd(['mctl', 'show', 'igmp', 'json'], "igmp-status.json")
     multicast = {}
 
     if ifname in data.get('fast-leave-ports', []):

--- a/src/statd/python/yanger/yanger.py
+++ b/src/statd/python/yanger/yanger.py
@@ -851,7 +851,12 @@ def main():
 
     # Set up syslog output for critical errors to aid debugging
     logger = logging.getLogger('yanger')
-    log = logging.handlers.SysLogHandler(address='/dev/log')
+    if os.path.exists('/dev/log'):
+        log = logging.handlers.SysLogHandler(address='/dev/log')
+    else:
+        # Use /dev/null as a fallback for unit tests
+        log = logging.FileHandler('/dev/null')
+
     fmt = logging.Formatter('%(name)s[%(process)d]: %(message)s')
     log.setFormatter(fmt)
     logger.setLevel(logging.INFO)

--- a/test/env
+++ b/test/env
@@ -50,6 +50,11 @@ usage: test/env [<OPTS>] -f <IMAGE> -q <QENETH-DIR> <COMMAND> [<ARGS>...]
       resulting topology is used as the default physical topology when
       running tests
 
+    -r
+      Use random container names instead of "infamyN".  Useful for the
+      unit tests running in CI environments which may see occasional
+      name clashes for "infamy0" due to race conditions.
+
     -t <TOPOLOGY>
       Rather than starting a qeneth network, attach to this existing
       topology. If the command is containerized, it will be launched
@@ -91,6 +96,11 @@ name()
     nm=infamy
     id=0
 
+    if [ -n "$random" ]; then
+	# Let podman/docker allocate random hostname and container name
+	return
+    fi
+
     names=$($(runner) ps -f name='infamy.*' --format '{{.Names}}')
     while true; do
 	name="$nm$id"
@@ -109,7 +119,7 @@ name()
 	break;
     done
 
-    echo "$name"
+    echo "--hostname $name --name $name"
 }
 
 # Global options
@@ -117,7 +127,7 @@ containerize=yes
 [ -c /dev/kvm ] && kvm="--device=/dev/kvm"
 files=
 
-while getopts "cCDf:hiKp:q:t:" opt; do
+while getopts "cCDf:hiKp:q:rt:" opt; do
     case ${opt} in
 	c)
 	    $(runner) image prune -af
@@ -149,6 +159,9 @@ while getopts "cCDf:hiKp:q:t:" opt; do
 	q)
 	    qenethdir="$OPTARG"
 	    network="--sysctl net.ipv6.conf.all.disable_ipv6=0"
+	    ;;
+	r)
+	    random=true
 	    ;;
 	t)
 	    topology="$OPTARG"
@@ -186,8 +199,7 @@ if [ "$containerize" ]; then
 	 --env PROMPT_DIRTRIM="$ixdir" \
 	 --env PS1="$(build_ps1)" \
 	 --expose 9001-9010 --publish-all \
-	 --hostname "$(name)" \
-	 --name "$(name)" \
+	 $(name) \
 	 $interactive \
 	 --rm \
 	 --security-opt seccomp=unconfined \

--- a/test/infamy/container.py
+++ b/test/infamy/container.py
@@ -1,4 +1,7 @@
 """Manage Infix containers"""
+import time
+from infamy.util import warn
+
 
 class Container:
     """Helper methods"""
@@ -32,4 +35,14 @@ class Container:
         return False
 
     def action(self, name, act):
-        return self.system.call_action(f"/infix-containers:containers/container[name='{name}']/{act}")
+        """Call container action (context RPC), retry three times."""
+        xpath = f"/infix-containers:containers/container[name='{name}']/{act}"
+
+        for attempt in range(3):
+            try:
+                return self.system.call_action(xpath)
+            except Exception as e:
+                warn(f"failed {act} {name} ({attempt + 1}/3): {e}")
+                time.sleep(1)
+                if attempt == 2:
+                    raise

--- a/test/infamy/util.py
+++ b/test/infamy/util.py
@@ -4,6 +4,7 @@ import infamy.neigh
 import infamy.netconf as netconf
 import infamy.restconf as restconf
 
+
 class ParallelFn(threading.Thread):
     def __init__(self, group=None, target=None, name=None,
                  args=(), kwargs={}, Verbose=None):
@@ -26,10 +27,12 @@ class ParallelFn(threading.Thread):
 
         return self._return
 
+
 def parallel(*fns):
     ths = [ParallelFn(target=fn) for fn in fns]
     [th.start() for th in ths]
     return [th.join() for th in ths]
+
 
 def until(fn, attempts=10, interval=1):
     for attempt in range(attempts):
@@ -39,6 +42,7 @@ def until(fn, attempts=10, interval=1):
         time.sleep(interval)
 
     raise Exception("Expected condition did not materialize")
+
 
 def wait_boot(target):
     until(lambda: target.reachable() == False, attempts = 100)
@@ -54,3 +58,10 @@ def wait_boot(target):
     until(lambda: restconf.restconf_reachable(neigh, target.location.password) == True, attempts = 300)
 
     return True
+
+
+def warn(msg):
+    """Print a warning message in yellow to stderr."""
+    YELLOW = "\033[93m"
+    RST = "\033[0m"
+    print(f"{YELLOW}warn - {msg}{RST}")

--- a/test/test.mk
+++ b/test/test.mk
@@ -15,12 +15,14 @@ binaries-x86_64  += OVMF.fd
 binaries := $(foreach bin,$(binaries-$(ARCH)),-f $(BINARIES_DIR)/$(bin))
 
 test:
-	$(test-dir)/env $(mode) $(binaries) $(ninepm) $(INFIX_TESTS)
+	$(test-dir)/env -r $(mode) $(binaries) $(ninepm) $(INFIX_TESTS)
 
 test-sh:
 	$(test-dir)/env $(mode) $(binaries) -i /bin/sh
 
+# Unit tests run with random (-r) hostname and container name to
+# prevent race conditions when running in CI environments.
 test-unit:
-	$(test-dir)/env $(ninepm) $(UNIT_TESTS)
+	$(test-dir)/env -r $(ninepm) $(UNIT_TESTS)
 
 .PHONY: test test-sh test-unit


### PR DESCRIPTION
## Description

This PR increases the robustness of the Infix `yanger` helper.  Basically, instead of bailing out with `sys.exit(1)`, causing `statd` to fail and automatically cause a non-working operational datastore, we allow external commands to fail and then return empty objects/arrays to the respective data parsers.

For example, asking the operational datastore for the status of a container before the container has been started properly should not b0rk the datastore, but rather return `None` information.  Same as if listing all containers.

The test framework has also been made slightly more fault tolerant by adding a retry of container commands.

Fixes #558 and #568

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [X] Bugfix
  - [X] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

