### PR TITLE
.github: Set usable version strings on PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         target: [aarch64, x86_64]
       fail-fast: false
+    outputs:
+      build_id: ${{ steps.vars.outputs.INFIX_BUILD_ID }}
     steps:
       - name: Cleanup Build Folder
         run: |
@@ -38,6 +40,16 @@ jobs:
       - name: Set Build Variables
         id: vars
         run: |
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+              # Since PRs are built from an internally generated merge
+              # commit, reverse lookups of PRs and/or commits from
+              # image version information are cumbersome.  Therefore:
+              # explicitly set a build id that references both the PR
+              # and the commit.
+              printf "INFIX_BUILD_ID=pr%d.%.7s\n" \
+                  "${{ github.event.number }}" "${{ github.event.pull_request.head.sha }}" \
+                  | tee -a $GITHUB_OUTPUT $GITHUB_ENV
+          fi
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
               if [ "${{ github.event.inputs.minimal }}" == "true" ]; then
                   flavor="_minimal"
@@ -132,6 +144,11 @@ jobs:
       - name: Set Build Variables
         id: vars
         run: |
+          if [ -n "${{ needs.build.outputs.build_id }}" ]; then
+              echo "INFIX_BUILD_ID=${{ needs.build.outputs.build_id }}" \
+                   >>$GITHUB_ENV
+          fi
+
           if [ "$GITHUB_REF_NAME" != "main" ]; then
               flavor="_minimal"
           else

--- a/board/common/mkrauc.sh
+++ b/board/common/mkrauc.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-GIT_VERSION=$(git -C "$BR2_EXTERNAL_INFIX_PATH" describe --always --dirty --tags)
-
 name=$1
 compat=$2
 sign=$3
@@ -26,7 +24,7 @@ cp -f "$BINARIES_DIR/rootfs.itbh"     "$work/rootfs.itbh"
 cat >"$work/manifest.raucm" <<EOF
 [update]
 compatible=${compat}
-version=${GIT_VERSION}
+version=${INFIX_VERSION}
 
 [bundle]
 format=verity

--- a/board/common/post-build.sh
+++ b/board/common/post-build.sh
@@ -39,22 +39,6 @@ if [ -n "${ID_LIKE}" ]; then
     ID="${ID} ${ID_LIKE}"
 fi
 
-if [ -z "$GIT_VERSION" ]; then
-    infix_path="$BR2_EXTERNAL_INFIX_PATH"
-    if [ -n "$INFIX_OEM_PATH" ]; then
-	# Use version from br2-external OEM:ing Infix
-	infix_path="$INFIX_OEM_PATH"
-    fi
-    GIT_VERSION=$(git -C "$infix_path" describe --always --dirty --tags)
-fi
-
-# Override VERSION in /etc/os-release and filenames for release builds
-if [ -n "$INFIX_RELEASE" ]; then
-    VERSION="$INFIX_RELEASE"
-else
-    VERSION=$GIT_VERSION
-fi
-
 if [ -n "$INFIX_IMAGE_ID" ]; then
     NAME="$INFIX_IMAGE_ID"
 else
@@ -71,12 +55,12 @@ rm -f "$TARGET_DIR/etc/os-release"
 {
     echo "NAME=\"$INFIX_NAME\""
     echo "ID=$INFIX_ID"
-    echo "PRETTY_NAME=\"$INFIX_TAGLINE $VERSION\""
+    echo "PRETTY_NAME=\"$INFIX_TAGLINE $INFIX_VERSION\""
     echo "ID_LIKE=\"${ID}\""
     echo "DEFAULT_HOSTNAME=$BR2_TARGET_GENERIC_HOSTNAME"
-    echo "VERSION=\"${VERSION}\""
-    echo "VERSION_ID=${VERSION}"
-    echo "BUILD_ID=\"${GIT_VERSION}\""
+    echo "VERSION=\"${INFIX_VERSION}\""
+    echo "VERSION_ID=${INFIX_VERSION}"
+    echo "BUILD_ID=\"${INFIX_BUILD_ID}\""
     if [ -n "$INFIX_IMAGE_ID" ]; then
 	echo "IMAGE_ID=\"$INFIX_IMAGE_ID\""
     fi
@@ -102,7 +86,7 @@ rm -f "$TARGET_DIR/etc/os-release"
     fi
 } > "$TARGET_DIR/etc/os-release"
 
-echo "$INFIX_TAGLINE $VERSION -- $(date +"%b %e %H:%M %Z %Y")" > "$TARGET_DIR/etc/version"
+echo "$INFIX_TAGLINE $INFIX_VERSION -- $(date +"%b %e %H:%M %Z %Y")" > "$TARGET_DIR/etc/version"
 
 # In case of ambguities, this is what the image was built from
 cp "$BR2_CONFIG" "$TARGET_DIR/usr/share/infix/config"

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -12,6 +12,7 @@ All notable changes to the project are documented in this file.
  - Add support for more mDNS settings: allow/deny interfaces, acting
    as "reflector" and filtering of reflected services.  Issue #678
  - Review of default `sysctl` settings, issue #829
+ - Upgrade Linux kernel to 6.12.1 (presumed LTS)
 
 ### Fixes
 

--- a/doc/branding.md
+++ b/doc/branding.md
@@ -370,22 +370,30 @@ But you can of course use only two numbers, *major.minor*, as well.
 > with your own versioning scheme.
 
 
-### `INFIX_RELEASE`
+### Specifying Versioning Information
 
-This global variable **must be** a lower-case string (no spaces or
-other characters outside of 0–9, a–z, '.', '_' and '-') identifying
-the operating system version, excluding any OS name information or
-release code name, and suitable for processing by scripts or usage
-in generated filenames.
+Two optional environment variables control the version information
+recorded in images. Both of these **must be** a lower-case string (no
+spaces or other characters outside of 0–9, a–z, '.', '_' and '-')
+identifying the operating system version, excluding any OS name
+information or release code name, and suitable for processing by
+scripts or usage in generated filenames.
+
+#### `INFIX_BUILD_ID`
+
+Used for `BUILD_ID` in `/etc/os-release`.
+
+**Default:** `$(git describe --always --dirty --tags)`, from the _top
+directory_. By default, the top directory refers to the root of the
+Infix source tree, but this can be changed by setting the branding
+variable `INFIX_OEM_PATH`, e.g. in a `defconfig` file or via `make
+menuconfig`, to the path of an enclosing br2-external.
+
+#### `INFIX_RELEASE`
 
 Used for `VERSION` and `VERSION_ID` in `/etc/os-release` and
 generated file names like disk images, etc.
 
-**Default:** generated using `git describe --always --dirty --tags`,
-with an additional `-C $infix_path`.  This variable defaults to the
-Infix tree and can be changed by setting the menuconfig branding
-variable `INFIX_OEM_PATH` to that of the br2-external.  It is also
-possible to set the `GIT_VERSION` variable in your `post-build.sh`
-script to change how the VCS version is extracted.
+**Default:** `${INFIX_BUILD_ID}`
 
 [NanoPi R2S]: https://github.com/kernelkit/infix/blob/main/board/aarch64/r2s/rootfs/etc/factory-config.cfg

--- a/external.mk
+++ b/external.mk
@@ -1,9 +1,7 @@
-IXMSG = printf "\e[37;44m>>>   $(call qstrip,$(1))\e[0m\n"
-
+include $(BR2_EXTERNAL_INFIX_PATH)/infix.mk
 include $(sort $(wildcard $(BR2_EXTERNAL_INFIX_PATH)/package/*/*.mk))
 include $(BR2_EXTERNAL_INFIX_PATH)/board/common/common.mk
 -include $(BR2_EXTERNAL_INFIX_PATH)/board/$(patsubst "%",%,$(BR2_ARCH))/board.mk
-include $(BR2_EXTERNAL_INFIX_PATH)/infix.mk
 include $(BR2_EXTERNAL_INFIX_PATH)/test/test.mk
 
 .PHONY: local.mk

--- a/infix.mk
+++ b/infix.mk
@@ -1,1 +1,11 @@
+IXMSG = printf "\e[37;44m>>>   $(call qstrip,$(1))\e[0m\n"
+
+INFIX_TOPDIR = $(if $(INFIX_OEM_PATH),$(INFIX_OEM_PATH),$(BR2_EXTERNAL_INFIX_PATH))
+
+# Unless the user specifies an explicit build id, source it from git.
+# The build id also becomes the image version, unless an official
+# release is being built.
+export INFIX_BUILD_ID ?= $(shell git -C $(INFIX_TOPDIR) describe --dirty --always --tags)
+export INFIX_VERSION = $(if $(INFIX_RELEASE),$(INFIX_RELEASE),$(INFIX_BUILD_ID))
+
 INFIX_CFLAGS:=-Wall -Werror -Wextra -Wno-unused-parameter -Wformat=2 -Wformat-overflow=2 -Winit-self -Wstrict-overflow=4 -Wno-format-truncation -Wno-format-nonliteral

--- a/test/test.mk
+++ b/test/test.mk
@@ -6,7 +6,6 @@ test-specification := $(O)/images/test-specification.pdf
 
 UNIT_TESTS         ?= $(test-dir)/case/all-repo.yaml $(test-dir)/case/all-unit.yaml
 TESTS              ?= $(test-dir)/case/all.yaml
-GIT_VERSION         = $(shell git -C $(GIT_PATH) describe --dirty --always --tags)
 
 base := -b $(base-dir)
 
@@ -34,7 +33,7 @@ test-sh:
 
 test-spec:
 	@esc_infix_name="$(echo $(INFIX_NAME) | sed 's/\//\\\//g')"; \
-	sed 's/{REPLACE}/$(subst ",,$(esc_infix_name)) $(GIT_VERSION)/'  $(spec-dir)/Readme.adoc.in > $(spec-dir)/Readme.adoc
+	sed 's/{REPLACE}/$(subst ",,$(esc_infix_name)) $(INFIX_VERSION)/'  $(spec-dir)/Readme.adoc.in > $(spec-dir)/Readme.adoc
 	@$(spec-dir)/generate_spec.py -d $(test-dir)/case -r $(BR2_EXTERNAL_INFIX_PATH)
 	@asciidoctor-pdf --failure-level INFO --theme $(spec-dir)/theme.yml -a pdf-fontsdir=$(spec-dir)/fonts -o $(test-specification) $(spec-dir)/Readme.adoc
 

--- a/test/test.mk
+++ b/test/test.mk
@@ -6,11 +6,6 @@ test-specification := $(O)/images/test-specification.pdf
 
 UNIT_TESTS         ?= $(test-dir)/case/all-repo.yaml $(test-dir)/case/all-unit.yaml
 TESTS              ?= $(test-dir)/case/all.yaml
-ifeq ($INFIX_OEM_PATH), "")
-GIT_PATH            = $(INFIX_OEM_PATH)
-else
-GIT_PATH            = $(BR2_EXTERNAL_INFIX_PATH)
-endif
 GIT_VERSION         = $(shell git -C $(GIT_PATH) describe --dirty --always --tags)
 
 base := -b $(base-dir)


### PR DESCRIPTION
## Description

This will make it easier to correlate an image to the corresponding PR and or commit.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [x] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
