### PR TITLE
Verify that bridge vlan separation works properly for broadcast packets

### DIFF
--- a/test/case/ietf_interfaces/bridge_vlan_separation/Readme.adoc
+++ b/test/case/ietf_interfaces/bridge_vlan_separation/Readme.adoc
@@ -14,9 +14,9 @@ Test that two VLANs are correctly separated in the bridge
  ,------------------------------------------------------------------------------,
  |  host:mgmt0 host:data10 host:data11    host:data20  host:data21  host:mgmt1  |
  |             [10.0.0.1]   [10.0.0.2]     [10.0.0.3]     [10.0.0.4]            |
- |              (ns10)         (ns11)          (s20)         (ns21)             |
+ |               (ns10)       (ns11)         (ns20)         (ns21)              |
  |                                                                              |
- |                                        [ HOST ]                              |
+ |                                  [ HOST ]                                    |
  '------------------------------------------------------------------------------'
 
 ....
@@ -39,6 +39,7 @@ endif::topdoc[]
 . Verify ping 10.0.0.3 from host:data10
 . Verify ping 10.0.0.4 from host:data11
 . Verify ping not possible host:data10->10.0.0.4, host:data11->10.0.0.3, host:data10->10.0.0.2, host:data11->10.0.0.1
+. Verify MAC broadcast isolation within VLANs
 
 
 <<<

--- a/test/spec/Readme.adoc
+++ b/test/spec/Readme.adoc
@@ -1,7 +1,7 @@
 :topdoc:
 
 = Test specification
-Infix v24.10.1-23-g8fc0ab9b-dirty
+ v24.10.2-2-g032a51b9-dirty
 :title-page:
 :toc:
 :toclevels: 2


### PR DESCRIPTION
- Verify that broadcast packets are also properly moved accross the bridge, i.e. the broadcast packets sent from vlan interface VLAN10 do not reach VLAN20

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
