### PR TITLE
confd: fix double free of container hostname

### DIFF
--- a/src/confd/src/infix-containers.c
+++ b/src/confd/src/infix-containers.c
@@ -52,12 +52,10 @@ static int add(const char *name, struct lyd_node *cif)
 	if ((string = lydx_get_cattr(cif, "hostname"))) {
 		char *fmt = (char *)string;
 
-		if (hostnamefmt(&confd, &fmt)) {
+		if (hostnamefmt(&confd, &fmt))
 			ERRNO("%s: failed setting custom hostname", name);
-		} else {
+		else
 			fprintf(fp, " --hostname %s", fmt);
-			free(fmt);
-		}
 	}
 
 	if (lydx_is_enabled(cif, "read-only"))


### PR DESCRIPTION
## Description
Fix a double free in the memory minefield surrounding container hostname provisioning. The hostnamefmt() function already does free() on success.

This caused all sorts of mayhem when working with multiple containers. However it mainly manifested itself by some containers not starting due to there activation script being polluted with gibberish name data. Your symptom might be different..

### Example of polluted activation script
``container --hostname foobar --net veth0k -r always \
  create ^S@`M-}^G docker://ghcr.io/kernelkit/curios:edge``


## Side note
I haven't looked into it but is it really legit to free memory returned from the various lydx_ functions used here?
It seems to work as intended but it looks risky at a glance.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
