### PR TITLE
Doc fix on QoS. PCP takes priority over DSCP for tagged IP packets

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -10,6 +10,9 @@ All notable changes to the project are documented in this file.
 addresses for interfaces!  For details, see below issue #680.
 
 ### Changes
+- Correcting documentation on QoS. For packets containing both a VLAN
+  tag and an IP header, PCP priority takes precedence over DSCP
+  priority (not vice versa).
 - Update CONTRIBUTING.md for scaling core team and helping external
   contributors understand the development process, issue #672
 - OSPF: Add limitation to only allow one interface per area

--- a/doc/qos.md
+++ b/doc/qos.md
@@ -54,8 +54,8 @@ significant bits of the DSCP is used to select the queue:
 |   6 | 48-55 | ⇒ |     6 |     25 |
 |   7 | 56-63 | ⇒ |     7 |     33 |
 
-For packets containing both a VLAN tag and an IP header, DSCP priority
-takes precedence over PCP priority. In cases where neither are
+For packets containing both a VLAN tag and an IP header, PCP priority
+takes precedence over DSCP priority. In cases where neither are
 available, packets are always assigned to queue 0.
 
 Each port's set of 8 egress queues operate on a Weighted Round Robin


### PR DESCRIPTION
## Description

For packets containing both a VLAN tag and an IP header, PCP priority takes precedence over DSCP priority (**not** vice versa).
This is how QoS is currently handled and how we want it to be by default. 
No code change, just doc change.


## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [X] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Other (please describe):
