### PR TITLE
Early bootstrap refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
     runs-on: [ self-hosted, release ]
     permissions:
       contents: write
+      discussions: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/board/aarch64/dts/styx/dcp-sc-28p.dtsi
+++ b/board/aarch64/dts/styx/dcp-sc-28p.dtsi
@@ -276,6 +276,12 @@
 			color = <LED_COLOR_ID_GREEN>; \
 			default-state = "keep"; \
 		}; \
+		led@1 { \
+			reg = <1>; \
+			function = _func; \
+			color = <LED_COLOR_ID_YELLOW>; \
+			default-state = "off"; \
+		}; \
 	}
 
 #define XSWP(_n, _label, _mac_offs, _sfp) \

--- a/board/aarch64/dts/styx/dcp-sc-28p.dtsi
+++ b/board/aarch64/dts/styx/dcp-sc-28p.dtsi
@@ -265,22 +265,40 @@
 	};
 };
 
-#define SWP_LED(_func) \
+#define SWP_LED \
 	leds { \
 		#address-cells = <1>; \
 		#size-cells = <0>; \
 		\
 		led@0 { \
 			reg = <0>; \
-			function = _func; \
+			function = "tp"; \
 			color = <LED_COLOR_ID_GREEN>; \
 			default-state = "keep"; \
 		}; \
 		led@1 { \
 			reg = <1>; \
-			function = _func; \
-			color = <LED_COLOR_ID_YELLOW>; \
+			function = "aux"; \
+			color = <LED_COLOR_ID_GREEN>; \
 			default-state = "off"; \
+		}; \
+	}
+
+/* SFP LEDs
+ * Rev A. LEDs do not work at all
+ * Rev B. only outer-most (green) LEDs work
+ */
+
+#define SFP_LED \
+	leds { \
+		#address-cells = <1>; \
+		#size-cells = <0>; \
+		\
+		led@0 { \
+			reg = <0>; \
+			function = "sfp"; \
+			color = <LED_COLOR_ID_GREEN>; \
+			default-state = "keep"; \
 		}; \
 	}
 
@@ -293,7 +311,7 @@
 		phy-mode = "10gbase-r"; \
 		managed = "in-band-status"; \
 		sfp = <_sfp>; \
-		SWP_LED("sfp"); \
+		SFP_LED; \
 	}
 
 #define XSWCPU(_n, _eth) \
@@ -327,7 +345,7 @@
 		nvmem-cell-names = "mac-address"; \
 		phy-mode = "gmii"; \
 		phy-handle = <_phy>; \
-		SWP_LED("tp"); \
+		SWP_LED; \
 	}
 
 #define GPHY(_n) \

--- a/board/aarch64/rootfs/usr/libexec/styx/led.sh
+++ b/board/aarch64/rootfs/usr/libexec/styx/led.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+# Raw switch LED Control for systems that do not run iitod
+
+
+LEDS=$(find /sys/class/leds -iname '*mdio-mii*')
+LINK=$(find /sys/class/leds -iname '*mdio-mii*p')
+
+# Disable ALL switch port LEDs
+clear()
+{
+    for led in $LEDS; do
+        echo 0 > "${led}/brightness"
+    done
+}
+
+setup()
+{
+    for led in $LINK; do
+        echo netdev > "${led}/trigger"
+    done
+
+    for led in $LINK; do
+        cd "$led"
+	# No sleep here, it's enough with the delay from previous loop
+        echo 1 > link
+        sleep 0.1
+        echo 1 > rx
+        sleep 0.1
+        echo 1 > tx
+        cd - >/dev/null
+    done
+}
+
+leds()
+{
+    for led in $LINK; do
+         printf "%3s: %s\n" "$(cat "$led/device_name" 2>/dev/null)" "$led"
+    done
+}
+
+list()
+{
+    leds | sort | while read -r port path; do
+        printf "%4s %s\n" "$port" "$(basename "$path")"
+
+        aux=${path%%:tp}:aux
+        if [ -e "$aux" ]; then
+            printf "%3s: %s\n" "" "$(basename "$aux")"
+        fi
+    done
+}
+
+flash()
+{
+    sec=$1
+
+    for led in $LEDS; do
+        echo timer > "${led}/trigger"
+    done
+
+    for led in $LEDS; do
+        echo 84 > "${led}/delay_on"
+        echo 84 > "${led}/delay_off"
+    done
+
+    sleep "$sec"
+    clear
+}
+
+usage()
+{
+    echo "usage: $0 [command]"
+    echo
+    echo "flash [SEC]  Flash all LEDs to locate device in rack, default: 5 sec"
+    echo "list         List all LEDs"
+    echo "setup        Set up and start normal operation"
+    echo "start        Call at system init, clears all LEDs and sets up normal op"
+    echo "stop         Clear all LEDs, may be called at system shutdown"
+    echo
+    echo "Please ensure no other tool or daemon is already managing the LEDs."
+}
+
+cmd=$1; shift
+case $cmd in
+    flash)
+        flash ${1:-5}
+        setup
+        ;;
+    help)
+	usage
+	exit 0
+	;;
+    list | ls)
+        list
+        ;;
+    setup)
+	setup
+	;;
+    start)
+	initctl -nbq cond clear led
+	clear
+	setup
+        ;;
+    stop)
+	clear
+	;;
+    *)
+        usage
+	exit 1
+        ;;
+esac

--- a/board/aarch64/rootfs/usr/share/product/styx,dcp-sc-28p/etc/product/init.d/S10-led
+++ b/board/aarch64/rootfs/usr/share/product/styx,dcp-sc-28p/etc/product/init.d/S10-led
@@ -1,0 +1,1 @@
+/usr/libexec/styx/led.sh

--- a/board/common/rootfs/etc/default/rauc
+++ b/board/common/rootfs/etc/default/rauc
@@ -1,0 +1,1 @@
+RAUC_ARGS="-s"

--- a/board/common/rootfs/etc/machine-id
+++ b/board/common/rootfs/etc/machine-id
@@ -1,0 +1,1 @@
+/var/lib/dbus/machine-id

--- a/board/common/rootfs/usr/libexec/infix/init.d/00-probe
+++ b/board/common/rootfs/usr/libexec/infix/init.d/00-probe
@@ -8,9 +8,10 @@ import struct
 import subprocess
 import sys
 
-onieprom = importlib.machinery.SourceFileLoader("onieprom","/bin/onieprom").load_module()
-SYSTEM_JSON   = "/run/system.json"
+onieprom = importlib.machinery.SourceFileLoader("onieprom", "/bin/onieprom").load_module()
+SYSTEM_JSON = "/run/system.json"
 KKIT_IANA_PEM = 61046
+
 
 class DTSystem:
     BASE = "/sys/firmware/devicetree/base"
@@ -28,7 +29,9 @@ class DTSystem:
             if not os.path.exists(phandle):
                 continue
 
-            ph, = struct.unpack(">L", open(phandle, "rb").read())
+            with open(phandle, "rb") as f:
+                data = f.read()
+            ph, = struct.unpack(">L", data)
             dt[ph] = root
 
         sys = {}
@@ -40,14 +43,18 @@ class DTSystem:
             if not os.path.exists(phandle):
                 continue
 
-            ph, = struct.unpack(">L", open(phandle, "rb").read())
+            with open(phandle, "rb") as f:
+                data = f.read()
+            ph, = struct.unpack(">L", data)
             if ph not in sys:
                 sys[ph] = []
             sys[ph].append(root)
 
         phs = set(list(dt.keys()) + list(sys.keys()))
 
-        self.devs = { ph: [Device(ph, dt.get(ph), s if s is not None else "") for s in (sys.get(ph) or []) if ph is not None]  for ph in phs }
+        self.devs = {ph: [Device(ph, dt.get(ph), s if s is not None else "")
+                          for s in (sys.get(ph) or []) if ph is not None]
+                     for ph in phs}
         self.base = Device(0, None, DTSystem.BASE)
         self.infix = Device(0, None, DTSystem.INFIX)
 
@@ -56,7 +63,8 @@ class DTSystem:
         if not os.path.exists(path):
             return ()
 
-        data = open(path, "rb").read()
+        with open(path, "rb") as f:
+            data = f.read()
         elems = len(data) // struct.calcsize(">L")
         return struct.unpack(">" + elems * "L", data)
 
@@ -69,7 +77,8 @@ class DTSystem:
                 return {}
 
             try:
-                data = onieprom.from_tlv(open(dev.attrpath("nvmem"), "rb", 0))
+                with open(dev.attrpath("nvmem"), "rb", 0) as f:
+                    data = onieprom.from_tlv(f)
             except:
                 data = {}
 
@@ -84,14 +93,18 @@ class DTSystem:
         }
 
     def infix_usb_devices(self, out):
-        names=self.infix.str_array("usb-port-names", ())
-        phs=self.__get_phandle_array("usb-ports")
-        data=dict(zip(names,phs))
+        names = self.infix.str_array("usb-port-names", ())
+        phs = self.__get_phandle_array("usb-ports")
+        data = dict(zip(names, phs))
         if data != {}:
             out["usb-ports"] = []
-        for name,ph in data.items():
-            [out["usb-ports"].extend([{"name": name, "path": dev.attrpath("authorized")}, {"name": name, "path": dev.attrpath("authorized_default")}]) for dev in self.devices_from_ph(ph)]
-
+        for name, ph in data.items():
+            [out["usb-ports"].extend([{
+                "name": name,
+                "path": dev.attrpath("authorized")}, {
+                    "name": name,
+                    "path": dev.attrpath("authorized_default")
+                }]) for dev in self.devices_from_ph(ph)]
 
     def infix_devices(self, kind):
         phs = self.__get_phandle_array(kind)
@@ -100,6 +113,7 @@ class DTSystem:
     def infix_vpds(self):
         flat_devices = [device for sublist in self.infix_devices("vpds") for device in sublist]
         return [self.into_vpd(device) for device in flat_devices]
+
 
 class QEMUSystem:
     BASE = "/sys/firmware/qemu_fw_cfg"
@@ -110,7 +124,8 @@ class QEMUSystem:
         data = {}
         if os.path.exists(QEMUSystem.VPD):
             try:
-                data = onieprom.from_tlv(open(QEMUSystem.VPD, "rb", 0))
+                with open(QEMUSystem.VPD, "rb", 0) as f:
+                    data = onieprom.from_tlv(f)
             except:
                 pass
 
@@ -127,38 +142,33 @@ class QEMUSystem:
     def usb_ports(self):
         ports = [
             {
-            "name": "USB",
-            "path": "/sys/bus/usb/devices/usb1/authorized"
-
-        },
-        {
-            "name": "USB",
-            "path": "/sys/bus/usb/devices/usb1/authorized_default"
-
-        },
-        {
-            "name": "USB2",
-            "path": "/sys/bus/usb/devices/usb2/authorized"
-        },
-        {
-            "name": "USB2",
-            "path": "/sys/bus/usb/devices/usb2/authorized_default"
-
-        }]
+                "name": "USB",
+                "path": "/sys/bus/usb/devices/usb1/authorized"
+            }, {
+                "name": "USB",
+                "path": "/sys/bus/usb/devices/usb1/authorized_default"
+            }, {
+                "name": "USB2",
+                "path": "/sys/bus/usb/devices/usb2/authorized"
+            }, {
+                "name": "USB2",
+                "path": "/sys/bus/usb/devices/usb2/authorized_default"
+            }]
         return ports
+
+
 class Device:
     def __init__(self, ph, dtpath, syspath):
         self.ph, self.dtpath, self.syspath = ph, dtpath, syspath
 
     def available(self):
-        return self.syspath != None
+        return self.syspath is not None
 
     def __getitem__(self, attr):
         return self.attr(attr).decode("utf-8").strip("\0")
 
     def __setitem__(self, attr, value):
         return self.attr(attr, val=value.encode("utf-8"))
-
 
     def attrpath(self, attr):
         return os.path.join(self.syspath, attr)
@@ -168,13 +178,16 @@ class Device:
 
     def attr(self, attr, default=None, val=None):
         if not self.hasattr(attr):
-            return default if val == None else False
+            return default if val is None else False
 
         if val:
-            open(self.attrpath(attr), "wb").write(value)
+            with open(self.attrpath(attr), "wb") as f:
+                f.write(val)
             return True
 
-        return open(self.attrpath(attr), "rb").read()
+        with open(self.attrpath(attr), "rb") as f:
+            data = f.read()
+        return data
 
     def str(self, attr, default=None):
         val = self.attr(attr)
@@ -194,7 +207,9 @@ class Device:
         if not self.hasdtattr(attr):
             return default
 
-        return open(self.dtattrpath(attr), "rb").read()
+        with open(self.dtattrpath(attr), "rb") as f:
+            data = f.read()
+        return data
 
     def dtstr(self, attr, default=None):
         val = self.dtattr(attr)
@@ -212,6 +227,7 @@ def vpd_get_json_ve(vpd, pem):
 
     return out
 
+
 def vpd_get_pwhash(vpd):
     if not vpd.get("trusted"):
         return None
@@ -219,8 +235,9 @@ def vpd_get_pwhash(vpd):
     kkit = vpd_get_json_ve(vpd, KKIT_IANA_PEM)
     return kkit.get("pwhash")
 
+
 def vpd_inject(out, vpds):
-    out["vpd"] = { vpd["board"]: vpd for vpd in vpds }
+    out["vpd"] = {vpd["board"]: vpd for vpd in vpds}
 
     product = out["vpd"].get("product", {}).get("data", {})
     hoistattrs = ("vendor", "product-name", "part-number", "serial-number", "mac-address")
@@ -234,6 +251,7 @@ def vpd_inject(out, vpds):
             out["factory-password-hash"] = pwhash
             break
 
+
 def qemu_base_mac():
     """Find MAC address of first non-loopback interface, subtract with 1"""
     base_path = '/sys/class/net'
@@ -244,7 +262,8 @@ def qemu_base_mac():
             continue
         try:
             # pylint: disable=invalid-name
-            with open(os.path.join(base_path, iface, 'address'), 'r', encoding='ascii') as f:
+            fn = os.path.join(base_path, iface, 'address')
+            with open(fn, 'r', encoding='ascii') as f:
                 mac = f.read().strip()
             interfaces.append((mac, iface))
         except FileNotFoundError:
@@ -260,6 +279,7 @@ def qemu_base_mac():
         return mac
 
     return None
+
 
 def probe_qemusystem(out):
     """Probe Qemu based test systems and 'make run'"""
@@ -288,6 +308,7 @@ def probe_qemusystem(out):
     subprocess.run("initctl -nbq cond set qemu".split(), check=False)
     return 0
 
+
 def probe_dtsystem(out):
     """Probe DTS based system, expects a VPD in ONIE PROM format."""
     dtsys = DTSystem()
@@ -303,6 +324,7 @@ def probe_dtsystem(out):
 
     vpd_inject(out, vpds)
     return 0
+
 
 def main():
     out = {
@@ -337,6 +359,7 @@ def main():
         json.dump(out, f)
     shutil.chown(SYSTEM_JSON, user="root", group="wheel")
     return err
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/board/common/rootfs/usr/libexec/infix/init.d/00-probe
+++ b/board/common/rootfs/usr/libexec/infix/init.d/00-probe
@@ -318,6 +318,8 @@ def probe_dtsystem(out):
     if model:
         out["product-name"] = model
 
+    out["compatible"] = dtsys.base.str_array("compatible")
+
     staticpw = dtsys.infix.str("factory-password-hash")
     if not out["factory-password-hash"]:
         out["factory-password-hash"] = staticpw

--- a/board/common/rootfs/usr/libexec/infix/init.d/05-product
+++ b/board/common/rootfs/usr/libexec/infix/init.d/05-product
@@ -1,22 +1,41 @@
 #!/bin/sh
-# Find and install any product specific files in /etc before bootstrap
+# Find, install, and run product specific files and script in /etc
+# before resuming bootstrap.
+#
+# Use /etc/product/init.d/S01-myscript for scripts, may be a symlink, it
+# will be called with `start` as its only argument.
+#
+# The compatible array is listed in the same order as the device tree,
+# most significant to least.  Hence the reverse.[], to ensure overrides
+# are applied in order of significance.
 ident=$(basename "$0")
 
+PRODUCT_INIT=/etc/product/init.d
 PREFIXD=/usr/share/product
-PRODUCT=$(jq -r '."product-name" | ascii_downcase' /run/system.json)
+COMPATIBLES=$(jq -r '.compatible | reverse.[] | ascii_downcase' /run/system.json)
 
 note()
 {
     logger -I $$ -k -p user.notice -t "$ident" "$1"
 }
 
-DIR="$PREFIXD/$PRODUCT"
-if [ -z "$PRODUCT" ] || [ ! -d "$DIR" ]; then
-    note "No vendor/product specific directory found, using built-in defaults."
-    exit 0
+found=false
+for PRODUCT in $COMPATIBLES; do
+    DIR="$PREFIXD/$PRODUCT"
+    if [ -d "$DIR" ]; then
+        note "Using vendor/product-specific defaults for $PRODUCT."
+        for dir in "$DIR"/*; do
+            [ -d "$dir" ] && cp -a "$dir" /
+        done
+        found=true
+    fi
+done
+
+if [ "$found" = false ]; then
+    note "No vendor/product-specific directory found, using built-in defaults."
 fi
 
-note "Using vendor/product specific defaults."
-for dir in "$DIR"/*; do
-    [ -d "$dir" ] && cp -a "$dir" /
-done
+note "Calling runparts $PRODUCT_INIT/S[0-9]+.* start"
+/usr/libexec/finit/runparts -bsp "$PRODUCT_INIT"
+
+exit 0

--- a/board/common/rootfs/usr/libexec/infix/init.d/05-product
+++ b/board/common/rootfs/usr/libexec/infix/init.d/05-product
@@ -35,7 +35,14 @@ if [ "$found" = false ]; then
     note "No vendor/product-specific directory found, using built-in defaults."
 fi
 
+# Conditions for bootstrap services, this enables product specific
+# init scripts to prevent select services from starting.
+initctl -nbq cond set led
+
 note "Calling runparts $PRODUCT_INIT/S[0-9]+.* start"
 /usr/libexec/finit/runparts -bsp "$PRODUCT_INIT"
+
+# Product specific init done.
+initctl -nbq cond set product
 
 exit 0

--- a/board/common/rootfs/usr/libexec/infix/init.d/25-mqprio
+++ b/board/common/rootfs/usr/libexec/infix/init.d/25-mqprio
@@ -46,7 +46,11 @@ while [ "$1" ]; do
     [ $txqs -lt 2 ] && continue
     [ $txqs -gt 8 ] && txqs=8
 
-    tc qdisc add dev $iface root mqprio hw 1 \
-       num_tc $txqs $(map $txqs) $(queues $txqs) || true
+    output=$(tc qdisc add dev $iface root mqprio hw 1 \
+		num_tc $txqs $(map $txqs) $(queues $txqs) 2>&1) || true
+    if echo "$output" | grep -q "does not support hardware offload"; then
+        echo "Skipping $iface, hardware offload not supported."
+    elif [ -n "$output" ]; then
+	echo "$output"
+    fi
 done
-

--- a/board/common/rootfs/usr/libexec/infix/init.d/99-done
+++ b/board/common/rootfs/usr/libexec/infix/init.d/99-done
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec initctl -bq cond set ixinit-done
+exec initctl -bq cond set ixinit

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -4,7 +4,7 @@ Change Log
 All notable changes to the project are documented in this file.
 
 
-[v24.10.2][UNRELEASED]
+[v24.10.2][] - 2024-11-08
 -------------------------
 
 ### Changes
@@ -22,19 +22,30 @@ All notable changes to the project are documented in this file.
 - Support for saving and restoring system clock from a disk file.  This
   allows restoring the system clock to a sane date in case the RTC is
   disabled or does not have a valid time, issue #794
-- Updated Discovery documentation with information on `infix.local`
-  mDNS alias, `netbrowse` support to discover *all* local units, and
-  command examples for disabling LLDP and mDNS services, issue #786
+- Update device discovery chapter with information on `infix.local` mDNS
+  alias, `netbrowse` support to discover *all* local units, and command
+  examples for disabling LLDP and mDNS services, issue #786
 - Updated OSPF documentation to include information on *global OSPF
   settings* (`redistribution`, `explicit-router-id`, etc.), issue #812
 - Added information on *forwarding of IEEE reserved group addresses*
   to bridge section of networking documentation, issue #788
+- Add support for bootstrap conditions and early init product overrides
+- Styx: enable second Ethernet port LED in device tree, again, rename
+  it: yellow -> aux, and make sure it is turned off at boot
+- Styx: disable second port LED for the 4xSFP slots, does not work
+- Styx: override iitod (LED daemon) with a product specific LED script
 
 ### Fixes
 - Fix #685: DSA conduit interface not always detected, randomly causing
   major issues configuring systems with multiple switch cores
 - Fix #778: reactivate OpenSSL backend for libssh/libssh2 for NanoPI R2S.
-  This fixes a regression in v24.10.0 causing loss of NETCONF supprt
+  This fixes a regression in v24.10.0 causing loss of NETCONF support
+- Fix #809: enable syslog logging for RAUC
+- Fix harmless bootstrap log error message on systems without USB ports:
+  `jq: error (at <stdin>:0): Cannot iterate over null (null)`
+- Change confusing `tc` log error message: `Error: does not support
+  hardware offload` to `Skipping $iface, hardware offload not supported.`
+
 
 
 [v24.10.1][] - 2024-10-18
@@ -1283,6 +1294,7 @@ Supported YANG models in addition to those used by sysrepo and netopeer:
 
 [buildroot]:  https://buildroot.org/
 [UNRELEASED]: https://github.com/kernelkit/infix/compare/v24.10.1...HEAD
+[v24.10.2]:   https://github.com/kernelkit/infix/compare/v24.10.1...v24.10.2
 [v24.10.1]:   https://github.com/kernelkit/infix/compare/v24.10.0...v24.10.1
 [v24.10.0]:   https://github.com/kernelkit/infix/compare/v24.09.0...v24.10.0
 [v24.09.0]:   https://github.com/kernelkit/infix/compare/v24.08.0...v24.09.0

--- a/package/confd/confd.conf
+++ b/package/confd/confd.conf
@@ -1,6 +1,6 @@
 #set DEBUG=1
 
-run name:bootstrap log:prio:user.notice norestart <usr/ixinit-done> \
+run name:bootstrap log:prio:user.notice norestart <usr/ixinit> \
 	[S] /usr/libexec/confd/bootstrap \
 	-- Bootstrapping YANG datastore
 

--- a/package/iito/iitod.svc
+++ b/package/iito/iitod.svc
@@ -1,1 +1,1 @@
-service [S0123456789] <!pid/syslogd> iitod -- LED daemon
+service [S0123456789] <!usr/product,usr/led> iitod -- LED daemon

--- a/patches/linux/6.6.52/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
+++ b/patches/linux/6.6.52/0001-net-phy-add-support-for-PHY-LEDs-polarity-modes.patch
@@ -1,7 +1,7 @@
 From 4be3e500b670f7b98e3dd6696b8e51e83f122c65 Mon Sep 17 00:00:00 2001
 From: Christian Marangi <ansuelsmth@gmail.com>
 Date: Thu, 25 Jan 2024 21:36:59 +0100
-Subject: [PATCH 01/33] net: phy: add support for PHY LEDs polarity modes
+Subject: [PATCH 01/34] net: phy: add support for PHY LEDs polarity modes
 Organization: Addiva Elektronik
 
 Add support for PHY LEDs polarity modes. Some PHY require LED to be set
@@ -22,6 +22,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 Reviewed-by: Andrew Lunn <andrew@lunn.ch>
 Link: https://lore.kernel.org/r/20240125203702.4552-4-ansuelsmth@gmail.com
 Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/phy/phy_device.c | 16 ++++++++++++++++
  include/linux/phy.h          | 22 ++++++++++++++++++++++

--- a/patches/linux/6.6.52/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
+++ b/patches/linux/6.6.52/0002-net-mvmdio-Support-setting-the-MDC-frequency-on-XSMI.patch
@@ -1,7 +1,7 @@
 From 4833b140cd11a57dd9f59754cdacfd71bc564c8f Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Mon, 4 Dec 2023 11:08:11 +0100
-Subject: [PATCH 02/33] net: mvmdio: Support setting the MDC frequency on XSMI
+Subject: [PATCH 02/34] net: mvmdio: Support setting the MDC frequency on XSMI
  controllers
 Organization: Addiva Elektronik
 
@@ -14,6 +14,7 @@ Reviewed-by: Andrew Lunn <andrew@lunn.ch>
 Tested-by: Andrew Lunn <andrew@lunn.ch>
 Link: https://lore.kernel.org/r/20231204100811.2708884-4-tobias@waldekranz.com
 Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/ethernet/marvell/mvmdio.c | 44 +++++++++++++++++++++++++++
  1 file changed, 44 insertions(+)

--- a/patches/linux/6.6.52/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
+++ b/patches/linux/6.6.52/0003-net-dsa-mv88e6xxx-Create-API-to-read-a-single-stat-c.patch
@@ -1,7 +1,7 @@
 From 50a2973e8a520a82e9f9ec15a1f69e059ce7a334 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:23 +0100
-Subject: [PATCH 03/33] net: dsa: mv88e6xxx: Create API to read a single stat
+Subject: [PATCH 03/34] net: dsa: mv88e6xxx: Create API to read a single stat
  counter
 Organization: Addiva Elektronik
 
@@ -16,6 +16,7 @@ Reviewed-by: Vladimir Oltean <vladimir.oltean@nxp.com>
 Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 162 ++++++++++++++++++-------------
  drivers/net/dsa/mv88e6xxx/chip.h |  27 +++---

--- a/patches/linux/6.6.52/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
+++ b/patches/linux/6.6.52/0004-net-dsa-mv88e6xxx-Give-each-hw-stat-an-ID.patch
@@ -1,7 +1,7 @@
 From 5916503e23e7f85796c1f927747e66b9535bac53 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:25 +0100
-Subject: [PATCH 04/33] net: dsa: mv88e6xxx: Give each hw stat an ID
+Subject: [PATCH 04/34] net: dsa: mv88e6xxx: Give each hw stat an ID
 Organization: Addiva Elektronik
 
 With the upcoming standard counter group support, we are no longer
@@ -16,6 +16,7 @@ Reviewed-by: Vladimir Oltean <vladimir.oltean@nxp.com>
 Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 138 +++++++++++++++++--------------
  1 file changed, 75 insertions(+), 63 deletions(-)

--- a/patches/linux/6.6.52/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
+++ b/patches/linux/6.6.52/0005-net-dsa-mv88e6xxx-Add-eth-mac-counter-group-support.patch
@@ -1,7 +1,7 @@
 From 32dda6562734ec8ee667bc546f3ef56794d5bf82 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:26 +0100
-Subject: [PATCH 05/33] net: dsa: mv88e6xxx: Add "eth-mac" counter group
+Subject: [PATCH 05/34] net: dsa: mv88e6xxx: Add "eth-mac" counter group
  support
 Organization: Addiva Elektronik
 
@@ -12,6 +12,7 @@ Reviewed-by: Vladimir Oltean <vladimir.oltean@nxp.com>
 Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 39 ++++++++++++++++++++++++++++++++
  1 file changed, 39 insertions(+)

--- a/patches/linux/6.6.52/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
+++ b/patches/linux/6.6.52/0006-net-dsa-mv88e6xxx-Limit-histogram-counters-to-ingres.patch
@@ -1,7 +1,7 @@
 From 36adbdd466ec550cab8b2ae54177f674c02cf631 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:27 +0100
-Subject: [PATCH 06/33] net: dsa: mv88e6xxx: Limit histogram counters to
+Subject: [PATCH 06/34] net: dsa: mv88e6xxx: Limit histogram counters to
  ingress traffic
 Organization: Addiva Elektronik
 
@@ -27,6 +27,7 @@ Reviewed-by: Andrew Lunn <andrew@lunn.ch>
 Reviewed-by: Vladimir Oltean <vladimir.oltean@nxp.com>
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c    | 6 +++---
  drivers/net/dsa/mv88e6xxx/global1.c | 7 +++----

--- a/patches/linux/6.6.52/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
+++ b/patches/linux/6.6.52/0007-net-dsa-mv88e6xxx-Add-rmon-counter-group-support.patch
@@ -1,7 +1,7 @@
 From abfa532c1149525b128b8c76d80965f55e208240 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 14 Dec 2023 14:50:28 +0100
-Subject: [PATCH 07/33] net: dsa: mv88e6xxx: Add "rmon" counter group support
+Subject: [PATCH 07/34] net: dsa: mv88e6xxx: Add "rmon" counter group support
 Organization: Addiva Elektronik
 
 Report the applicable subset of an mv88e6xxx port's counters using
@@ -11,6 +11,7 @@ Reviewed-by: Vladimir Oltean <vladimir.oltean@nxp.com>
 Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
 Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 Signed-off-by: David S. Miller <davem@davemloft.net>
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 42 ++++++++++++++++++++++++++++++++
  1 file changed, 42 insertions(+)

--- a/patches/linux/6.6.52/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
+++ b/patches/linux/6.6.52/0009-net-dsa-mv88e6xxx-Add-LED-infrastructure.patch
@@ -1,11 +1,13 @@
 From 4407b94b4a08536fccb6eea2826955ff12d63ec2 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 19:44:32 +0100
-Subject: [PATCH 09/33] net: dsa: mv88e6xxx: Add LED infrastructure
+Subject: [PATCH 09/34] net: dsa: mv88e6xxx: Add LED infrastructure
 Organization: Addiva Elektronik
 
 Parse DT for LEDs and register them for devices that support it,
 though no actual implementations exist yet.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/Makefile |   1 +
  drivers/net/dsa/mv88e6xxx/chip.c   |   5 +-

--- a/patches/linux/6.6.52/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
+++ b/patches/linux/6.6.52/0010-net-dsa-mv88e6xxx-Add-LED-support-for-6393X.patch
@@ -1,13 +1,15 @@
 From a5cf5c0353db07e74d7a29dd4d5c2cb7775d5bec Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 Nov 2023 21:59:35 +0100
-Subject: [PATCH 10/33] net: dsa: mv88e6xxx: Add LED support for 6393X
+Subject: [PATCH 10/34] net: dsa: mv88e6xxx: Add LED support for 6393X
 Organization: Addiva Elektronik
 
 Trigger support:
 - "none"
 - "timer"
 - "netdev"
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c |   1 +
  drivers/net/dsa/mv88e6xxx/leds.c | 226 +++++++++++++++++++++++++++++++

--- a/patches/linux/6.6.52/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
+++ b/patches/linux/6.6.52/0011-net-dsa-mv88e6xxx-Fix-timeout-on-waiting-for-PPU-on-.patch
@@ -1,13 +1,15 @@
 From be94ec851dbb8e55c3f5e82f197b2dc59566aea2 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Mar 2024 10:27:24 +0100
-Subject: [PATCH 11/33] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
+Subject: [PATCH 11/34] net: dsa: mv88e6xxx: Fix timeout on waiting for PPU on
  6393X
 Organization: Addiva Elektronik
 
 In a multi-chip setup, delays of up to 750ms are observed before the
 device (6393X) signals completion of PPU initialization (Global 1,
 register 0, bit 15). Therefore, increase the timeout threshold to 1s.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/patches/linux/6.6.52/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
+++ b/patches/linux/6.6.52/0012-net-dsa-Support-MDB-memberships-whose-L2-addresses-o.patch
@@ -1,7 +1,7 @@
 From 69092f83541e6539ab82eec3052325c403675de4 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 16 Jan 2024 16:00:55 +0100
-Subject: [PATCH 12/33] net: dsa: Support MDB memberships whose L2 addresses
+Subject: [PATCH 12/34] net: dsa: Support MDB memberships whose L2 addresses
  overlap
 Organization: Addiva Elektronik
 
@@ -29,6 +29,8 @@ as long as the count is positive. Fortunately, all the infrastructure
 needed to do this is already in place, since it is also needed on CPU
 and DSA ports. Thus, "implement" this by simply removing the guards
 which previously skipped reference countung on user ports.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  net/dsa/switch.c | 16 ----------------
  1 file changed, 16 deletions(-)

--- a/patches/linux/6.6.52/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
+++ b/patches/linux/6.6.52/0013-net-phy-marvell10g-Support-firmware-loading-on-88X33.patch
@@ -1,7 +1,7 @@
 From 7c19df77212d0728874515e97cf297863a6ff2cd Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 19 Sep 2023 18:38:10 +0200
-Subject: [PATCH 13/33] net: phy: marvell10g: Support firmware loading on
+Subject: [PATCH 13/34] net: phy: marvell10g: Support firmware loading on
  88X3310
 Organization: Addiva Elektronik
 
@@ -11,6 +11,8 @@ its RAM, ask userspace for the binary and load it over XMDIO.
 We have no choice but to bail out of the probe if firmware is not
 available, as the device does not have any built-in image on which to
 fall back.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/phy/marvell10g.c | 161 +++++++++++++++++++++++++++++++++++
  1 file changed, 161 insertions(+)

--- a/patches/linux/6.6.52/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
+++ b/patches/linux/6.6.52/0014-net-phy-marvell10g-Fix-power-up-when-strapped-to-sta.patch
@@ -1,13 +1,15 @@
 From 0c34b42b7a72ddf1af6f3534870d647801e493fa Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 21 Nov 2023 20:15:24 +0100
-Subject: [PATCH 14/33] net: phy: marvell10g: Fix power-up when strapped to
+Subject: [PATCH 14/34] net: phy: marvell10g: Fix power-up when strapped to
  start powered down
 Organization: Addiva Elektronik
 
 On devices which are hardware strapped to start powered down (PDSTATE
 == 1), make sure that we clear the power-down bit on all units
 affected by this setting.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/phy/marvell10g.c | 18 +++++++++++++++---
  1 file changed, 15 insertions(+), 3 deletions(-)

--- a/patches/linux/6.6.52/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
+++ b/patches/linux/6.6.52/0015-net-phy-marvell10g-Add-LED-support-for-88X3310.patch
@@ -1,7 +1,7 @@
 From 6576918d3348f8e20802379d568d7632228af4d7 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 15 Nov 2023 20:58:42 +0100
-Subject: [PATCH 15/33] net: phy: marvell10g: Add LED support for 88X3310
+Subject: [PATCH 15/34] net: phy: marvell10g: Add LED support for 88X3310
 Organization: Addiva Elektronik
 
 Pickup the LEDs from the state in which the hardware reset or
@@ -17,6 +17,8 @@ Trigger support:
 	   software blinking
 - "netdev": Offload link or duplex information to the solid behavior;
   	    tx and/or rx activity to blink behavior.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/phy/marvell10g.c | 422 +++++++++++++++++++++++++++++++++++
  1 file changed, 422 insertions(+)

--- a/patches/linux/6.6.52/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
+++ b/patches/linux/6.6.52/0016-net-phy-marvell10g-Support-LEDs-tied-to-a-single-med.patch
@@ -1,7 +1,7 @@
 From 1ad7f010e46133c725df5cab4d85f71f689ca191 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 12 Dec 2023 09:51:05 +0100
-Subject: [PATCH 16/33] net: phy: marvell10g: Support LEDs tied to a single
+Subject: [PATCH 16/34] net: phy: marvell10g: Support LEDs tied to a single
  media side
 Organization: Addiva Elektronik
 
@@ -14,6 +14,8 @@ tied to a particular media side, and use that information to refine
 the offloading of the "netdev" trigger, such that LEDs attached to the
 RJ45 jack only lights up when a copper link is established, and vice
 versa for the SFP cage.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/phy/marvell10g.c | 23 ++++++++++++++++++++++-
  1 file changed, 22 insertions(+), 1 deletion(-)

--- a/patches/linux/6.6.52/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
+++ b/patches/linux/6.6.52/0017-nvmem-layouts-onie-tlv-Let-device-probe-even-when-TL.patch
@@ -1,7 +1,7 @@
 From 11b9a3e328241edede03b6615bb9b0f1a40b9b7d Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 24 Nov 2023 23:29:55 +0100
-Subject: [PATCH 17/33] nvmem: layouts: onie-tlv: Let device probe even when
+Subject: [PATCH 17/34] nvmem: layouts: onie-tlv: Let device probe even when
  TLV is invalid
 Organization: Addiva Elektronik
 
@@ -13,6 +13,8 @@ be successfully probed.
 
 Therefore, settle for reporting data corruption issues in the log, and
 simply refrain from registering any cells in those cases.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/nvmem/layouts/onie-tlv.c | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)

--- a/patches/linux/6.6.52/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
+++ b/patches/linux/6.6.52/0018-net-bridge-avoid-classifying-unknown-multicast-as-mr.patch
@@ -1,7 +1,7 @@
 From ce1148b5c2e33541ad13ff2c4769d0b37d4e42b9 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Mon, 4 Mar 2024 16:47:28 +0100
-Subject: [PATCH 18/33] net: bridge: avoid classifying unknown multicast as
+Subject: [PATCH 18/34] net: bridge: avoid classifying unknown multicast as
  mrouters_only
 Organization: Addiva Elektronik
 

--- a/patches/linux/6.6.52/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
+++ b/patches/linux/6.6.52/0019-net-bridge-Ignore-router-ports-when-forwarding-L2-mu.patch
@@ -1,7 +1,7 @@
 From ce74ee8c5461cc53851ca323b4dfc9937cab0e41 Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Tue, 5 Mar 2024 06:44:41 +0100
-Subject: [PATCH 19/33] net: bridge: Ignore router ports when forwarding L2
+Subject: [PATCH 19/34] net: bridge: Ignore router ports when forwarding L2
  multicast
 Organization: Addiva Elektronik
 

--- a/patches/linux/6.6.52/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
+++ b/patches/linux/6.6.52/0020-net-dsa-Support-EtherType-based-priority-overrides.patch
@@ -1,9 +1,10 @@
 From 3c9b05198e0b7193f2dcddc1860cd77f0adbc3a2 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 21 Mar 2024 19:12:15 +0100
-Subject: [PATCH 20/33] net: dsa: Support EtherType based priority overrides
+Subject: [PATCH 20/34] net: dsa: Support EtherType based priority overrides
 Organization: Addiva Elektronik
 
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  include/net/dsa.h |  4 ++++
  net/dsa/slave.c   | 56 +++++++++++++++++++++++++++++++++++++++++++++--

--- a/patches/linux/6.6.52/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
+++ b/patches/linux/6.6.52/0021-net-dsa-mv88e6xxx-Support-EtherType-based-priority-o.patch
@@ -1,10 +1,11 @@
 From 333134a4ff2b8dd7fb00a75560254de96d1082ad Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Fri, 22 Mar 2024 16:15:43 +0100
-Subject: [PATCH 21/33] net: dsa: mv88e6xxx: Support EtherType based priority
+Subject: [PATCH 21/34] net: dsa: mv88e6xxx: Support EtherType based priority
  overrides
 Organization: Addiva Elektronik
 
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c    | 64 +++++++++++++++++++++++++++++
  drivers/net/dsa/mv88e6xxx/chip.h    | 21 ++++++++++

--- a/patches/linux/6.6.52/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
+++ b/patches/linux/6.6.52/0022-net-phy-Do-not-resume-PHY-when-attaching.patch
@@ -1,7 +1,7 @@
 From cdddc24c05cedc0d0fabc48da17ec26aeb7c1ef9 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 27 Mar 2024 10:10:19 +0100
-Subject: [PATCH 22/33] net: phy: Do not resume PHY when attaching
+Subject: [PATCH 22/34] net: phy: Do not resume PHY when attaching
 Organization: Addiva Elektronik
 
 The PHY should not start negotiating with its link-partner until
@@ -15,6 +15,8 @@ Otherwise, drivers that attached to their PHYs during
 probing (e.g. DSA) would end up with a physical link being
 established, even though the corresponding interface was still
 administratively down.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/phy/phy_device.c | 1 -
  1 file changed, 1 deletion(-)

--- a/patches/linux/6.6.52/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
+++ b/patches/linux/6.6.52/0023-net-dsa-mv88e6xxx-Improve-indirect-register-access-p.patch
@@ -1,7 +1,7 @@
 From 1ec21a3fc54fb447501fd7edbf692b00a31fe3ec Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 27 Mar 2024 15:52:43 +0100
-Subject: [PATCH 23/33] net: dsa: mv88e6xxx: Improve indirect register access
+Subject: [PATCH 23/34] net: dsa: mv88e6xxx: Improve indirect register access
  perf on 6393
 Organization: Addiva Elektronik
 
@@ -13,6 +13,8 @@ previous families).
 Therefore, add a new set of SMI operations which remaps accesses to
 such registers to the corresponding directly addressable register. All
 other accesses use the regular indirect interface.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c    |  7 +++
  drivers/net/dsa/mv88e6xxx/global1.h |  3 ++

--- a/patches/linux/6.6.52/0024-net-bridge-drop-delay-for-applying-strict-multicast-.patch
+++ b/patches/linux/6.6.52/0024-net-bridge-drop-delay-for-applying-strict-multicast-.patch
@@ -1,7 +1,7 @@
 From 5d7be493dcaa75ee69d521043062389d7772f8dc Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Thu, 4 Apr 2024 16:36:30 +0200
-Subject: [PATCH 24/33] net: bridge: drop delay for applying strict multicast
+Subject: [PATCH 24/34] net: bridge: drop delay for applying strict multicast
  filtering
 Organization: Addiva Elektronik
 

--- a/patches/linux/6.6.52/0025-net-dsa-mv88e6xxx-Honor-ports-being-managed-via-in-b.patch
+++ b/patches/linux/6.6.52/0025-net-dsa-mv88e6xxx-Honor-ports-being-managed-via-in-b.patch
@@ -1,7 +1,7 @@
 From 492a824661dbc188b5abeb7434b5cf67c2016415 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Mon, 22 Apr 2024 23:18:01 +0200
-Subject: [PATCH 25/33] net: dsa: mv88e6xxx: Honor ports being managed via
+Subject: [PATCH 25/34] net: dsa: mv88e6xxx: Honor ports being managed via
  in-band-status
 Organization: Addiva Elektronik
 
@@ -13,6 +13,8 @@ USXGMII autoneg)
 This state is the default set up by mv88e6xxx_port_setup_mac(), so all
 we have to do is to make the phylink MAC callbacks no-ops in cases
 when in-band-status is being used.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 6 ++++++
  1 file changed, 6 insertions(+)

--- a/patches/linux/6.6.52/0026-net-dsa-mv88e6xxx-Fix-port-policy-config-on-6393X.patch
+++ b/patches/linux/6.6.52/0026-net-dsa-mv88e6xxx-Fix-port-policy-config-on-6393X.patch
@@ -1,7 +1,7 @@
 From c9c9597a47b00b720f5223c83ab05bb89481eda8 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 24 Apr 2024 21:35:26 +0200
-Subject: [PATCH 26/33] net: dsa: mv88e6xxx: Fix port policy config on 6393X
+Subject: [PATCH 26/34] net: dsa: mv88e6xxx: Fix port policy config on 6393X
 Organization: Addiva Elektronik
 
 mv88e6393x_port_policy_{read,write} expect the `pointer` argument to
@@ -16,6 +16,7 @@ never enabled on DSA ports, which broke standalone port isolation in
 multichip switch trees made up of 6393X decices.
 
 Fixes: 6584b26020fc ("net: dsa: mv88e6xxx: implement .port_set_policy for Amethyst")
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/port.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/patches/linux/6.6.52/0027-net-dsa-mv88e6xxx-Limit-rsvd2cpu-policy-to-user-port.patch
+++ b/patches/linux/6.6.52/0027-net-dsa-mv88e6xxx-Limit-rsvd2cpu-policy-to-user-port.patch
@@ -1,7 +1,7 @@
 From 4ff224b5f5de1347a1f686aa85cb918a7db18879 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 24 Apr 2024 22:41:04 +0200
-Subject: [PATCH 27/33] net: dsa: mv88e6xxx: Limit rsvd2cpu policy to user
+Subject: [PATCH 27/34] net: dsa: mv88e6xxx: Limit rsvd2cpu policy to user
  ports on 6393X
 Organization: Addiva Elektronik
 
@@ -29,6 +29,8 @@ Before this change, due to rsvd2cpu being enabled on the CPU port, the
 switch would try to trap it back to the CPU. Given that the CPU is
 trusted, instead assume that it indeed meant for the packet to be
 forwarded like any other.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/port.c | 31 +++++++++++++++++++++++++------
  1 file changed, 25 insertions(+), 6 deletions(-)

--- a/patches/linux/6.6.52/0028-usb-core-adjust-log-level-for-unauthorized-devices.patch
+++ b/patches/linux/6.6.52/0028-usb-core-adjust-log-level-for-unauthorized-devices.patch
@@ -1,7 +1,7 @@
 From f0d4beabe769fec594b309c3f1ebb79cfdbede8b Mon Sep 17 00:00:00 2001
 From: Joachim Wiberg <troglobit@gmail.com>
 Date: Mon, 29 Apr 2024 15:14:51 +0200
-Subject: [PATCH 28/33] usb: core: adjust log level for unauthorized devices
+Subject: [PATCH 28/34] usb: core: adjust log level for unauthorized devices
 Organization: Addiva Elektronik
 
 The fact that a USB device currently is not authorized is not an error,

--- a/patches/linux/6.6.52/0029-net-dsa-mv88e6xxx-Grab-register-lock-during-counter-.patch
+++ b/patches/linux/6.6.52/0029-net-dsa-mv88e6xxx-Grab-register-lock-during-counter-.patch
@@ -1,7 +1,7 @@
 From 5f96d718c850084504c53ec0b8d9fcf75ea9996c Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 15 May 2024 13:50:58 +0200
-Subject: [PATCH 29/33] net: dsa: mv88e6xxx: Grab register lock during counter
+Subject: [PATCH 29/34] net: dsa: mv88e6xxx: Grab register lock during counter
  snapshotting
 Organization: Addiva Elektronik
 
@@ -9,6 +9,8 @@ This was missing for the standard counter groups. Since no caller
 already holds the lock, opt for pushing the locking down into
 mv88e6xxx_stats_snapshot() rather than having it duplicated at each
 call site.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 10 ++++++----
  1 file changed, 6 insertions(+), 4 deletions(-)

--- a/patches/linux/6.6.52/0030-net-bridge-Differentiate-MDB-additions-from-modifica.patch
+++ b/patches/linux/6.6.52/0030-net-bridge-Differentiate-MDB-additions-from-modifica.patch
@@ -1,7 +1,7 @@
 From 6d4c436335003259cc02a0f015fd3d1d54e988a2 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Thu, 16 May 2024 14:51:54 +0200
-Subject: [PATCH 30/33] net: bridge: Differentiate MDB additions from
+Subject: [PATCH 30/34] net: bridge: Differentiate MDB additions from
  modifications
 Organization: Addiva Elektronik
 
@@ -21,6 +21,8 @@ generated.
 
 Therefore, discriminate new groups from changes to existing groups by
 introducing a RTM_SETMDB events to be used in the latter scenario.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  include/uapi/linux/rtnetlink.h | 2 ++
  net/bridge/br_mdb.c            | 4 ++--

--- a/patches/linux/6.6.52/0031-net-dsa-tag_dsa-Use-tag-priority-as-initial-skb-prio.patch
+++ b/patches/linux/6.6.52/0031-net-dsa-tag_dsa-Use-tag-priority-as-initial-skb-prio.patch
@@ -1,7 +1,7 @@
 From c333c612688d5e974b95fcf4b04f185d7cf4f80d Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 28 May 2024 10:38:42 +0200
-Subject: [PATCH 31/33] net: dsa: tag_dsa: Use tag priority as initial
+Subject: [PATCH 31/34] net: dsa: tag_dsa: Use tag priority as initial
  skb->priority
 Organization: Addiva Elektronik
 
@@ -19,6 +19,8 @@ Ideally we could then map this priority to an internal one, like we
 can do with an "ingress-qos-map" on VLAN interfaces. Until that is
 implemented, support the setup that is likely to be the most common; a
 1:1 mapping from FPri to skb->priority.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  net/dsa/tag_dsa.c | 7 +++++++
  1 file changed, 7 insertions(+)

--- a/patches/linux/6.6.52/0032-net-dsa-mv88e6xxx-Add-mqprio-qdisc-support.patch
+++ b/patches/linux/6.6.52/0032-net-dsa-mv88e6xxx-Add-mqprio-qdisc-support.patch
@@ -1,7 +1,7 @@
 From 18c025745fd8b8c9b3e688e9d78668a56cf71217 Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Tue, 28 May 2024 11:04:22 +0200
-Subject: [PATCH 32/33] net: dsa: mv88e6xxx: Add mqprio qdisc support
+Subject: [PATCH 32/34] net: dsa: mv88e6xxx: Add mqprio qdisc support
 Organization: Addiva Elektronik
 
 Add support for attaching mqprio qdisc's to mv88e6xxx ports and use
@@ -24,6 +24,8 @@ are effectively only specifying the QPri.
 Since FPri is always a 3-bit field, even on older chips with only 4
 physical queues, always report 8 queues and let the chip's policy
 handle the mapping down to the "real" number.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 70 ++++++++++++++++++++++++++++++++
  net/dsa/tag_dsa.c                |  4 +-

--- a/patches/linux/6.6.52/0033-net-dsa-mv88e6xxx-Use-VLAN-prio-over-IP-when-both-ar.patch
+++ b/patches/linux/6.6.52/0033-net-dsa-mv88e6xxx-Use-VLAN-prio-over-IP-when-both-ar.patch
@@ -1,7 +1,7 @@
 From f2d4ff12c7a0e644cbeac6675b755fb4a87b362a Mon Sep 17 00:00:00 2001
 From: Tobias Waldekranz <tobias@waldekranz.com>
 Date: Wed, 29 May 2024 13:20:41 +0200
-Subject: [PATCH 33/33] net: dsa: mv88e6xxx: Use VLAN prio over IP when both
+Subject: [PATCH 33/34] net: dsa: mv88e6xxx: Use VLAN prio over IP when both
  are available
 Organization: Addiva Elektronik
 
@@ -22,6 +22,8 @@ main reasons for choosing the new default:
    packet's priority. As the packet then moves through the network
    core over trusted VLAN trunks, the packet should keep its original
    priority, independent of what inner protocol fields may indicate.
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
 ---
  drivers/net/dsa/mv88e6xxx/chip.c | 11 ++++++++---
  1 file changed, 8 insertions(+), 3 deletions(-)

--- a/patches/linux/6.6.52/0034-net-dsa-mb88e6xxx-use-EOPNOTSUPP-for-unsupported-fla.patch
+++ b/patches/linux/6.6.52/0034-net-dsa-mb88e6xxx-use-EOPNOTSUPP-for-unsupported-fla.patch
@@ -1,0 +1,43 @@
+From ceaaa4f44f9b3ec82c4e0a24c2322aae58fa3aa0 Mon Sep 17 00:00:00 2001
+From: Joachim Wiberg <troglobit@gmail.com>
+Date: Wed, 6 Nov 2024 15:39:33 +0100
+Subject: [PATCH 34/34] net: dsa: mb88e6xxx: use EOPNOTSUPP for unsupported
+ flags
+Organization: Addiva Elektronik
+
+Make sure to return correct error code for unsupported flags, and
+propagate any error.
+
+Follow-up to a5cf5c0
+
+Signed-off-by: Joachim Wiberg <troglobit@gmail.com>
+---
+ drivers/net/dsa/mv88e6xxx/leds.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/dsa/mv88e6xxx/leds.c b/drivers/net/dsa/mv88e6xxx/leds.c
+index b2a55d96b506..fe1ed3ed2a8a 100644
+--- a/drivers/net/dsa/mv88e6xxx/leds.c
++++ b/drivers/net/dsa/mv88e6xxx/leds.c
+@@ -99,7 +99,7 @@ static int mv88e6393x_led_flags_to_mode(struct mv88e6xxx_led *led, unsigned long
+ 			return i;
+ 	}
+ 
+-	return -EINVAL;
++	return -EOPNOTSUPP;
+ }
+ 
+ static int mv88e6393x_led_mode_to_flags(struct mv88e6xxx_led *led, u8 mode,
+@@ -216,6 +216,9 @@ static int mv88e6393x_led_hw_control_set(struct mv88e6xxx_led *led,
+ {
+ 	int mode = mv88e6393x_led_flags_to_mode(led, flags);
+ 
++	if (mode < 0)
++		return mode;
++
+ 	return mv88e6393x_led_set(led, mode);
+ }
+ 
+-- 
+2.43.0
+

--- a/src/confd/bin/gen-hardware
+++ b/src/confd/bin/gen-hardware
@@ -1,19 +1,23 @@
 #!/bin/sh
 set -e
 
-usb_ports=$(cat /run/system.json | jq -r '.["usb-ports"] | map(.name) | unique | join(" ")')
+if jq -e '.["usb-ports"]' /run/system.json > /dev/null; then
+    usb_ports=$(jq -r '.["usb-ports"] | map(.name) | unique | join(" ")' /run/system.json)
+else
+    usb_ports=""
+fi
 
 gen_port()
 {
-	local port="$1"
-	cat <<EOF
-    	{
-		"class": "infix-hardware:usb",
-		"name": "$port",
-		"state": {
-    			"admin-state": "unlocked"
-  			}
-    	}
+    port="$1"
+    cat <<EOF
+{
+    "class": "infix-hardware:usb",
+    "name": "$port",
+    "state": {
+	"admin-state": "unlocked"
+    }
+}
 EOF
 }
 first=1
@@ -24,7 +28,7 @@ cat <<EOF
 EOF
 for port in $usb_ports; do
     if [ $first -eq 0 ]; then
-       echo -n ','
+	echo -n ','
     fi
     first=0;
     gen_port "$port"


### PR DESCRIPTION
## Description

Some products need workarounds to default Infix behavior.  This change set is a refactor of the early system bootstrap to provide product-specific hooks.  For the Styx platform we install a LED script that disables `iitod` in favor of a static setup.

Sumamry of general changes in this pull request:

 - The Infix prope script had some PEP8 fixes, as well as a few bug fixes
 - The device tree `compatible` string is now split up and listed, in reverse order, as an array in `/run/system.json`
 - The product specific setup now use the `compatible` array from /run/system.json` to apply overrides, from least significant to most significant
 - The product specific setup in Infix init now calls `runparts -s /etc/product/init.d`, meaning all product specific override scripts in that directory are called with a `start` argument
 - New bootstrap conditions:
   - rename ixinit-done -> ixinit, to match other conditions
   - add `led` and `product` conditions, triggering `iitod`
 - The missing file `/etc/machine-id`, required by RAUC, now points to `/var/lib/dbus/machine-id`, created by the Finit D-BUS plugin after factory reset
 - RAUC is now started with the flag `-s` to enable syslog support, previously added in 0f410eb, this fixes #809 

Styx requires a few more generic, *and specific*, changes:

 - The Linux mv88e6xxx LED driver reported `EINVAL` instead of `EOPNOTSUPP`, causing lots of (bogus) worrying log messages
 - The LED override script clears the `led` condition, effectively disabling `iitod`.  This script can be called from the prompt to perform other actions as well (list, flash, setup, etc.), call `/usr/libexec/styx/led.sh` (without any arguments) for more information
 - The device tree has restored copper LED `LED1`, the second green port.  Instead of being called `<device>:yellow:tp` it is now called `<device>:green:aux`
 - The device tree has been updated to disable the second LED for all SFP ports, it is not connected on the boards (Rev. A and Rev. B)

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [X] Bugfix
  - [ ] Regression tests
  - [X] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
