### PR TITLE
Fix test issues after adding veth-delete test

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -83,6 +83,8 @@ documentation for details.
   interface changes (tries to delete both ends of the pair)
 - Spellcheck path to `/var/lib/containers` when unpacking OCI archives
   on container upgrade
+- cli: restore `tcpdump` permissions for administrator level users,
+  regression introduced in v24.08.0
 - The timeout before giving up on loading the `startup-config` at boot
   is now 1 minute, just like operations via other front-ends (NETCONF
   and RESTCONF). This was previously (incorrectly) set to 10 seconds

--- a/src/confd/share/migrate/1.0/10-infix-shell-type.sh
+++ b/src/confd/share/migrate/1.0/10-infix-shell-type.sh
@@ -2,8 +2,9 @@
 # Migrate infix-shell-type:bash -> infix-system:bash
 
 file=$1
-temp=$1.tmp
+temp=${file}.tmp
 
-jq '.["ietf-system:system"].authentication.user |= map(.["infix-system:shell"] |= gsub("infix-shell-type:"; ""))' "$file" > "$temp"
-mv "$temp" "$file"
-
+if jq -e '.["ietf-system:system"]?.authentication?.user? | length > 0' "$file" > /dev/null 2>&1; then
+    jq '.["ietf-system:system"].authentication.user |= map(.["infix-system:shell"] |= gsub("infix-shell-type:"; ""))' "$file" > "$temp"
+    mv "$temp" "$file"
+fi

--- a/src/confd/share/migrate/1.1/10-infix-routing-type.sh
+++ b/src/confd/share/migrate/1.1/10-infix-routing-type.sh
@@ -1,7 +1,19 @@
 #!/bin/sh
 # migrate ietf-routing-type => infix-routing-type
-file=$1
-temp=$1.tmp
 
-jq '(.["ietf-routing:routing"]."control-plane-protocols"."control-plane-protocol"[] | select(.type == "ietf-ospf:ospfv2").type) |= "infix-routing:ospfv2"'  "$file" > "$temp"
-jq '(.["ietf-routing:routing"]."control-plane-protocols"."control-plane-protocol"[] | select(.type == "static").type) |= "infix-routing:static"' "$temp" > "$file"
+migrate_routing_type()
+{
+    file=$1
+    match=$2
+    replace=$3
+
+    if jq -e '.["ietf-routing:routing"]?."control-plane-protocols"?."control-plane-protocol"?[] | length > 0' "$file" > /dev/null 2>&1; then
+        jq --arg match "${match}" --arg replace "${replace}" '
+            (.["ietf-routing:routing"]."control-plane-protocols"."control-plane-protocol"[] |
+            select(.type == $match).type) |= $replace' "${file}" > "${file}.tmp"
+	mv "${file}.tmp" "${file}"
+    fi
+}
+
+migrate_routing_type "$1" "ietf-ospf:ospfv2" "infix-routing:ospfv2"
+migrate_routing_type "$1" "static"           "infix-routing:static"

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -1657,7 +1657,7 @@ static int netdag_gen_iface_del(struct dagger *net, struct lyd_node *dif,
 	if (dagger_should_skip_current(net, ifname))
 		return 0;
 
-	if (!strcmp(iftype, "infix-if-type:veth")) {
+	if (iftype && !strcmp(iftype, "infix-if-type:veth")) {
 		struct lyd_node *node;
 		const char *peer;
 

--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -528,7 +528,7 @@
       count=${KLISH_PARAM_cnt:+-c $KLISH_PARAM_cnt}
       size=${KLISH_PARAM_sz:+-s $KLISH_PARAM_sz}
       verbose=${KLISH_PARAM_verbose:+-vvv}
-      tcpdump -ln $count $size $verbose -i $KLISH_PARAM_iface $KLISH_PARAM_expr
+      doas tcpdump -ln $count $size $verbose -i $KLISH_PARAM_iface $KLISH_PARAM_expr
     </ACTION>
   </COMMAND>
 

--- a/test/infamy/restconf.py
+++ b/test/infamy/restconf.py
@@ -207,7 +207,13 @@ class Device(Transport):
             dspath = f"{dspath}/{path}"
 
         url = f"{self.restconf_url}{dspath}"
-        return self._get_raw(url, parse)
+        try:
+            return self._get_raw(url, parse)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                return None
+            else:
+                raise e
 
     def get_running(self, path=None):
         """Wrapper function to get running datastore"""


### PR DESCRIPTION
## Description

 - Fixes a regression introduced on `main` while fixing issue #658
 - Check for `control-plane-protocol` in `startup-config` before migrating and causing empty `startup-config`
 - Return `None` on 404 return for fetching a given operational XPath in RESTCONF test backend
 - Fix `tcpdump` permissions for `admin` user in CLI

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [x] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

