### PR TITLE
Uboot improvements

### DIFF
--- a/board/common/uboot/scripts/ixboot.sh
+++ b/board/common/uboot/scripts/ixboot.sh
@@ -1,4 +1,4 @@
-echo "Press Ctrl-C NOW to enter boot menu"
+echo "Press Ctrl-C NOW to override the default boot sequence"
 if sleep "${ixbootdelay}"; then
     run ixbootorder
 
@@ -7,8 +7,12 @@ if sleep "${ixbootdelay}"; then
     reset
 fi
 
-bootmenu
 if test "${dev_mode}" != "yes"; then
+    bootmenu
     pause "Console shell access PROHIBITED. Press any key to reset..."
     reset
 fi
+
+echo
+echo 'Run "bootmenu" to interactively select a boot device'
+echo

--- a/board/common/uboot/scripts/ixprepdhcp.sh
+++ b/board/common/uboot/scripts/ixprepdhcp.sh
@@ -1,6 +1,6 @@
 setenv autoload no
 
-if dhcp; then
+if test -n "${ipaddr}" -a -n "${netmask}" -a -n "${serverip}" -a -n "${bootfile}" || dhcp; then
     setenv proto tftp
     setenv dltool tftpboot
 

--- a/board/common/uboot/scripts/ixprepdhcp.sh
+++ b/board/common/uboot/scripts/ixprepdhcp.sh
@@ -4,9 +4,12 @@ if test -n "${ipaddr}" -a -n "${netmask}" -a -n "${serverip}" -a -n "${bootfile}
     setenv proto tftp
     setenv dltool tftpboot
 
-    if setexpr proto sub "^(http|tftp)://.*" "\\1" "${bootfile}" && setexpr bootfile sub "^(http|tftp)://([^/]+?)/(.*)" "\2:\3"; then
+    if setexpr proto sub "^(http|tftp)://.*" "\\1" "${bootfile}"; then
 	if test "${proto}" = "http"; then
 	    setenv dltool wget
+	    setexpr bootfile sub "^http://([^/]+?)/(.*)" "\1:/\2"
+	else
+	    setexpr bootfile sub "^tftp://([^/]+?)/(.*)" "\1:\2"
 	fi
     fi
 


### PR DESCRIPTION
## Description

- Skip `bootmenu` when developer mode is enabled, drop straight into the shell
- Skip DHCP if the network has already been statically configured by the user
- Ensure that the path for HTTP GETs include a leading slash


## Other information

Example of netbooting over HTTP without a DHCP server:

```
[...]
Valid boot device found on mmc1 (order: net)
Press Ctrl-C NOW to override the default boot sequence

Run "bootmenu" to interactively select a boot device

(cn9130-crb) setenv ipaddr 198.18.106.2 
(cn9130-crb) setenv netmask 255.255.255.0
(cn9130-crb) setenv serverip 198.18.106.1
(cn9130-crb) setenv bootfile http://198.18.106.1/rootfs.itb
(cn9130-crb) run boot_net
net: Preparing...
proto=http
bootfile=198.18.106.1:/rootfs.itb
mvpp2 mvpp2-0: incorrect phy mode
mvpp2-1 Waiting for PHY auto negotiation to complete....... done
HTTP/1.0 200 OK| | | [...] | | |
Packets received 40507, Transfer Successful
Bytes transferred = 58646528 (37ee000 hex)
Working FDT set to a000000
Working fdt: 0a000000
net: Validating...
[...]
```

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

