### PR TITLE
Enable Running Infix Tests from External Project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export BR2_EXTERNAL := $(CURDIR)
+export BR2_EXTERNAL ?= $(CURDIR)
 export PATH         := $(CURDIR)/bin:$(PATH)
 
 ARCH ?= $(shell uname -m)

--- a/test/env
+++ b/test/env
@@ -15,6 +15,10 @@ usage: test/env [<OPTS>] -f <IMAGE> -q <QENETH-DIR> <COMMAND> [<ARGS>...]
 
   Options:
 
+    -b <BASE-DIR>
+     Use this directory as the top-level bind mount inside the container.
+	 If not specified, Infix's top directory is used.
+
     -c
      Clean up cruft, lingering images, old containers, unused volumes.
      Used by GitHub action to prevent issues with running tests.
@@ -126,9 +130,13 @@ name()
 containerize=yes
 [ -c /dev/kvm ] && kvm="--device=/dev/kvm"
 files=
+basedir="$ixdir"
 
-while getopts "cCDf:hiKp:q:rt:" opt; do
+while getopts "b:cCDf:hiKp:q:rt:" opt; do
     case ${opt} in
+	b)
+	    basedir="$OPTARG"
+	    ;;
 	c)
 	    $(runner) image prune -af
             $(runner) volume prune -f
@@ -177,7 +185,7 @@ while getopts "cCDf:hiKp:q:rt:" opt; do
 done
 
 if [ "$containerize" ]; then
-    volumes="--volume $ixdir:$ixdir --workdir=$ixdir/test"
+    volumes="--volume $basedir:$basedir --workdir=$ixdir/test"
     case "$(runner)" in
 	docker)
 	    volumes="$volumes --env HOST_CHOWN_PATH=$ixdir/test"

--- a/test/test.mk
+++ b/test/test.mk
@@ -1,28 +1,35 @@
+base-dir := $(lastword $(subst :, ,$(BR2_EXTERNAL)))
 test-dir := $(BR2_EXTERNAL_INFIX_PATH)/test
 ninepm   := $(BR2_EXTERNAL_INFIX_PATH)/test/9pm/9pm.py
 
 UNIT_TESTS  ?= $(test-dir)/case/all-repo.yaml $(test-dir)/case/all-unit.yaml
-INFIX_TESTS ?= $(test-dir)/case/all.yaml
+TESTS ?= $(test-dir)/case/all.yaml
+
+IMAGE ?= infix
+TOPOLOGY-DIR ?= $(test-dir)/virt/quad
+
+base := -b $(base-dir)
 
 TEST_MODE ?= qeneth
-mode-qeneth := -q $(test-dir)/virt/quad
+mode-qeneth := -q $(TOPOLOGY-DIR)
 mode-host   := -t $(or $(TOPOLOGY),/etc/infamy.dot)
 mode-run    := -t $(BINARIES_DIR)/qemu.dot
 mode        := $(mode-$(TEST_MODE))
 
-binaries-$(ARCH) := $(addprefix infix-$(ARCH),.img -disk.img .pkg)
+
+binaries-$(ARCH) := $(addprefix $(IMAGE)-$(ARCH),.img -disk.img .pkg)
 binaries-x86_64  += OVMF.fd
 binaries := $(foreach bin,$(binaries-$(ARCH)),-f $(BINARIES_DIR)/$(bin))
 
 test:
-	$(test-dir)/env -r $(mode) $(binaries) $(ninepm) $(INFIX_TESTS)
+	$(test-dir)/env -r $(base) $(mode) $(binaries) $(ninepm) $(TESTS)
 
 test-sh:
-	$(test-dir)/env $(mode) $(binaries) -i /bin/sh
+	$(test-dir)/env $(base) $(mode) $(binaries) -i /bin/sh
 
 # Unit tests run with random (-r) hostname and container name to
 # prevent race conditions when running in CI environments.
 test-unit:
-	$(test-dir)/env -r $(ninepm) $(UNIT_TESTS)
+	$(test-dir)/env -r $(base) $(ninepm) $(UNIT_TESTS)
 
 .PHONY: test test-sh test-unit


### PR DESCRIPTION
Minor adjustments have been made to enable calling infix tests from an external make test target. This essentially allows running any external test (or a group of tests) using the 9pm tool.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):
  - [x] Enhancements in the test environment 

