### PR TITLE
Fix eui 64 based ipv6 addresses

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -357,6 +357,10 @@ future releases.
 - Fix #349: minor changes to `bridge-port` settings, like setting `pvid`
   when you forget it, did not take without a reboot
 - Fix #353: impossible to remove bridge port with `no bridge-port`
+- Fix #357: EUI-64 based IPv6 autoconf address on bridges seem to be
+  randomized.  Problem caused by kernel setting a random MAC before any
+  bridge port is added.  Fixed by using the device's base MAC address on
+  bridge interfaces.  Possible to override using `phys-address` option
 - Fix #358: MAC address no longer shown for bridge interfaces in CLI
   `show interfaces` command
 - Fix #365: not possible to run `ping` from container

--- a/src/confd/src/core.c
+++ b/src/confd/src/core.c
@@ -4,7 +4,7 @@
 
 #include "core.h"
 
-static struct confd confd;
+struct confd confd;
 
 uint32_t core_hook_prio(void)
 {

--- a/src/confd/src/core.h
+++ b/src/confd/src/core.h
@@ -32,6 +32,9 @@
 #define CB_PRIO_PRIMARY   65535
 #define CB_PRIO_PASSIVE   65000
 
+extern struct confd confd;
+
+
 static inline void print_val(sr_val_t *val)
 {
 	char *str;

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -1284,15 +1284,37 @@ static int netdag_gen_bridge(sr_session_ctx_t *session, struct dagger *net, stru
 	vlan_filtering = bridge_vlan_settings(cif, &proto, &vlan_mcast);
 	fwd_mask = bridge_fwd_mask(cif);
 
+	fprintf(ip, "link %s dev %s", op, brname);
+	/*
+	 * Must set base mac on add to prevent kernel from seeding ipv6
+	 * addrgenmode eui64 with random mac, issue #357.
+	 */
+	if (add) {
+		const char *mac;
+
+		mac = lydx_get_cattr(cif, "phys-address");
+		if (!mac) {
+			struct json_t *j;
+
+			j = json_object_get(confd.root, "mac-address");
+			if (j)
+				mac = json_string_value(j);
+		}
+		if (mac)
+			fprintf(ip, " address %s", mac);
+
+		/* on failure, fall back to kernel's random mac */
+	}
+
 	/*
 	 * Issue #198: we require explicit VLAN assignment for ports
 	 *             when VLAN filtering is enabled.  We strongly
 	 *             believe this is the only sane way of doing it.
 	 * Issue #310: malplaced 'vlan_default_pvid 0'
 	 */
-	fprintf(ip, "link %s dev %s type bridge group_fwd_mask %d mcast_flood_always 1"
+	fprintf(ip, " type bridge group_fwd_mask %d mcast_flood_always 1"
 		" vlan_filtering %d vlan_default_pvid 0",
-		op, brname, fwd_mask, vlan_filtering ? 1 : 0);
+		fwd_mask, vlan_filtering ? 1 : 0);
 
 	if ((err = bridge_mcast_settings(ip, brname, cif, vlan_mcast)))
 		goto out;


### PR DESCRIPTION
## Description
 
This PR fixes the EUI-64 based IPv6 autoconf address on bridges and updates the IGMP basic test.                                                                                                                                            
                                                                                                                                                                                                                                            
The EUI-64 address is fixed by explicitly assigning the base mac address to the bridge when creating it. Strangely, this messes with some timing in the bridge, causing the first multicast querier message sent to the bridge from user-space to be lost. This is caused by the bridge using the "NOOP" scheduler (noop_enqueue()) for a short period of time while the interface is starting up. To avoid the test-case failing when this happens we introduce a retry that will wait for the second query message. This is a bit strange in the case of a software device such as a bridge, i.e. it might be a bug. However, loosing the first query isn't strange in the case of a normal HW interface. That's how we justify the retry loop. 