### PR TITLE
nghttp2-asio: resolve numeric IPv6 server address

### DIFF
--- a/patches/nghttp2-asio/0001-resolve-numeric-ipv6.patch
+++ b/patches/nghttp2-asio/0001-resolve-numeric-ipv6.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/asio_server.cc b/lib/asio_server.cc
+index 74c9227..c3d42aa 100644
+--- a/lib/asio_server.cc
++++ b/lib/asio_server.cc
+@@ -82,8 +82,13 @@ boost::system::error_code server::bind_and_listen(boost::system::error_code &ec,
+   // Open the acceptor with the option to reuse the address (i.e.
+   // SO_REUSEADDR).
+   tcp::resolver resolver(io_service_pool_.get_io_service());
++
+   tcp::resolver::query query(address, port);
+   auto it = resolver.resolve(query, ec);
++  if (ec) {
++    tcp::resolver::query query(address, port, boost::asio::ip::resolver_query_base::numeric_host);
++    auto it = resolver.resolve(query, ec);
++  }
+   if (ec) {
+     return ec;
+   }


### PR DESCRIPTION
The boost library refuses to resolve a numeric IPv6 host (::1) because its resolver flags are set to 'address_configured' by default. This patch simply runs an additional query in such a case with flags set to 'numeric_host'.

See https://www.boost.org/doc/libs/1_83_0/doc/html/boost_asio/reference/ip__resolver_base.html for more info.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
