### PR TITLE
U-Boot HTTP Netboot Fixes

### DIFF
--- a/board/common/uboot/scripts/ixprepdhcp.sh
+++ b/board/common/uboot/scripts/ixprepdhcp.sh
@@ -1,6 +1,6 @@
 setenv autoload no
 
-if test -n "${ipaddr}" -a -n "${netmask}" -a -n "${serverip}" -a -n "${bootfile}" || dhcp; then
+if test -n "${ipaddr}" || dhcp; then
     setenv proto tftp
     setenv dltool tftpboot
 

--- a/board/common/uboot/scripts/ixprepdhcp.sh
+++ b/board/common/uboot/scripts/ixprepdhcp.sh
@@ -3,17 +3,18 @@ setenv autoload no
 if test -n "${ipaddr}" || dhcp; then
     setenv proto tftp
     setenv dltool tftpboot
+    setenv dlfile "${bootfile}"
 
     if setexpr proto sub "^(http|tftp)://.*" "\\1" "${bootfile}"; then
 	if test "${proto}" = "http"; then
 	    setenv dltool wget
-	    setexpr bootfile sub "^http://([^/]+?)/(.*)" "\1:/\2"
+	    setexpr dlfile sub "^http://([^/]+?)/(.*)" "\\1:/\\2" "${bootfile}"
 	else
-	    setexpr bootfile sub "^tftp://([^/]+?)/(.*)" "\1:\2"
+	    setexpr dlfile sub "^tftp://([^/]+?)/(.*)" "\\1:\\2" "${bootfile}"
 	fi
     fi
 
-    if ${dltool} ${ramdisk_addr_r} "${bootfile}"; then
+    if ${dltool} ${ramdisk_addr_r} "${dlfile}"; then
 	setenv old_fdt_addr ${fdt_addr}
 	if fdt addr ${ramdisk_addr_r}; then
 	    fdt get value sqoffs /images/rootfs data-position


### PR DESCRIPTION
## Description

Fix repeated HTTP netboot attempts. Avoid having to supply `serverip` when `proto://path` format is used for `bootfile`.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
