### PR TITLE
Add script for merging defconfigs

### DIFF
--- a/utils/generate-defconfig.sh
+++ b/utils/generate-defconfig.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Create new defconfigs by only applying the changes from a standard defconfig
+set -e
+
+SCRIPT_DIR="$(readlink -f $(dirname -- "$0"))"
+MERGE_CONFIG="${SCRIPT_DIR}/../buildroot/support/kconfig/merge_config.sh"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") -b BASE_CONFIG -c CHANGES -o OUTPUT_FILE
+
+Create a new defconfig by applying changes to a base configuration.
+
+Required Options:
+    -b, --base BASE          Path to base defconfig file
+    -c, --changes CHANGES    Path to config changes to apply
+    -o, --output OUTPUT      Path to output defconfig file
+
+Example:
+    $(basename "$0") \\
+        -b configs/aarch64_defconfig \\
+        -c changes/no-containers.conf \\
+        -o configs/aarch64_wo_containers_defconfig
+
+EOF
+    exit 1
+}
+check_file() {
+    file="$1"
+    type="$2"
+
+    if [ ! -f "$file" ]; then
+        echo "Error: $type file does not exist: $file" >&2
+        exit 1
+    elif [ ! -r "$file" ]; then
+        echo "Error: $type file is not readable: $file" >&2
+        exit 1
+    fi
+}
+
+
+while [ $# -gt 0 ]; do
+    case $1 in
+            -b|--base)
+		    base="$2"
+		    shift 2
+		    ;;
+	    -c|--changes)
+		    changes="$2"
+		    shift 2
+		    ;;
+	    -o|--output)
+		    output="$2"
+		    shift 2
+		    ;;
+            *)
+		    usage
+		    exit 1
+		    ;;
+    esac
+done
+
+if [ -z $output ] || [ -z $changes ] || [ -z $output ]; then
+        usage
+        exit 1
+fi
+
+if [ ! -x "$MERGE_CONFIG" ]; then
+    echo "Error: merge_config.sh not found or not executable at: $MERGE_CONFIG"
+    exit 1
+fi
+
+check_file "$base" "Base config"
+check_file "$changes" "Changes config"
+
+TMPDIR=`mktemp -d`
+$MERGE_CONFIG -O "$TMPDIR" -n "$base" "$changes"
+O="$TMPDIR" make savedefconfig
+mv "$TMPDIR"/defconfig "$output"
+rm -r "$TMPDIR"


### PR DESCRIPTION
Useful to only create a new image with only small diff with for example aarch64_defconfig.

example:
If the only diff is the VENDOR, instead of KernelKit you want 'foobar'. create a file with the change:
INFIX_VENDOR="foobar"

and call ./utils/generate-defconfig.sh -b aarch64_defconfig -c foobar-diff.conf -o configs/foobar_defconfig

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
