### PR TITLE
Generate and load test-config when in test-mode

### DIFF
--- a/package/confd/tmpfiles.conf
+++ b/package/confd/tmpfiles.conf
@@ -1,3 +1,4 @@
 d  /run/confd/factory.d		- - -
 d  /run/confd/failure.d		- - -
+d  /run/confd/test.d            - - -   
 d  /run/resolvconf/interfaces	- - -

--- a/src/confd/bin/.confdrc
+++ b/src/confd/bin/.confdrc
@@ -12,15 +12,19 @@ RUN_PATH_=/tmp/confd/run
 
 FACTORY_DEFAULTS_D=../share/factory.d
 FAILURE_DEFAULTS_D=../share/failure.d
+TEST_DEFAULTS_D=../share/test.d
 
 FACTORY_D=$RUN_PATH_/factory.d
 FAILURE_D=$RUN_PATH_/failure.d
+TEST_D=$RUN_PATH_/test.d
 
 FACTORY_GEN=$RUN_PATH_/factory-config.gen
 FAILURE_GEN=$RUN_PATH_/failure-config.gen
+TEST_GEN=$RUN_PATH_/test-config.gen
 
 FACTORY_CFG=$RUN_PATH_/factory-config.cfg
 FAILURE_CFG=$RUN_PATH_/failure-config.cfg
+TEST_CFG=$RUN_PATH_/test-config.cfg
 STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 
 # Uncomment this line in to create a bridge (br0) with all (classified
@@ -32,6 +36,7 @@ STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 # Default hostname in Fail Secure mode, plus last three octets in the base
 # MAC address, e.g. "failed-c0-ff-ee".
 FAIL_HOSTNAME="failed"
+TEST_HOSTNAME="test"
 
 # Only needed for testing
 mkdir -p "$CFG_PATH_" "$RUN_PATH_" "$FACTORY_D" "$FAILURE_D"

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -1,11 +1,11 @@
 #!/bin/sh
-# Bootstrap system factory-config, failure-config and sysrepo db.
+# Bootstrap system factory-config, failure-config, test-config and sysrepo db.
 #
 ########################################################################
-# The system factory-config and failure-config are derived from default
-# settings snippets, from /usr/share/confd/factory.d, and some generated
-# snippets, e.g., hostname (based on base MAC address) and number of
-# interfaces.
+# The system factory-config, failure-config and test-config are derived
+# from default settings snippets, from /usr/share/confd/factory.d, and 
+# some generated snippets, e.g., hostname (based on base MAC address) 
+# and number of interfaces.
 #
 # The resulting factory-config is used to create the syrepo db (below)
 # {factory} datastore.  Hence, the factory-config file must match the
@@ -127,10 +127,26 @@ failure()
     collate "$FAILURE_GEN" "$FAILURE_CFG" "$FAILURE_D"
 }
 
+gen_test_cfg()
+{
+    # Fetch defaults, simplifies sort in collate()
+    cp "$TEST_DEFAULTS_D"/* "$TEST_D"
+
+    gen-hostname   "$TEST_HOSTNAME"                         >"$TEST_D/20-hostname.json"
+    gen-interfaces                                          >"$TEST_D/20-interfaces.json"
+    gen-version                                             >"$TEST_D/20-version.json"
+
+    collate "$TEST_GEN" "$TEST_CFG" "$TEST_D"
+}
+
 # Both factory-config and failure-config are generated every boot
 # regardless if there is a static /etc/factory-config.cfg or not.
 factory "$FACTORY_GEN"
 failure "$FAILURE_GEN"
+
+if [ -f "/mnt/aux/test-mode" ]; then
+    gen_test_cfg
+fi
 
 if [ -n "$TESTING" ]; then
 	echo "Done."

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -88,10 +88,8 @@ console_error()
     return 0
 }
 
-factory()
+gen_factory_cfg()
 {
-    gen=$1
-
     # Fetch defaults, simplifies sort in collate()
     cp "$FACTORY_DEFAULTS_D"/* "$FACTORY_D/"
 
@@ -110,10 +108,8 @@ factory()
     collate "$FACTORY_GEN" "$FACTORY_CFG" "$FACTORY_D"
 }
 
-failure()
+gen_failure_cfg()
 {
-    gen=$1
-
     # Fetch defaults, simplifies sort in collate()
     cp "$FAILURE_DEFAULTS_D"/* "$FAILURE_D"
 
@@ -141,8 +137,8 @@ gen_test_cfg()
 
 # Both factory-config and failure-config are generated every boot
 # regardless if there is a static /etc/factory-config.cfg or not.
-factory "$FACTORY_GEN"
-failure "$FAILURE_GEN"
+gen_factory_cfg 
+gen_failure_cfg
 
 if [ -f "/mnt/aux/test-mode" ]; then
     gen_test_cfg

--- a/src/confd/bin/bootstrap
+++ b/src/confd/bin/bootstrap
@@ -115,7 +115,7 @@ gen_failure_cfg()
 
     gen-hostname   "$FAIL_HOSTNAME"                         >"$FAILURE_D/20-hostname.json"
     gen-interfaces                                          >"$FAILURE_D/20-interfaces.json"
-    gen-version                                             >"$FACTORY_D/20-version.json"
+    gen-version                                             >"$FAILURE_D/20-version.json"
 
     # Optional failure/error config to generate (or override) for br2-externals
     [ -x "$(command -v gen-err-custom)" ] && gen-err-custom >"$FAILURE_D/30-error.json"

--- a/src/confd/bin/load
+++ b/src/confd/bin/load
@@ -1,5 +1,5 @@
 #!/bin/sh
-# load [-b] <startup-config | failure-config>
+# load [-b] <startup-config | failure-config | test-config>
 #
 # Import a configuration to the sysrepo datastore using `sysrepocfg -Ifile`
 #
@@ -41,6 +41,17 @@ err()
 . /etc/confdrc
 
 config=$1
+
+if [ -f "/mnt/aux/test-mode" ] && [ "$config" = "startup-config" ]; then
+
+	if [ -f "/mnt/aux/test-override-startup" ]; then
+		rm -f "/mnt/aux/test-override-startup"
+	else
+    	note "Test mode detected, switching to test-config"
+    	config="test-config"
+	fi
+fi
+
 if [ -f "$config" ]; then
     fn="$config"
 else

--- a/src/confd/confdrc
+++ b/src/confd/confdrc
@@ -12,19 +12,23 @@ RUN_PATH_=/run/confd
 # Static defaults, base Infix and any br2-external derivative.
 FACTORY_DEFAULTS_D=/usr/share/confd/factory.d
 FAILURE_DEFAULTS_D=/usr/share/confd/failure.d
+TEST_DEFAULTS_D=/usr/share/confd/test.d
 
 # Generated config snippets, e.g., hostname, password, and interfaces.
 FACTORY_D=$RUN_PATH_/factory.d
 FAILURE_D=$RUN_PATH_/failure.d
+TEST_D=$RUN_PATH_/test.d
 
 # The default config snippets and generated snippets are collated into
 # RAM-only name-config.gen , which are candidates for name-config.cfg
 FACTORY_GEN=$RUN_PATH_/factory-config.gen
 FAILURE_GEN=$RUN_PATH_/failure-config.gen
+TEST_GEN=$RUN_PATH_/test-config.gen
 
 # The resulting .cfg files can be peristent (factory-config) or not.
 FACTORY_CFG=$SYS_PATH_/factory-config.cfg
 FAILURE_CFG=$SYS_PATH_/failure-config.cfg
+TEST_CFG=$SYS_PATH_/test-config.cfg
 STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 
 # Uncomment this line in to create a bridge (br0) with all (classified
@@ -36,6 +40,7 @@ STARTUP_CFG=$CFG_PATH_/startup-config.cfg
 # Default hostname in Fail Secure mode, plus last three octets in the base
 # MAC address, e.g. "failed-c0-ff-ee".
 FAIL_HOSTNAME="failed"
+TEST_HOSTNAME="test"
 
 # Optional overrides by br2-external
 if [ -f /etc/confdrc.local ]; then

--- a/src/confd/configure.ac
+++ b/src/confd/configure.ac
@@ -11,6 +11,7 @@ AC_CONFIG_FILES([
 	share/Makefile
 	share/factory.d/Makefile
 	share/failure.d/Makefile
+	share/test.d/Makefile
 	share/migrate/Makefile
 	share/migrate/1.0/Makefile
 	src/Makefile

--- a/src/confd/share/Makefile.am
+++ b/src/confd/share/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS             = factory.d failure.d migrate
+SUBDIRS             = factory.d failure.d test.d migrate
 dist_pkgdata_DATA   = README

--- a/src/confd/share/README
+++ b/src/confd/share/README
@@ -1,1 +1,1 @@
-Templates for generating device-specific factory-config and failure-config.
+Templates for generating device-specific factory-config, failure-config and test-config.

--- a/src/confd/share/test.d/10-infix-services.json
+++ b/src/confd/share/test.d/10-infix-services.json
@@ -1,0 +1,11 @@
+{
+    "infix-services:mdns": {
+		"enabled": true
+    },
+    "infix-services:web": {
+		"enabled": true,
+		"restconf": {
+			"enabled": true
+		}
+    }
+}

--- a/src/confd/share/test.d/10-nacm.json
+++ b/src/confd/share/test.d/10-nacm.json
@@ -1,0 +1,1 @@
+../factory.d/10-nacm.json

--- a/src/confd/share/test.d/10-netconf-server.json
+++ b/src/confd/share/test.d/10-netconf-server.json
@@ -1,0 +1,1 @@
+../factory.d/10-netconf-server.json

--- a/src/confd/share/test.d/10-system.json
+++ b/src/confd/share/test.d/10-system.json
@@ -1,0 +1,14 @@
+{
+    "ietf-system:system": {
+	"hostname": "test",
+	"authentication": {
+	    "user": [
+		{
+		    "name": "admin",
+		    "password": "$factory$",
+		    "infix-system:shell": "bash"
+		}
+	    ]
+	}
+    }
+}

--- a/src/confd/share/test.d/Makefile.am
+++ b/src/confd/share/test.d/Makefile.am
@@ -1,0 +1,4 @@
+testdir		= $(pkgdatadir)/test.d
+dist_test_DATA	= 10-nacm.json \
+		10-netconf-server.json 10-system.json
+


### PR DESCRIPTION
Currently, it's not possible to run infix tests from an external project (based on infix) due to an incompatibility between the
configuration used in the tests (the default configuration within the image generated by the external project) and the infix
base configuration expected by the test cases. 
Therefore, a simple configuration specifically for testing purposes needs to be generated within an image. 
This test-config should only be generated and loaded when the device is in test mode.
