### PR TITLE
Introduce Test Mode only within Test Environment

### DIFF
--- a/board/common/Config.in
+++ b/board/common/Config.in
@@ -107,18 +107,6 @@ config DISK_IMAGE_BOOT_OFFSET
 	  to make sure that the GPT still fits at the start of the
 	  image.
 
-config DISK_IMAGE_TEST_MODE
-	bool "Enable Test Mode"
-	depends on DISK_IMAGE
-	default y
-	help
-	  Enable the test mode option by default. This setting creates a test-mode flag
-	  in the auxiliary partition of the disk image, initiating the system with the test-config
-	  instead of regular startup-config. The primary purpose of running an image in this mode
-	  is to ensure proper execution of all Infix tests. Additionally, it enables extra RPCs
-	  related to system restart and configuration overrides, allowing tests to be run even on
-	  systems where the factory configuration may potentially create L2 loops. 
-
 config DISK_IMAGE_RELEASE_URL
 	string "Infix URL"
 	depends on DISK_IMAGE

--- a/board/common/mkdisk.sh
+++ b/board/common/mkdisk.sh
@@ -128,7 +128,7 @@ diskimg=disk.img
 bootimg=
 bootpart=
 
-while getopts "a:b:B:n:s:t" opt; do
+while getopts "a:b:B:n:s:" opt; do
     case ${opt} in
 	a)
 	    arch=$OPTARG
@@ -145,9 +145,6 @@ while getopts "a:b:B:n:s:t" opt; do
 	s)
 	    total=$(size2int $OPTARG)
 	    ;;
-	t)
-		testmode=true
-		;;
     esac
 done
 shift $((OPTIND - 1))
@@ -192,12 +189,6 @@ mkdir -p $root/aux
 cp -f $BINARIES_DIR/rootfs.itbh $root/aux/primary.itbh
 cp -f $BINARIES_DIR/rootfs.itbh $root/aux/secondary.itbh
 cp -f $BINARIES_DIR/rauc.status $root/aux/rauc.status
-
-if [ "$testmode" = true ]; then
-    touch "$root/aux/test-mode"
-else 
-    rm -f "$root/aux/test-mode"
-fi
 
 case "$arch" in
     aarch64)

--- a/board/common/post-image.sh
+++ b/board/common/post-image.sh
@@ -59,13 +59,8 @@ if [ "$DISK_IMAGE" = "y" ]; then
 	tar -xa --strip-components=1 -C "$BINARIES_DIR" -f "$archive"
     fi
 
-    testmode_flag=""
-    if [ "$DISK_IMAGE_TEST_MODE" = "y" ]; then 
-	testmode_flag="-t"
-    fi
-
     $common/mkrauc-status.sh "$BINARIES_DIR/${NAME}.pkg" >"$BINARIES_DIR/rauc.status"
-    $common/mkdisk.sh -a $BR2_ARCH -n $diskimg $testmode_flag -s $DISK_IMAGE_SIZE $bootcfg
+    $common/mkdisk.sh -a $BR2_ARCH -n $diskimg -s $DISK_IMAGE_SIZE $bootcfg
 fi
 
 load_cfg SDCARD_AUX

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -24,8 +24,12 @@ All notable changes to the project are documented in this file.
   authorized users, like `admin`, to not being able to query status
   of OSPF or BFD.  Workaround by using the UNIX shell `sudo vtysh`.
   Regression introduced in v24.08.0
+- Fix #603: regression in GNS3 image, starts in test mode by default. 
+  Introduced in v24.08.
 - Fix #613: CLI regression in tab completion of container commands,
   e.g., `container shell <TAB>`.  Regression introduced in v24.08.0
+- Fix #616: Silent failure when selecting bash as login shell for
+  non-admin user, this silent lock has been removed.
 - Fix #618: CLI command `show interfaces` does not show bridges and
   bridge ports, regression introduced in v24.08.0 -- only affects
   bridges without multicast snooping
@@ -33,8 +37,6 @@ All notable changes to the project are documented in this file.
   regression introduced in v24.06.0
 - Spellcheck path to `/var/lib/containers` when unpacking OCI archives
   on container upgrade
-- Fix #616: Silent failure when selecting bash as login shell for
-  non-admin user, this silent lock has been removed.
 - The timeout before giving up on loading the `startup-config` at boot
   is now 1 minute, just like operations via other front-ends (NETCONF
   and RESTCONF). This was previously (incorrectly) set to 10 seconds.

--- a/test/.env
+++ b/test/.env
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034,SC2154
 
 # Current container image
-INFIX_TEST=ghcr.io/kernelkit/infix-test:1.8
+INFIX_TEST=ghcr.io/kernelkit/infix-test:1.9
 
 ixdir=$(readlink -f "$testdir/..")
 logdir=$(readlink -f "$testdir/.log")

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --no-cache \
     tshark \
     openssl \
     curl \
+    e2tools \
     make
 
 ARG MTOOL_VERSION="3.0"

--- a/test/env
+++ b/test/env
@@ -70,6 +70,14 @@ usage: test/env [-cDhiKr] -f <IMAGE> -q <QENETH-DIR> <COMMAND> [<ARGS>...]
 EOF
 }
 
+get_base_img()
+{
+    local files="$1"
+    local base_img_file
+    base_img_file=$(echo "$files" | tr ' ' '\n' | grep -- '-disk.img$')
+    echo "$envdir/qeneth/$(basename "$base_img_file")"
+}
+
 start_topology()
 {
     qenethdir="$1"
@@ -86,6 +94,9 @@ start_topology()
 	file=$(readlink -f "$f")
 	ln -sf "$file" "$envdir/qeneth/$filename"
     done
+
+    base_img=$(get_base_img "$files")
+    $testdir/inject-test-mode -b "$base_img" -o "${base_img%-disk.img}-disk-test.img"
 
     (cd "$envdir/qeneth/" && $qeneth generate && $qeneth start)
     INFAMY_ARGS="$INFAMY_ARGS $envdir/qeneth/topology.dot"

--- a/test/inject-test-mode
+++ b/test/inject-test-mode
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# This script injects a "test-mode" file into a copy of the main disk image. 
+# It begins by parsing the partition table of the disk image to identify the
+# 'aux' partition, which is then extracted. An empty 'test-mode' file is 
+# injected into the extracted partition, and the modified partition is written
+# back to the output image. The output image can subsequently be used as a 
+# backing image for Copy-on-Write (QCOW) images utilized by Qeneth.
+
+set -e
+
+while getopts "b:o:" opt; do
+  case $opt in
+    b) base_img="$OPTARG" ;;  # Base image (Original image)
+    o) output_img="$OPTARG" ;;  # Output image (Backing image for QCoW images)
+    *) echo "Usage: $0 -b <BASE-IMAGE> -o <OUTPUT-IMAGE>" ; exit 1 ;;
+  esac
+done
+
+if [ -z "$base_img" ] || [ -z "$output_img" ]; then
+  echo "Both -b (base image) and -o (output image) parameters are required."
+  exit 1
+fi
+
+rm -f "$output_img"
+if ! cp "$base_img" "$output_img"; then
+  echo "Error: Failed to copy $base_img to $output_img"
+  exit 1
+fi
+
+if ! part_table=$(fdisk -l "$output_img" 2>/dev/null); then
+  echo "Error: Failed to read partition table from $output_img"
+  exit 1
+fi
+
+aux_line=$(echo "$part_table" | grep 'aux')
+if [ -z "$aux_line" ]; then
+  echo "Error: 'aux' partition not found in $output_img"
+  exit 1
+fi
+
+start=$(echo "$aux_line" | awk '{print $2}')
+end=$(echo "$aux_line" | awk '{print $3}')
+count=$(($end - $start + 1))
+block_size=$(echo "$part_table" | grep "Logical sector size" | awk '{print $4}')
+
+dd if="$output_img" of="tmpaux" skip="$start" count="$count" bs="$block_size" status=none
+
+touch tmp-empty-file
+e2cp tmp-empty-file tmpaux:/test-mode
+rm tmp-empty-file
+
+dd of="$output_img" if="tmpaux" seek="$start" count="$count" bs="$block_size" status=none conv=notrunc
+rm tmpaux

--- a/test/virt/dual/topology.dot.in
+++ b/test/virt/dual/topology.dot.in
@@ -7,7 +7,8 @@ graph "dual" {
         node [shape=record, fontname="monospace"];
 	edge [color="cornflowerblue", penwidth="2"];
 
-	qn_template="infix-x86_64";
+	qn_template="infix-bios-x86_64";
+	qn_image="infix-x86_64-disk-test.img"
 	qn_oui="00:a0:85";
 	qn_append="quiet";
 

--- a/test/virt/quad/topology.dot.in
+++ b/test/virt/quad/topology.dot.in
@@ -8,6 +8,7 @@ graph "quad" {
 	edge [color="cornflowerblue", penwidth="2"];
 
 	qn_template="infix-bios-x86_64";
+	qn_image="infix-x86_64-disk-test.img"
 	qn_oui="00:a0:85";
 	qn_append="quiet";
 


### PR DESCRIPTION
## Description

The test mode, introduced at the config/build phase (commit 241f3f2), causes the device to start in test-mode when used in GNS3 (or other environments). This has unintentionally become the default configuration for the image, which is not desirable and is only acceptable for the Infix test system. 

With this update, the original configuration is preserved, and the test mode is applied only within the test environment.

## Other information

<!-- Other relevant info, e.g., before/after screenshots -->


## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

