### PR TITLE
rauc: improve upgrade output

### DIFF
--- a/patches/rauc/1.11.3/0003-src-install-print-bootname-when-checking-slot.patch
+++ b/patches/rauc/1.11.3/0003-src-install-print-bootname-when-checking-slot.patch
@@ -1,0 +1,29 @@
+This makes the output more user friendly on systems where the bootname
+is the common way to refer to a slot.
+
+Example output:
+...
+40% Checking slot rootfs.1 (secondary)
+46% Checking slot rootfs.1 (secondary) done.
+...
+
+diff --git a/src/install.c b/src/install.c
+index ea7c95b3..fb38bcab 100644
+--- a/src/install.c
++++ b/src/install.c
+@@ -965,7 +965,11 @@ static gboolean handle_slot_install_plan(const RaucManifest *manifest, const RIm
+ 
+ 	install_args_update(args, "Checking slot %s", plan->target_slot->name);
+ 
+-	r_context_begin_step_weighted_formatted("check_slot", 0, 1, "Checking slot %s", plan->target_slot->name);
++	r_context_begin_step_weighted_formatted("check_slot", 0, 1, "Checking slot %s%s%s%s",
++						plan->target_slot->name,
++						plan->target_slot->bootname ? " (" : "",
++						plan->target_slot->bootname ? plan->target_slot->bootname : "",
++						plan->target_slot->bootname ? ")" : "");
+ 
+ 	r_slot_status_load(plan->target_slot);
+ 	slot_state = plan->target_slot->status;
+-- 
+2.34.1
+

--- a/patches/rauc/1.11.3/0004-src-main-add-warning-banner-at-start-of-installation.patch
+++ b/patches/rauc/1.11.3/0004-src-main-add-warning-banner-at-start-of-installation.patch
@@ -1,0 +1,24 @@
+Print "the standard" warning banner at start of installation.
+
+diff --git a/src/main.c b/src/main.c
+index 8e851b47..bba1d012 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -258,6 +258,14 @@ static gboolean install_start(int argc, char **argv)
+ 	if (access_args.http_headers)
+ 		args->access_args.http_headers = g_strdupv(access_args.http_headers);
+ 
++	g_print("+------------------------------------------------------------------------------+\n");
++	g_print("|                                                                              |\n");
++	g_print("|      [!] Installation might take a while. DO NOT power off the device.       |\n");
++	g_print("|                                                                              |\n");
++	g_print("|                   Please wait while the upgrade completes.                   |\n");
++	g_print("|                                                                              |\n");
++	g_print("+------------------------------------------------------------------------------+\n");
++
+ 	r_loop = g_main_loop_new(NULL, FALSE);
+ 	if (ENABLE_SERVICE) {
+ 		g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT(NULL);
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description
Add two patches which improve upgrade output.

### 0003-src-install-print-bootname-when-checking-slot.patch
Prints the bootname during slot probing. This patch is sent upstream but not reviewed yet.
```
 40% Updating slots
 40% Checking slot rootfs.1 (secondary)
 46% Checking slot rootfs.1 (secondary) done.
 46% Copying image to rootfs.1
```

### 0004-src-main-add-warning-banner-at-start-of-installation.patch
Print a "standard warning banner" at start of install.

```
rauc install tftp://192.168.122.1/infix-x86_64.pkg
+------------------------------------------------------------------------------+
|                                                                              |
|      [!] Installation might take a while. DO NOT power off the device.       |
|                                                                              |
|                   Please wait while the upgrade completes.                   |
|                                                                              |
+------------------------------------------------------------------------------+
installing
  0% Installing
  0% Determining slot states
 10% Determining slot states done.
```

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
