### PR TITLE
Statd: improve speed of interface data 

### DIFF
--- a/src/statd/statd.c
+++ b/src/statd/statd.c
@@ -189,7 +189,7 @@ static int sr_iface_cb(sr_session_ctx_t *session, uint32_t, const char *model,
 }
 
 static int sr_generic_cb(sr_session_ctx_t *session, uint32_t, const char *model,
-			 const char *path, const char *, uint32_t,
+			 const char *, const char *xpath, uint32_t,
 			 struct lyd_node **parent, __attribute__((unused)) void *priv)
 {
 	char *yanger_args[5] = {
@@ -200,6 +200,8 @@ static int sr_generic_cb(sr_session_ctx_t *session, uint32_t, const char *model,
 	const struct ly_ctx *ctx;
 	sr_conn_ctx_t *con;
 	sr_error_t err;
+
+	DEBUG("Incoming generic query for xpath: %s", xpath);
 
 	con = sr_session_get_connection(session);
 	if (!con) {
@@ -223,7 +225,7 @@ static int sr_generic_cb(sr_session_ctx_t *session, uint32_t, const char *model,
 }
 
 static int sr_ospf_cb(sr_session_ctx_t *session, uint32_t, const char *,
-		      const char *path, const char *, uint32_t,
+		      const char *, const char *xpath, uint32_t,
 		      struct lyd_node **parent, __attribute__((unused)) void *priv)
 {
 	char *yanger_args[5] = {
@@ -235,7 +237,7 @@ static int sr_ospf_cb(sr_session_ctx_t *session, uint32_t, const char *,
 	sr_conn_ctx_t *con;
 	sr_error_t err;
 
-	DEBUG("Incoming ospf query for xpath: %s", path);
+	DEBUG("Incoming ospf query for xpath: %s", xpath);
 
 	con = sr_session_get_connection(session);
 	if (!con) {

--- a/src/statd/statd.c
+++ b/src/statd/statd.c
@@ -56,12 +56,8 @@ struct statd {
 	struct ev_loop *ev_loop;
 };
 
-/*
- * The 'fail' parameter is true for most calls to this function, except
- * when reading ethtool data (below).
- */
 static int ly_add_yanger_data(const struct ly_ctx *ctx, struct lyd_node **parent,
-			      char *yanger_args[], bool fail)
+			      char *yanger_args[])
 {
 	FILE *stream;
 	int err;
@@ -86,8 +82,6 @@ static int ly_add_yanger_data(const struct ly_ctx *ctx, struct lyd_node **parent
 		ERROR("Error, running yanger");
 		fclose(stream);
 		close(fd);
-		if (!fail)
-			return SR_ERR_OK;
 		return SR_ERR_SYS;
 	}
 
@@ -179,7 +173,7 @@ static int sr_iface_cb(sr_session_ctx_t *session, uint32_t, const char *model,
 		yanger_args[2] = "-p";
 		yanger_args[3] = ifname;
 	}
-	err = ly_add_yanger_data(ctx, parent, yanger_args, true);
+	err = ly_add_yanger_data(ctx, parent, yanger_args);
 	if (err)
 		ERROR("Error adding interface yanger data");
 
@@ -215,7 +209,7 @@ static int sr_generic_cb(sr_session_ctx_t *session, uint32_t, const char *model,
 		return SR_ERR_INTERNAL;
 	}
 
-	err = ly_add_yanger_data(ctx, parent, yanger_args, true);
+	err = ly_add_yanger_data(ctx, parent, yanger_args);
 	if (err)
 		ERROR("Error adding yanger data");
 
@@ -251,7 +245,7 @@ static int sr_ospf_cb(sr_session_ctx_t *session, uint32_t, const char *,
 		return SR_ERR_INTERNAL;
 	}
 
-	err = ly_add_yanger_data(ctx, parent, yanger_args, true);
+	err = ly_add_yanger_data(ctx, parent, yanger_args);
 	if (err)
 		ERROR("Error adding yanger data");
 


### PR DESCRIPTION
## Description
This PR removes the statd interface netlink code and improve speed of operational interface data.
    
This is a major redesign of statd interface handling. The goal here is to reduce the time it takes for statd to produce operational data for all interfaces on larger iron. Which manifested itself most notably in the CLI command "show interfaces".
    
This PR removes the netlink interface subscriptions done by the statd c code. Instead statd now subscribes to the ietf-interfaces base path which means it will be invoked for all interfaces. If the user (sysrepo) has specified an explicit interface name such as eth0, it will be extracted by statd and passed down to Yanger.
    
This PR also modifies Yanger to fit this new modus. No explicitly passed interface name now means all interfaces.
    
 ## Side note
The main culprit of the slow operational interface data is the time it takes to bootstrap python. Which prior to this PR was done for each interface. On the HW system I'm testing this PR on, runtime is reduced by a factor of 10.