### PR TITLE
bug: Add missing " in date-cpp package reference

### DIFF
--- a/package/Config.in
+++ b/package/Config.in
@@ -32,5 +32,5 @@ source "$BR2_EXTERNAL_INFIX_PATH/package/libyang-cpp/Config.in"
 source "$BR2_EXTERNAL_INFIX_PATH/package/sysrepo-cpp/Config.in"
 source "$BR2_EXTERNAL_INFIX_PATH/package/rousette/Config.in"
 source "$BR2_EXTERNAL_INFIX_PATH/package/nghttp2-asio/Config.in"
-source "$BR2_EXTERNAL_INFIX_PATH/package/date-cpp/Config.in
+source "$BR2_EXTERNAL_INFIX_PATH/package/date-cpp/Config.in"
 endmenu


### PR DESCRIPTION
## Description

Almost cosmetic bugfix adding a missing " in date-cpp package reference, which caused a build time warning

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

