### PR TITLE
Update r2s factory-config

### DIFF
--- a/board/aarch64/r2s/rootfs/etc/factory-config.cfg
+++ b/board/aarch64/r2s/rootfs/etc/factory-config.cfg
@@ -58,6 +58,7 @@
     }
   },
   "ietf-netconf-acm:nacm": {
+    "enable-nacm": true,
     "groups": {
       "group": [
         {
@@ -81,6 +82,21 @@
             "access-operations": "*",
             "action": "permit",
             "comment": "Allow 'admin' group complete access to all operations and data."
+          }
+        ]
+      },
+      {
+        "name": "default-deny-all",
+        "group": [
+          "*"
+        ],
+        "rule": [
+          {
+            "name":  "deny-password-read",
+            "module-name": "ietf-system",
+            "path": "/ietf-system:system/authentication/user/password",
+            "access-operations": "*",
+            "action": "deny"
           }
         ]
       }
@@ -123,7 +139,8 @@
           "name": "ntp.org",
           "udp": {
             "address": "pool.ntp.org"
-          }
+          },
+	  "iburst": true
         }
       ]
     },
@@ -169,7 +186,7 @@
     ]
   },
   "infix-meta:meta": {
-    "infix-meta:version": "1.0"
+    "infix-meta:version": "1.2"
   },
   "infix-services:mdns": {
     "enabled": true


### PR DESCRIPTION
## Description

 - add default-deny-all rule from 2341e07
 - enable iburst for the ntp client (quicker initial sync)
 - bump meta version (to skip .cfg migration at boot)

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
