### PR TITLE
build: Source build id from the correct repo, fix #872

### DIFF
--- a/infix.mk
+++ b/infix.mk
@@ -1,6 +1,7 @@
 IXMSG = printf "\e[37;44m>>>   $(call qstrip,$(1))\e[0m\n"
 
-INFIX_TOPDIR = $(if $(INFIX_OEM_PATH),$(INFIX_OEM_PATH),$(BR2_EXTERNAL_INFIX_PATH))
+oem-dir := $(call qstrip,$(INFIX_OEM_PATH))
+INFIX_TOPDIR = $(if $(oem-dir),$(oem-dir),$(BR2_EXTERNAL_INFIX_PATH))
 
 # Unless the user specifies an explicit build id, source it from git.
 # The build id also becomes the image version, unless an official


### PR DESCRIPTION
## Description

INFIX_OEM_PATH is `""` by default (i.e., not empty in `make`'s eyes). So we called `git` with `-C ""`, which it interpreted as "from the current directory" and thus we sourced the autogenerated build id from _buildroot_ instead of Infix.

Therefore, make sure to strip any quotes from the OEM path before determining the top directory.

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [x] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
