### PR TITLE
cli: hide internal interfaces in tabcomplete

### DIFF
--- a/src/klish-plugin-infix/src/infix.c
+++ b/src/klish-plugin-infix/src/infix.c
@@ -361,7 +361,7 @@ int infix_files(kcontext_t *ctx)
 int infix_ifaces(kcontext_t *ctx)
 {
 	(void)ctx;
-	system("ls /sys/class/net");
+	system("ip -j link | jq -r '.[] | select(.group != \"internal\") | .ifname'");
 	return 0;
 }
 


### PR DESCRIPTION
## Description
Don't show "internal" interfaces in "show interface name" tab completion.

### Side note
I initially implemented this in the `show` command, as "show ifnames". It worked but was unreasonably slow for some reason, perhaps due to the `show` init code that does resize and such. As there's no variables involved I abandoned that approach and inlined it instead. 

## Checklist

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

