### PR TITLE
confd: initctl touch mcd after querier changes

### DIFF
--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -1128,6 +1128,7 @@ static void mcast_querier(const char *ifname, int vid, int mode, int interval)
 	fclose(fp);
 
 	systemf("initctl -bnq enable mcd");
+	systemf("initctl -bnq touch mcd");
 }
 
 static char *find_vlan_interface(sr_session_ctx_t *session, const char *brname, int vid)


### PR DESCRIPTION
## Description
Prior to this commit, querier multicast changes such as query-interval where not applied to an existing multicast interface. The new initctl touch makes finit send a sighup to mcd which causes it to re-load its configuration files.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

