### PR TITLE
Dagger memory usage

### DIFF
--- a/src/confd/bin/dagger
+++ b/src/confd/bin/dagger
@@ -84,19 +84,25 @@ EOF
     done
 }
 
-do_exec()
+maybe_get_current()
 {
-    local action="$1"
+    echo $([ -f "$basedir/current" ] && cat "$basedir/current" || true)
+    [ ! "$current" ] || [ -d "$basedir/$current" ] \
+	|| abort "Current generation does not exist"
+}
+
+get_current()
+{
     local current=
 
-    current=$([ -f "$basedir/current" ] && cat "$basedir/current")
+    current=$(maybe_get_current)
     [ "$current" ] && [ -d "$basedir/$current" ] \
 	|| abort "Current generation does not exist"
 
-    action_exec "$1" "$basedir/$current"
+    echo "$current"
 }
 
-do_abandon()
+get_next()
 {
     local next=
 
@@ -104,7 +110,21 @@ do_abandon()
     [ "$next" ] && [ -d "$basedir/$next" ] \
 	|| abort "Next generation does not exist"
 
-    tar caf "$basedir/$next-ABANDONED-$(date +%F-%t).tar.gz" "$basedir/$next"
+    echo "$next"
+}
+
+do_exec()
+{
+    local action="$1"
+
+    action_exec "$1" "$basedir/$(get_current)"
+}
+
+do_abandon()
+{
+    local next=$(get_next)
+
+    (cd "$basedir" && tar caf "$next-ABANDONED-$(date +%F-%T.tar.gz)" "$next")
     rm -rf "$basedir/$next"
 
     rm "$basedir/next"
@@ -113,16 +133,8 @@ do_abandon()
 
 do_evolve()
 {
-    local current=
-    local next=
-
-    current=$([ -f "$basedir/current" ] && cat "$basedir/current" || true)
-    [ ! "$current" ] || [ -d "$basedir/$current" ] \
-	|| abort "Current generation does not exist"
-
-    next=$([ -f "$basedir/next" ] && cat "$basedir/next" || true)
-    [ "$next" ] && [ -d "$basedir/$next" ] \
-	|| abort "Next generation does not exist"
+    local current=$(maybe_get_current)
+    local next=$(get_next)
 
     [ "$current" ] && action_exec exit "$basedir/$current"
 

--- a/src/confd/bin/dagger
+++ b/src/confd/bin/dagger
@@ -124,10 +124,9 @@ do_abandon()
 {
     local next=$(get_next)
 
-    (cd "$basedir" && tar caf "$next-ABANDONED-$(date +%F-%T.tar.gz)" "$next")
-    rm -rf "$basedir/$next"
+    date +%F-%T >"$basedir/$next/ABANDONED"
 
-    rm "$basedir/next"
+    mv "$basedir/next" "$basedir/current"
     inform info "Abandoned generation $next"
 }
 
@@ -135,6 +134,7 @@ do_evolve()
 {
     local current=$(maybe_get_current)
     local next=$(get_next)
+    local ar=
 
     [ "$current" ] && action_exec exit "$basedir/$current"
 
@@ -144,8 +144,11 @@ do_evolve()
     inform info "Evolved to generation $next"
 
     if [ "$current" ]; then
-       (cd "$basedir" && tar caf "$current.tar.gz" "$current")
-       rm -rf "$basedir/$current"
+	ar="$current.tar.gz"
+	[ -f "$basedir/$current/ABANDONED" ] && ar="$current-ABANDONED.tar.gz"
+
+	(cd "$basedir" && tar caf "$ar.tar.gz" "$current")
+	rm -rf "$basedir/$current"
     fi
 }
 

--- a/src/confd/bin/dagger
+++ b/src/confd/bin/dagger
@@ -104,7 +104,9 @@ do_abandon()
     [ "$next" ] && [ -d "$basedir/$next" ] \
 	|| abort "Next generation does not exist"
 
-    mv "$basedir/$next" "$basedir/$next-ABANDONED-$(date +%F-%T)"
+    tar caf "$basedir/$next-ABANDONED-$(date +%F-%t).tar.gz" "$basedir/$next"
+    rm -rf "$basedir/$next"
+
     rm "$basedir/next"
     inform info "Abandoned generation $next"
 }
@@ -128,6 +130,19 @@ do_evolve()
 
     mv "$basedir/next" "$basedir/current"
     inform info "Evolved to generation $next"
+
+    if [ "$current" ]; then
+       (cd "$basedir" && tar caf "$current.tar.gz" "$current")
+       rm -rf "$basedir/$current"
+    fi
+}
+
+do_prune()
+{
+    local keep=${1:-10}
+
+    cd "$basedir"
+    rm -f old=$(ls -rv *.tar.gz | tail "+$((keep + 1))")
 }
 
 usage()
@@ -157,6 +172,10 @@ Commands:
 
   exec <action>
     Run the specified action of the current generation.
+
+  prune [<num-generations>]
+    Remove all but the last <num-generations>, or 10 by default,
+    archived generations.
 
   help
     Show this message.
@@ -200,6 +219,9 @@ case $cmd in
 	;;
     "exec")
 	do_exec "$@"
+	;;
+    "prune")
+	do_prune "$@"
 	;;
 
     *)

--- a/src/confd/src/dagger.c
+++ b/src/confd/src/dagger.c
@@ -114,11 +114,23 @@ int dagger_evolve(struct dagger *d)
 	return exitcode;
 }
 
+static int dagger_prune(struct dagger *d)
+{
+	int exitcode;
+
+	exitcode = systemf("dagger -C %s prune", d->path);
+	DEBUG("dagger(%d->%d): prune: exitcode=%d\n",
+	      d->current, d->next, exitcode);
+
+	return exitcode;
+}
+
 int dagger_evolve_or_abandon(struct dagger *d)
 {
 	int exitcode, err;
 
 	exitcode = dagger_evolve(d);
+	dagger_prune(d);
 	if (!exitcode)
 		return 0;
 

--- a/src/confd/src/ietf-interfaces.c
+++ b/src/confd/src/ietf-interfaces.c
@@ -304,6 +304,11 @@ static int netdag_exit_reload(struct dagger *net)
 {
 	FILE *initctl;
 
+	if (systemf("runlevel >/dev/null 2>&1"))
+		/* If we are still bootstrapping, there is nothing to
+		 * reload. */
+		return 0;
+
 	/* We may end up writing this file multiple times, e.g. if
 	 * multiple services are disabled in the same config cycle,
 	 * but since the contents of the file are static it doesn't


### PR DESCRIPTION
## Description

When reconfiguring the system many times (seen during regression testing), the RAM usage of keeping all generations around starts to add up.

A tmpfs file, no matter how small, will always consume at least one full page (4k). So one generation of tiny setup scripts and log files can end up locking :warning: 1 MB :warning:  of memory.

Therefore: Once we're done with a generation, archive it in a compressed tarball, which typically fits inside a single 4k page. Limit the total number of archives to 10. This should give full visibility into the history of a system in all normal situations, while still allowing hammering systems with reconfig cycles in testing scenarios.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
