### PR TITLE
Enable rngd by default

### DIFF
--- a/package/skeleton-init-finit/skeleton-init-finit.mk
+++ b/package/skeleton-init-finit/skeleton-init-finit.mk
@@ -204,6 +204,14 @@ endif
 
 endif # BR2_PACKAGE_QUAGGA
 
+ifeq ($(BR2_PACKAGE_RNG_TOOLS),y)
+define SKELETON_INIT_FINIT_SET_RNGD
+	cp $(SKELETON_INIT_FINIT_AVAILABLE)/rngd.conf $(FINIT_D)/available/
+	ln -sf ../available/rngd.conf $(FINIT_D)/enabled/rngd.conf
+endef
+SKELETON_INIT_FINIT_POST_INSTALL_TARGET_HOOKS += SKELETON_INIT_FINIT_SET_RNGD
+endif
+
 ifeq ($(BR2_PACKAGE_SMCROUTE),y)
 define SKELETON_INIT_FINIT_SET_SMCROUTE
 	cp $(SKELETON_INIT_FINIT_AVAILABLE)/smcroute.conf $(FINIT_D)/available/

--- a/package/skeleton-init-finit/skeleton/etc/finit.d/available/rngd.conf
+++ b/package/skeleton-init-finit/skeleton/etc/finit.d/available/rngd.conf
@@ -1,0 +1,1 @@
+service [S12345789] log rngd -f -- Entropy gathering daemon (rngd)


### PR DESCRIPTION
## Description

Platforms with `/dev/hwrandom` should use that to see `/dev/urandom`.  We already have rngd from rng-tools installed, so all we need to do is start it early at boot.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
