### PR TITLE
Allow admin to run 'show ntp'

### DIFF
--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -268,10 +268,10 @@
   </COMMAND>
 
   <COMMAND name="ntp" help="Show NTP (client) status">
-    <ACTION sym="script">ntp tracking</ACTION>
+    <ACTION sym="script">doas ntp tracking</ACTION>
     <SWITCH name="optional" min="0">
       <COMMAND name="sources" help="Show NTP sources">
-        <ACTION sym="script">ntp sources</ACTION>
+        <ACTION sym="script">doas ntp sources</ACTION>
       </COMMAND>
     </SWITCH>
   </COMMAND>


### PR DESCRIPTION
`show ntp` command could not be run from the `cli` for `admin` user.
Minor fix in klish-plugin-infix/infix.xml 

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
