### PR TITLE
test: use static time in ietf-routing unit tests

### DIFF
--- a/src/statd/python/cli_pretty/cli_pretty.py
+++ b/src/statd/python/cli_pretty/cli_pretty.py
@@ -5,6 +5,7 @@ import sys
 import re
 from datetime import datetime, timezone
 
+UNIT_TEST = False
 
 class Pad:
     iface = 16
@@ -79,6 +80,10 @@ class Decore():
     def underline(txt):
         return Decore.decorate("4", txt, "24")
 
+def datetime_now():
+    if UNIT_TEST:
+        return datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    return datetime.now(timezone.utc)
 
 def get_json_data(default, indata, *args):
     data = indata
@@ -156,7 +161,7 @@ class Route:
             adjusted = self.last_updated
 
         last_updated = datetime.strptime(adjusted, '%Y-%m-%dT%H:%M:%S%z')
-        current_time = datetime.now(timezone.utc)
+        current_time = datetime_now()
         uptime_delta = current_time - last_updated
 
         hours, remainder = divmod(int(uptime_delta.total_seconds()), 3600)
@@ -677,6 +682,8 @@ def show_hardware(json):
             port.print()
 
 def main():
+    global UNIT_TEST
+
     try:
         json_data = json.load(sys.stdin)
     except json.JSONDecodeError:
@@ -688,6 +695,8 @@ def main():
 
     parser = argparse.ArgumentParser(description="JSON CLI Pretty Printer")
     subparsers = parser.add_subparsers(dest='command', help='Commands')
+
+    parser.add_argument('-t', '--test', action='store_true', help='Enable unit test mode')
 
     parser_show_routing_table = subparsers.add_parser('show-routing-table', help='Show the routing table')
     parser_show_routing_table.add_argument('-i', '--ip', required=True, help='IPv4 or IPv6 address')
@@ -703,6 +712,7 @@ def main():
     parser_show_routing_table = subparsers.add_parser('show-hardware', help='Show USB ports')
 
     args = parser.parse_args()
+    UNIT_TEST = args.test
 
     if args.command == "show-interfaces":
         show_interfaces(json_data, args.name)

--- a/src/statd/python/yanger/yanger.py
+++ b/src/statd/python/yanger/yanger.py
@@ -11,6 +11,10 @@ from datetime import datetime, timedelta, timezone
 TESTPATH = ""
 logger = None
 
+def datetime_now():
+    if TESTPATH:
+        return datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    return datetime.now(timezone.utc)
 
 def json_get_yang_type(iface_in):
     if iface_in['link_type'] == "loopback":
@@ -234,7 +238,7 @@ def uptime2datetime(uptime):
     """Convert uptime (HH:MM:SS) to YANG format (YYYY-MM-DDTHH:MM:SS+00:00)"""
     h, m, s = map(int, uptime.split(':'))
     uptime_delta = timedelta(hours=h, minutes=m, seconds=s)
-    current_time = datetime.now(timezone.utc)
+    current_time = datetime_now()
     last_updated = current_time - uptime_delta
     date_timestd = last_updated.strftime('%Y-%m-%dT%H:%M:%S%z')
 

--- a/test/case/cli/run.sh
+++ b/test/case/cli/run.sh
@@ -55,8 +55,8 @@ if [ $# -eq 2 ] && [ $1 = "update" ]; then
              > "$CLI_OUTPUT_PATH/show-interface-${iface}.txt"
       done
     elif [ $2 = "show-routing-table" ]; then
-      "$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "show-routing-table" -i "ipv4" > "$CLI_OUTPUT_PATH/show-routes-ipv4.txt"
-      "$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "show-routing-table" -i "ipv6" > "$CLI_OUTPUT_PATH/show-routes-ipv6.txt"
+      "$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "-t" "show-routing-table" -i "ipv4" > "$CLI_OUTPUT_PATH/show-routes-ipv4.txt"
+      "$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "-t" "show-routing-table" -i "ipv6" > "$CLI_OUTPUT_PATH/show-routes-ipv6.txt"
     elif [ $2  = "show-bridge-mdb" ]; then
       "$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "show-bridge-mdb" > "$CLI_OUTPUT_PATH/show-bridge-mdb.txt"
     else
@@ -90,8 +90,8 @@ fi
 ok "\"show bridge mdb\" output looks intact"
 
 # Show ipv4 routes
-echo "# $SR_EMULATOR_TOOL | $CLI_PRETTY_TOOL show-routing-table -i ipv4"
-"$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "show-routing-table" -i "ipv4" > "$CLI_OUTPUT_FILE"
+echo "# $SR_EMULATOR_TOOL | $CLI_PRETTY_TOOL -t show-routing-table -i ipv4"
+"$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "-t" "show-routing-table" -i "ipv4" > "$CLI_OUTPUT_FILE"
 
 if ! diff -u "$CLI_OUTPUT_PATH/show-routes-ipv4.txt" "$CLI_OUTPUT_FILE"; then
     print_update_txt
@@ -100,8 +100,8 @@ fi
 ok "\"show routes ipv4\" output looks intact"
 
 # Show ipv6 routes
-echo "# $SR_EMULATOR_TOOL | $CLI_PRETTY_TOOL show-routing-table -i ipv6"
-"$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "show-routing-table" -i "ipv6" > "$CLI_OUTPUT_FILE"
+echo "# $SR_EMULATOR_TOOL | $CLI_PRETTY_TOOL -t show-routing-table -i ipv6"
+"$SR_EMULATOR_TOOL" | "$CLI_PRETTY_TOOL" "-t" "show-routing-table" -i "ipv6" > "$CLI_OUTPUT_FILE"
 
 if ! diff -u "$CLI_OUTPUT_PATH/show-routes-ipv6.txt" "$CLI_OUTPUT_FILE"; then
     print_update_txt


### PR DESCRIPTION
## Description
Fix flaky ietf-routing unit tests.

Prior to this patch, there was a unit-test race between Yanger (sysrepo emulator) and cli-pretty, where the local system time could change between crafting the data and printing it. This caused the CLI output to change and the ietf-routing unit test to fail.

Fixes #668 

## Checklist

- [x] Bugfix
  - [x] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):