### PR TITLE
test: Disable services_basic

### DIFF
--- a/test/case/infix_services/infix_services.yaml
+++ b/test/case/infix_services/infix_services.yaml
@@ -1,4 +1,9 @@
 ---
 
-- name: services_basic
-  case: services_basic/test.py
+# Disabled, see #654 for more information. Once that issue is fixed,
+# we should split this test into service_mdns and service_lldp, where
+# the LLDP test can be skipped if there are no links available that
+# are transparent with respect to IEEE link-local multicast.
+#- name: services_basic
+#  case: services_basic/test.py
+[]


### PR DESCRIPTION
As detailed in the comment, we disable this test pending a fix for #654 which will allow us to detect when the host won't be able to sniff LLDP frames.


## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [x] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

