### PR TITLE
Documentation of forwarding IEEE reserved group addresses

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -27,6 +27,8 @@ All notable changes to the project are documented in this file.
   command examples for disabling LLDP and mDNS services, issue #786
 - Updated OSPF documentation to include information on *global OSPF
   settings* (`redistribution`, `explicit-router-id`, etc.), issue #812
+- Added information on *forwarding of IEEE reserved group addresses*
+  to bridge section of networking documentation, issue #788
 
 ### Fixes
 - Fix #685: DSA conduit interface not always detected, randomly causing

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -383,6 +383,33 @@ an IGMP/MLD fast-leave port.
 [RFC3376]: https://www.rfc-editor.org/rfc/rfc3376.html
 [RFC3810]: https://www.rfc-editor.org/rfc/rfc3810.html
 
+#### Forwarding of IEEE Reserved Group Addresses
+
+Addresses in range `01:80:C2:00:00:0X` are used by various bridge
+signaling protocols, and are not forwarded by default. Still, it can
+be useful to let the bridge forward such packets transparently in
+specific use cases. Infix supports enabling forwarding of individual
+reserved addresses (per bridge), by specifying the protocol name or
+the last address *nibble* as a value `0..15`.
+
+```
+admin@example:/config/> edit interface br0 bridge
+admin@example:/config/interface/br0/bridge/> set ieee-group-forward <?>
+  [0..15]  List of IEEE link-local protocols to forward, e.g., STP, LLDP
+  dot1x    802.1X Port-Based Network Access Control.
+  lacp     802.3 Slow Protocols, e.g., LACP.
+  lldp     802.1AB Link Layer Discovery Protocol (LLDP).
+  stp      Spanning Tree (STP/RSPT/MSTP).
+admin@example:/config/interface/br0/bridge/> set ieee-group-forward
+```
+
+The following example configures bridge *br0* to forward LLDP packets.
+
+```
+admin@example:/config/interface/br0/bridge/> set ieee-group-forward lldp
+admin@example:/config/interface/br0/bridge/>
+```
+
 ### VLAN Interfaces
 
 Creating a VLAN can be done in many ways. This section assumes VLAN

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -386,11 +386,10 @@ an IGMP/MLD fast-leave port.
 #### Forwarding of IEEE Reserved Group Addresses
 
 Addresses in range `01:80:C2:00:00:0X` are used by various bridge
-signaling protocols, and are not forwarded by default. Still, it can
-be useful to let the bridge forward such packets transparently in
-specific use cases. Infix supports enabling forwarding of individual
-reserved addresses (per bridge), by specifying the protocol name or
-the last address *nibble* as a value `0..15`.
+signaling protocols, and are not forwarded by default. Still, it is
+sometimes useful to let the bridge forward such packets, and Infix
+supports this by specifying protocol names or the last address
+*nibble* as decimal value `0..15`.
 
 ```
 admin@example:/config/> edit interface br0 bridge


### PR DESCRIPTION
## Description

Add documentation of forwarding IEEE reserved group addresses to bridge section of networking documentation

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [X] Documentation content changes
  - [X] ChangeLog updated (for major changes)
- [ ] Other (please describe):
