### PR TITLE
Introduce Test Mode for Build

### DIFF
--- a/board/common/Config.in
+++ b/board/common/Config.in
@@ -107,6 +107,18 @@ config DISK_IMAGE_BOOT_OFFSET
 	  to make sure that the GPT still fits at the start of the
 	  image.
 
+config DISK_IMAGE_TEST_MODE
+	bool "Enable Test Mode"
+	depends on DISK_IMAGE
+	default y
+	help
+	  Enable the test mode option by default. This setting creates a test-mode flag
+	  in the auxiliary partition of the disk image, initiating the system with the test-config
+	  instead of regular startup-config. The primary purpose of running an image in this mode
+	  is to ensure proper execution of all Infix tests. Additionally, it enables extra RPCs
+	  related to system restart and configuration overrides, allowing tests to be run even on
+	  systems where the factory configuration may potentially create L2 loops. 
+
 config DISK_IMAGE_RELEASE_URL
 	string "Infix URL"
 	depends on DISK_IMAGE

--- a/board/common/mkdisk.sh
+++ b/board/common/mkdisk.sh
@@ -128,7 +128,7 @@ diskimg=disk.img
 bootimg=
 bootpart=
 
-while getopts "a:b:B:n:s:" opt; do
+while getopts "a:b:B:n:s:t" opt; do
     case ${opt} in
 	a)
 	    arch=$OPTARG
@@ -145,6 +145,9 @@ while getopts "a:b:B:n:s:" opt; do
 	s)
 	    total=$(size2int $OPTARG)
 	    ;;
+	t)
+		testmode=true
+		;;
     esac
 done
 shift $((OPTIND - 1))
@@ -189,6 +192,12 @@ mkdir -p $root/aux
 cp -f $BINARIES_DIR/rootfs.itbh $root/aux/primary.itbh
 cp -f $BINARIES_DIR/rootfs.itbh $root/aux/secondary.itbh
 cp -f $BINARIES_DIR/rauc.status $root/aux/rauc.status
+
+if [ "$testmode" = true ]; then
+    touch "$root/aux/test-mode"
+else 
+    rm -f "$root/aux/test-mode"
+fi
 
 case "$arch" in
     aarch64)

--- a/board/common/post-image.sh
+++ b/board/common/post-image.sh
@@ -59,8 +59,13 @@ if [ "$DISK_IMAGE" = "y" ]; then
 	tar -xa --strip-components=1 -C "$BINARIES_DIR" -f "$archive"
     fi
 
+    testmode_flag=""
+    if [ "$DISK_IMAGE_TEST_MODE" = "y" ]; then 
+	testmode_flag="-t"
+    fi
+
     $common/mkrauc-status.sh "$BINARIES_DIR/${NAME}.pkg" >"$BINARIES_DIR/rauc.status"
-    $common/mkdisk.sh -a $BR2_ARCH -n $diskimg -s $DISK_IMAGE_SIZE $bootcfg
+    $common/mkdisk.sh -a $BR2_ARCH -n $diskimg $testmode_flag -s $DISK_IMAGE_SIZE $bootcfg
 fi
 
 load_cfg SDCARD_AUX

--- a/doc/test-arch.md
+++ b/doc/test-arch.md
@@ -241,6 +241,31 @@ could accept an arbitrary physical topology, run the STP algorithm on
 it offline, enable STP on all DUTs, and then verify that the resulting
 spanning tree matches the expected one.
 
+Integration to Infix
+--------------------
+To successfully run all Infix tests, the image must be built in 
+'test-mode'. This can be achieved by setting the DISK_IMAGE_TEST_MODE
+parameter to true. Although this is the default setting, it’s advisable
+to verify it by running:
+
+    $ make menuconfig
+    (External Options --> -*- Disk image --> [*] Enable Test Mode)
+
+Building an image in 'test-mode' results in the creation of a 'test-mode'
+file within the auxiliary (aux) partition of the Infix disk image 
+(/mnt/aux/test-mode).
+
+During the bootstrap phase, the system checks for the presence of this 
+test-mode flag (file). If the flag exists, a 'test-config.cfg' file is 
+generated. In the following step, the system loads the 'test-config' 
+instead of the standard startup-config (or factory-config). This 
+configuration is simple and safe, equivalent to the one used in 'Secure Mode'
+(also known as 'failure-config').
+
+Additionally, the configuration enables extra RPCs related to system 
+restart and configuration overrides, allowing tests to be run even on 
+systems where the factory configuration may potentially create L2 loops. 
+
 [9PM]:    https://github.com/rical/9pm
 [Qeneth]: https://github.com/wkz/qeneth
 [TAP]:    https://testanything.org/

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -25,6 +25,17 @@ for `x86_64`:
     $ make
     $ make test
 
+It is important to mention that Infix build system by default creates
+an image in 'test-mode'. The mode is set by DISK_IMAGE_TEST_MODE
+parameter (default=true). To generate a standard image set the
+DISK_IMAGE_TEST_MODE to 'false'. However, only the test mode ensures
+that all Infix tests are executed properly. Prior to the set of commands
+above, it is always good to check that DISK_IMAGE_TEST_MODE is properly
+set by running:
+
+    $ make menuconfig
+    (External Options --> -*- Disk image --> [*] Enable Test Mode)
+
 ### Physical Devices
 
 To run the tests on a preexisting topology from the host's network

--- a/src/confd/share/factory.d/Makefile.am
+++ b/src/confd/share/factory.d/Makefile.am
@@ -1,3 +1,3 @@
-factorydir          = $(pkgdatadir)/factory.d
-dist_factory_DATA   = 10-nacm.json 10-netconf-server.json \
-		      10-infix-services.json 10-system.json
+factorydir          	= $(pkgdatadir)/factory.d
+dist_factory_DATA   	= 10-nacm.json 10-netconf-server.json \
+		      	10-infix-services.json 10-system.json

--- a/src/confd/share/failure.d/Makefile.am
+++ b/src/confd/share/failure.d/Makefile.am
@@ -1,4 +1,4 @@
-failuredir          = $(pkgdatadir)/failure.d
-dist_failure_DATA   = 10-nacm.json \
-		      10-netconf-server.json 10-system.json
+failuredir		= $(pkgdatadir)/failure.d
+dist_failure_DATA	= 10-nacm.json 10-netconf-server.json \
+			10-infix-services.json 10-system.json
 

--- a/src/confd/share/test.d/Makefile.am
+++ b/src/confd/share/test.d/Makefile.am
@@ -1,4 +1,4 @@
 testdir		= $(pkgdatadir)/test.d
-dist_test_DATA	= 10-nacm.json \
-		10-netconf-server.json 10-system.json
+dist_test_DATA	= 10-nacm.json 10-netconf-server.json \
+		10-infix-services.json 10-system.json
 


### PR DESCRIPTION
To support testing, the 'test-config.cfg' has been introduced in Infix. Additionally, a test mode for the running image is required for this configuration to be applied.

Basically the 'test-config' will only be generated and loaded when the device is in 'test-mode', which is determined by the presence of the '/mnt/aux/test-mode file'. However, placing this file via the Qeneth system proved to be inconvenient in the test environment. Therefore, the entire image is built in test mode, with the 'test-mode' file preloaded onto the disk image (specifically in the auxiliary partition).

To support this, a new variable, '(bool) DISK_IMAGE_TEST_MODE', has been introduced:
 * 'enabled': the image will be built in the test mode;
 * 'disabled': the image will be built in the standard mode.