### PR TITLE
Add support for overriding the compatible string

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -52,6 +52,17 @@ config INFIX_IMAGE_ID
 	  Mandatory.  When INFIX_RELEASE is set, this string is appended to
 	  the IMAGE_ID with a '-' separator.
 
+config INFIX_COMPATIBLE
+	string "Operating system compatible string"
+	default "${INFIX_IMAGE_ID}"
+	help
+	  A lower-case string (no spaces or other characters outside of 0–9,
+	  a–z, ".", "_" and "-"), used for image identification at upgrade.
+	  E.g., the RAUC [system] compatible string.
+
+	  Mandatory.  Defaults to $INFIX_IMAGE_ID, which in turn is composed
+	  of $INFIX_ID-$BR2_ARCH.
+
 config INFIX_TAGLINE
 	string "Operating system tagline"
 	default "Infix -- a Network Operating System"

--- a/board/common/post-build.sh
+++ b/board/common/post-build.sh
@@ -62,7 +62,7 @@ else
 fi
 
 if [ -f "$TARGET_DIR/etc/rauc/system.conf" ]; then
-    sed -i "s/compatible=.*/compatible=$NAME/" "$TARGET_DIR/etc/rauc/system.conf"
+    sed -i "s/compatible=.*/compatible=$INFIX_COMPATIBLE/" "$TARGET_DIR/etc/rauc/system.conf"
 fi
 
 # This is a symlink to /usr/lib/os-release, so we remove this to keep


### PR DESCRIPTION
## Description

Some customers would like to seamlessly upgrade between their branded Infix-based software and vanilla Infix.  E.g., for testing of new features and end-customer support.

This PR adds support for overriding the default compatible string, which by default is taken from `INFIX_IMAGE_ID`, created from the `INFIX_ID` in the defconfig and `BR2_ARCH`.  This new setting, `INFIX_COMPATIBLE` is by default `INFIX_IMAGE_ID`.

Background, the `INFIX_IMAGE_ID` is also used for the image file names, as well as the tarballs, so overriding that in the defconfig has wider implications.  Hence this extension.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [X] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
