### PR TITLE
Simplify Running Infix Tests from External Projects

### DIFF
--- a/test/env
+++ b/test/env
@@ -96,14 +96,18 @@ start_topology()
     done
 
     base_img=$(get_base_img "$files")
-    $testdir/inject-test-mode -b "$base_img" -o "${base_img%-disk.img}-disk-test.img"
+    test_img="${base_img%-disk.img}-disk-test.img"
+    
+    $testdir/inject-test-mode -b "$base_img" -o "$test_img"
+
+    img_name=$(basename "$test_img")
+    sed -i "s/qn_image=\".*\"/qn_image=\"$img_name\"/" "$envdir/qeneth/topology.dot.in"
 
     (cd "$envdir/qeneth/" && $qeneth generate && $qeneth start)
     INFAMY_ARGS="$INFAMY_ARGS $envdir/qeneth/topology.dot"
 
     cat <<EOF >"$envdir/bin/qeneth"
 #!/bin/sh
-set -x
 cd $envdir/qeneth && exec $testdir/qeneth/qeneth "\$@"
 EOF
     chmod +x "$envdir/bin/qeneth"

--- a/test/test.mk
+++ b/test/test.mk
@@ -13,18 +13,16 @@ GIT_PATH            = $(BR2_EXTERNAL_INFIX_PATH)
 endif
 GIT_VERSION         = $(shell git -C $(GIT_PATH) describe --dirty --always --tags)
 
-IMAGE ?= infix
-TOPOLOGY-DIR ?= $(test-dir)/virt/quad
-
 base := -b $(base-dir)
 
 TEST_MODE ?= qeneth
-mode-qeneth := -q $(TOPOLOGY-DIR)
+mode-qeneth := -q $(test-dir)/virt/quad
 mode-host   := -t $(or $(TOPOLOGY),/etc/infamy.dot)
 mode-run    := -t $(BINARIES_DIR)/qemu.dot
 mode        := $(mode-$(TEST_MODE))
 
-binaries-$(ARCH) := $(addprefix $(IMAGE)-$(ARCH),.img -disk.img .pkg)
+INFIX_IMAGE_ID := $(call qstrip,$(INFIX_IMAGE_ID))
+binaries-$(ARCH) := $(addprefix $(INFIX_IMAGE_ID),.img -disk.img .pkg)
 binaries-x86_64  += OVMF.fd
 binaries := $(foreach bin,$(binaries-$(ARCH)),-f $(BINARIES_DIR)/$(bin))
 


### PR DESCRIPTION
This will facilitate running infix tests from external projects:
  - eliminate the need for an external topology.dot.in file
  - eliminate the requirement to manually provide external image name

Fixes #763

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
