### PR TITLE
board/aarch64: styx: Source product data from VPD

### DIFF
--- a/board/aarch64/dts/styx/styx.dtsi
+++ b/board/aarch64/dts/styx/styx.dtsi
@@ -92,7 +92,7 @@
 		compatible = "atmel,24c256";
                 reg = <0x50>;
 
-		infix,board = "cpu";
+		infix,board = "product";
 		infix,trusted;
 
 		nvmem-layout {


### PR DESCRIPTION
In order for the probe logic to source product data from a VPD, it must be marked as such. Otherwise we end up in a scenario where the data is collected, but not hoisted up to the system level, leaving the system without a defined base-MAC for instance.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

