### PR TITLE
Statd: Add 'admin-status' to Interface Operational Data

### DIFF
--- a/src/statd/python/yanger/yanger.py
+++ b/src/statd/python/yanger/yanger.py
@@ -664,6 +664,15 @@ def add_ip_link(ifname, iface_in, iface_out):
     if 'link' in iface_in and not iface_is_dsa(iface_in):
         insert(iface_out, "infix-interfaces:vlan", "lower-layer-if", iface_in['link'])
 
+    if 'flags' in iface_in:
+        admin_xlate = { 
+            "UP": "up", 
+            "DOWN": "down" 
+            }
+
+        admin_status = admin_xlate.get("UP" if "UP" in iface_in['flags'] else "DOWN", "testing")
+        iface_out['admin-status'] = admin_status
+
     if 'operstate' in iface_in:
         xlate = {
                 "DOWN":                "down",


### PR DESCRIPTION
The interface operational data was missing the 'admin-status' parameter, which indicates whether an interface is administratively enabled or disabled. 
To resolve this, the 'admin-status' was added to the 'yanger' library, allowing 'statd' to retrieve and include this parameter in the operational data.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
