### PR TITLE
Match on Edge Attributes when Mapping Topologies

### DIFF
--- a/test/case/ietf_interfaces/bridge_basic/topology.dot
+++ b/test/case/ietf_interfaces/bridge_basic/topology.dot
@@ -9,16 +9,16 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data> data } | target\n10.0.0.2/24 (br0)",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt  [kind=mgmt, color="lightgray"]
+	host:mgmt -- target:mgmt  [requires="mgmt", color=lightgray]
 	host:data -- target:data [color=black, fontcolor=black, taillabel="10.0.0.1/24"]
 }

--- a/test/case/ietf_interfaces/bridge_fwd_dual_dut/topology.dot
+++ b/test/case/ietf_interfaces/bridge_fwd_dual_dut/topology.dot
@@ -11,26 +11,26 @@ graph "2x4" {
 	    	pos="0,15!",
 	    	height=3,
 
-	    	kind="controller",
+	    	requires="controller",
 	];
 
         dut1 [
 	    	label="{ <mgmt> mgmt | <data1> data1 } | { dut1 \n\n| <link> link }",
 	    	pos="4,15.68!",
-	    	kind="infix",    
+	    	requires="infix",    
 	];
 
         dut2 [
 		label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | { <link> link | \n dut2 }",
 	    	pos="4,14.43!",
 	    	height=1.2,
-	    	kind="infix",
+	    	requires="infix",
 	];
 
-	host:mgmt1 -- dut1:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt1 -- dut1:mgmt [requires="mgmt", color=lightgrey]
 	host:data11 -- dut1:data1 [color=black, fontcolor=black, taillabel="10.0.0.2"]
 
-	host:mgmt2 -- dut2:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt2 -- dut2:mgmt [requires="mgmt", color=lightgrey]
 	host:data21 -- dut2:data1 [color=black, fontcolor=black, taillabel="10.0.0.3"]
 	host:data22 -- dut2:data2 [color=black, fontcolor=black, taillabel="10.0.0.4"]
 

--- a/test/case/ietf_interfaces/bridge_fwd_sgl_dut/topology.dot
+++ b/test/case/ietf_interfaces/bridge_fwd_sgl_dut/topology.dot
@@ -9,17 +9,17 @@ graph "1x3" {
 	host [
 	    label="host | { <mgmt> mgmt | <data1> data1 | <data2>  data2 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- target:mgmt [requires="mgmt", color=lightgrey]
 	host:data1 -- target:data1 [color=black, fontcolor=black, taillabel="10.0.0.1"]
 	host:data2 -- target:data2 [color=black, fontcolor=black, taillabel="10.0.0.2"]
 }

--- a/test/case/ietf_interfaces/bridge_stp_basic/topology.dot
+++ b/test/case/ietf_interfaces/bridge_stp_basic/topology.dot
@@ -9,34 +9,34 @@ graph "stp" {
         host [
 	    label="{ { <mgmtd> mgmtd | <d> d | <mgmta> mgmta | <a> a | <b> b | <mgmtb> mgmtb | <c> c | <mgmtc> mgmtc } | host }",
 	    color="grey",fontcolor="grey",pos="9,0!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         A [
 	    label="{ A | { <mgmt> mgmt | <h> h } } | { <b> b | <c> c | <d> d }",
 	    pos="6,6!",
-	    kind="infix",
+	    requires="infix",
 	];
         B [
 	    label="{ <a> a | <d> d | <c> c } | { B | { <h> h | <mgmt> mgmt } }",
 	    pos="12,6!",
-	    kind="infix",
+	    requires="infix",
 	];
         C [
 	    label="{ <b> b | <a> a | <d> d } | { C | { <h> h | <mgmt> mgmt } }",
 	    pos="12,3!",
-	    kind="infix",
+	    requires="infix",
 	];
         D [
 	    label="{ D | { <mgmt> mgmt | <h> h } } | { <a> a | <b> b | <c> c }",
 	    pos="6,3!",
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmta -- A:mgmt [kind=mgmt, color="lightgrey"]
-	host:mgmtb -- B:mgmt [kind=mgmt, color="lightgrey"]
-	host:mgmtc -- C:mgmt [kind=mgmt, color="lightgrey"]
-	host:mgmtd -- D:mgmt [kind=mgmt, color="lightgrey"]
+	host:mgmta -- A:mgmt [requires="mgmt", color="lightgrey"]
+	host:mgmtb -- B:mgmt [requires="mgmt", color="lightgrey"]
+	host:mgmtc -- C:mgmt [requires="mgmt", color="lightgrey"]
+	host:mgmtd -- D:mgmt [requires="mgmt", color="lightgrey"]
 
 	host:a -- A:h [color="cornflowerblue"]
 	host:b -- B:h [color="cornflowerblue"]

--- a/test/case/ietf_interfaces/bridge_veth/topology.dot
+++ b/test/case/ietf_interfaces/bridge_veth/topology.dot
@@ -9,16 +9,16 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data> data } | target(br0:veth)\n10.0.0.2/24",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt -- target:mgmt [requires="mgmt", color="lightgray"]
 	host:data -- target:data [color=black, fontcolor=black, taillabel="10.0.0.1/24"]
 }

--- a/test/case/ietf_interfaces/bridge_vlan/topology.dot
+++ b/test/case/ietf_interfaces/bridge_vlan/topology.dot
@@ -9,23 +9,24 @@ graph "2x2" {
 	host [
 	    label="host | { <mgmt1> mgmt1 | <data> data | <mgmt2> mgmt2 }",
 	    pos="0,16!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         dut1 [
 	    label="{ <mgmt> mgmt | <data> data | <link> link} | dut1\n(10.0.0.2) ",
 	    pos="10,16!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	dut2 [
 	    label="{ <link> link | <mgmt> mgmt } | dut2\n(10.0.0.3)",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
-	host:mgmt1 -- dut1:mgmt [kind=mgmt, color="lightgray"]
-        host:mgmt2 -- dut2:mgmt [kind=mgmt, color="lightgray"]
+	
+	host:mgmt1 -- dut1:mgmt [requires="mgmt", color="lightgray"]
+	host:mgmt2 -- dut2:mgmt [requires="mgmt", color="lightgray"]
 	host:data -- dut1:data [color=black]
 
 	dut1:link -- dut2:link [color=black]

--- a/test/case/ietf_interfaces/bridge_vlan_separation/topology.dot
+++ b/test/case/ietf_interfaces/bridge_vlan_separation/topology.dot
@@ -9,28 +9,28 @@ graph "2x4" {
 	host [
 	    label="host | { <mgmt1> mgmt1 | <data10> data10 | <data11>  data11 | <> \n\n\n | <mgmt2> mgmt2 | <data20> data20 | <data21>  data21 }",
 	    pos="0,15!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         dut1 [
 	    label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | { \n dut1 \n\n |  <link> link }",
 	    pos="2,15.25!",
 	    fontsize=12,
-	    kind="infix",
+	    requires="infix",
 	];
 
         dut2 [
 		label="{ <mgmt> mgmt | <data1> data1| <data2> data2 } | { <link> link | \n dut2 \n\n }",
 	    pos="2,14.75!",
 	    fontsize=12,
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt1 -- dut1:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt1 -- dut1:mgmt [requires="mgmt", color="lightgray"]
 	host:data10 -- dut1:data1 [color=purple, fontcolor=purple, taillabel="10.0.0.1", headlabel="VLAN10 U"]
 	host:data11 -- dut1:data2 [color=darkgreen, fontcolor=darkgreen, taillabel="10.0.0.2", headlabel="VLAN20 U"]
 
-	host:mgmt2 -- dut2:mgmt [kind=mgmt color="lightgrey"]
+	host:mgmt2 -- dut2:mgmt [requires="mgmt" color="lightgrey"]
 	host:data20 -- dut2:data1 [color=purple, fontcolor=purple, taillabel="10.0.0.3", headlabel="VLAN10 U"]
 	host:data21 -- dut2:data2 [color=darkgreen, fontcolor=darkgreen, taillabel="10.0.0.4", headlabel="VLAN20 U"]
 

--- a/test/case/ietf_interfaces/iface_enable_disable/topology.dot
+++ b/test/case/ietf_interfaces/iface_enable_disable/topology.dot
@@ -9,27 +9,27 @@ graph "2x4" {
 	host [
 	    label="host | { <mgmt1> mgmt1 | <data> data | <mgmt2> mgmt2 }",
 	    pos="0,15!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target1 [
 	    label="{ <mgmt> mgmt | <data> data | <link> link } | { \n dut1 \n\n }",
 	    pos="8,15!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
         target2 [
             label="{ <link> link | <mgmt> mgmt } | { \n dut2 \n\n }",
 	    pos="8,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt1 -- target1:mgmt [kind=mgmt, color="lightgrey"]
+	host:mgmt1 -- target1:mgmt [requires="mgmt", color="lightgrey"]
 	host:data -- target1:data [color=black, fontcolor=black, taillabel="10.10.10.1/24"]
 
-	host:mgmt2 -- target2:mgmt [kind=mgmt, color="lightgrey"]
+	host:mgmt2 -- target2:mgmt [requires="mgmt", color="lightgrey"]
 
 	target1:link -- target2:link [color=black, fontcolor=black, headlabel="10.10.10.2/24"]
 }

--- a/test/case/ietf_interfaces/igmp_basic/topology.dot
+++ b/test/case/ietf_interfaces/igmp_basic/topology.dot
@@ -9,17 +9,17 @@ graph "1x4" {
 	host [
 	    label="host | { <mgmt> mgmt | <data1> data1 | <data2>  data2 | <data3>  data3 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 | <data3> data3 } | target \n\n(br0)\n10.0.0.1/24",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt  -- target:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt  -- target:mgmt [requires="mgmt", color="lightgray"]
 	host:data1 -- target:data1 [color=black, fontcolor=black, taillabel="10.0.0.2/24"]
 	host:data2 -- target:data2 [color=black, fontcolor=black, taillabel="10.0.0.3/24"]
 	host:data3 -- target:data3 [color=black, fontcolor=black, taillabel="10.0.0.4/24"]

--- a/test/case/ietf_interfaces/igmp_vlan/topology.dot
+++ b/test/case/ietf_interfaces/igmp_vlan/topology.dot
@@ -9,28 +9,28 @@ graph "2x4" {
 	host [
 		label="host | { <mgmt1> mgmt1 | <data11> data11 | <data12>  data12 | <> \n\n\n | <mgmt2> mgmt2 | <data21> data21 | <data22>  data22 }",
 		pos="0,15!",
-		kind="controller",
+		requires="controller",
 	];
 
         dut1 [
 		label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | { dut1 \nVLAN55: 10.0.1.1 \nVLAN77: 10.0.2.1 |  <link> link }",
 		pos="3,15.4!",
 		fontsize=12,
-		kind="infix",
+		requires="infix",
 	];
 
         dut2 [
 		label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | { <link> link | dut2 \nVLAN55: 10.0.1.2 \nVLAN77: 10.0.2.2\n }",
 		pos="3,14.6!",
 		fontsize=12,
-		kind="infix",
+		requires="infix",
 	];
 
-	host:mgmt1 -- dut1:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt1 -- dut1:mgmt [requires="mgmt", color=lightgrey]
 	host:data11 -- dut1:data1 [color=purple, fontcolor=purple, taillabel="10.0.1.11", headlabel="VLAN55 U"]
 	host:data12 -- dut1:data2 [color=darkgreen, fontcolor=darkgreen, taillabel="10.0.2.11", headlabel="VLAN77 U"]
 
-	host:mgmt2 -- dut2:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt2 -- dut2:mgmt [requires="mgmt", color=lightgrey]
 	host:data21 -- dut2:data1 [color=purple, fontcolor=purple, taillabel="10.0.1.22", headlabel="VLAN55 U"]
 	host:data22 -- dut2:data2 [color=darkgreen, fontcolor=darkgreen, taillabel="10.0.2.22", headlabel="VLAN77 U"]
 

--- a/test/case/ietf_interfaces/routing_basic/topology.dot
+++ b/test/case/ietf_interfaces/routing_basic/topology.dot
@@ -8,17 +8,17 @@ graph "routing_basic" {
 	host [
 	    label="host | { <mgmt> mgmt | <data1> data1 | <data2>  data2 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt  -- target:mgmt  [kind=mgmt, color="lightgray"]
+	host:mgmt  -- target:mgmt  [requires="mgmt", color="lightgray"]
 	host:data1 -- target:data1 [color=black, fontcolor=black, fontsize=12, taillabel=".10", label="192.168.0.0/24", headlabel=".1"]
 	host:data2 -- target:data2 [color=black, fontcolor=black, fontsize=12,  taillabel=".10", label="10.0.0.0/24", headlabel=".1"]
 }

--- a/test/case/ietf_interfaces/tunnel_basic/topology.dot
+++ b/test/case/ietf_interfaces/tunnel_basic/topology.dot
@@ -9,26 +9,26 @@ graph "gre-basic" {
 	host [
 	    label="host | { <mgmt1> mgmt1 } | { <data> data } | { <mgmt2> mgmt2 }"
 	    pos="3,0!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         left [
 	    label="{ left } | { <mgmt> mgmt } | { <data> data  } |  { <link> link }",
 	    pos="0, -3!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
         right [
 	    label="{ <link> link } | { <mgmt> mgmt } |  { right }",
 	    pos="8,-3!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt1 -- left:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt1 -- left:mgmt [requires="mgmt", color="lightgray"]
 	host:data -- left:data [headlabel=".1", label="192.168.10.0/24" taillabel=".2&nbsp;", labeldistance=1, fontcolor="black", color="black"]
-	host:mgmt2 -- right:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt2 -- right:mgmt [requires="mgmt", color="lightgray"]
 
 
 	left:link -- right:link [headlabel=".1\n\n", label="192.168.50.0/24", taillabel="\n.2", labeldistance=1, fontcolor="black", color="black"]

--- a/test/case/ietf_interfaces/tunnel_bridged/topology.dot
+++ b/test/case/ietf_interfaces/tunnel_bridged/topology.dot
@@ -9,26 +9,26 @@ graph "gre-basic" {
 	host [
 	    label="host | { <mgmt1> mgmt1 } | { <data> data } | { <mgmt2> mgmt2 }"
 	    pos="3,0!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         left [
 	    label="{ left } | { <mgmt> mgmt } | { <data> data  } |  { <link> link }",
 	    pos="0, -3!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
         right [
 	    label="{ <link> link } | { <mgmt> mgmt } | { right }",
 	    pos="8,-3!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt1 -- left:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt1 -- left:mgmt [requires="mgmt", color="lightgray"]
 	host:data -- left:data [taillabel="192.168.10.2/24&nbsp;&nbsp;&nbsp;&nbsp;", fontcolor="black", color="black"]
-	host:mgmt2 -- right:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt2 -- right:mgmt [requires="mgmt", color="lightgray"]
 
 
 	left:link -- right:link [headlabel=".1\n\n", label="192.168.50.0/24", taillabel="\n.2", labeldistance=1, fontcolor="black", color="black"]

--- a/test/case/ietf_interfaces/verify_all_interface_types/topology.dot
+++ b/test/case/ietf_interfaces/verify_all_interface_types/topology.dot
@@ -9,17 +9,17 @@ graph "1x3" {
 	host [
 	    label="host | { <mgmt> mgmt  | <data1> data1 | <data2> data2 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <ethX> ethX | <ethQ> ethQ } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- target:mgmt [requires="mgmt", color=lightgrey]
 	host:data1 -- target:ethX [color=black]
 	host:data2 -- target:ethQ [color=black]
 }

--- a/test/case/ietf_interfaces/veth_delete/topology.dot
+++ b/test/case/ietf_interfaces/veth_delete/topology.dot
@@ -9,17 +9,17 @@ graph "1x3" {
 	host [
 	    label="host | { <mgmt> mgmt | <data1> data1 | <data2> data2 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- target:mgmt [requires="mgmt", color=lightgrey]
 	host:data1 -- target:data1 [color=black]
 	host:data2 -- target:data2 [color=black]
 }

--- a/test/case/ietf_interfaces/vlan_ping/topology.dot
+++ b/test/case/ietf_interfaces/vlan_ping/topology.dot
@@ -9,16 +9,16 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data\n(vlan10) }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data> data\n(vlan10) } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt  -- target:mgmt  [kind=mgmt, color="lightgray"]
+	host:mgmt  -- target:mgmt  [requires="mgmt", color="lightgray"]
 	host:data -- target:data [color=black, fontcolor=black, fontsize=12, taillabel="10.0.0.1/24", headlabel="10.0.0.2/24"]
 }

--- a/test/case/ietf_interfaces/vlan_qos/topology.dot
+++ b/test/case/ietf_interfaces/vlan_qos/topology.dot
@@ -9,17 +9,17 @@ graph "1x3" {
 	host [
 	    label="host | { <mgmt> mgmt | <data0> data0 | <data1>  data1 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 } | target",
 	    pos="15,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- target:mgmt [requires="mgmt", color=lightgrey]
 	host:data0 -- target:data0 [color=black, fontcolor=black, fontsize=12, taillabel="(vlan10) 192.168.10.2/24", headlabel="192.168.10.1/24 (vlan10)"]
 	host:data1 -- target:data1 [color=black, fontcolor=black, fontsize=12, taillabel="(vlan11) 192.168.11.2/24", headlabel="192.168.11.1/24 (vlan11)"]
 }

--- a/test/case/ietf_routing/ospf_basic/topology.dot
+++ b/test/case/ietf_routing/ospf_basic/topology.dot
@@ -10,23 +10,24 @@ graph "2x2" {
 	PC [
 	    label="PC | { <mgmt1> mgmt1 | <data> data | <mgmt2> mgmt2 }",
 	    pos="20,80!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         R1 [
 	    label="{ <mgmt> mgmt | <data> data | <link> link} | R1 \n 192.168.100.1/32 \n(lo)",
 	    pos="250,80!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	R2 [
 	    label="{ <link> link | <mgmt> mgmt | <data> data  } | R2 \n 192.168.200.1/32 \n(lo)",
 	    pos="250,30!",
 
-	    kind="infix",
+	    requires="infix",
 	];
-	PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
+	
+	PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
 	PC:data -- R1:data  [color="black", headlabel="192.168.10.1/24", taillabel="192.168.10.2/24", fontcolor="black"]
 	R1:link -- R2:link  [headlabel="192.168.50.2/24", taillabel="192.168.50.1/24", labeldistance=1, fontcolor="black", color="black"]
 }

--- a/test/case/ietf_routing/ospf_bfd/topology.dot
+++ b/test/case/ietf_routing/ospf_bfd/topology.dot
@@ -11,23 +11,23 @@ graph "ospf-bfd" {
 	    label=" { { R1 | <slow> slow } | { <mgmt> mgmt | <h1> h1 | <fast> fast } }",
 	    pos="0,6!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	R2 [
 	    label="{ { <slow> slow | R2 } | { <fast> fast | <h2> h2 | <mgmt> mgmt  } }",
 	    pos="18,6!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
 	PC [
 	    label="{ { <R1mgmt> R1mgmt | <h1> h1 | <R1fast> R1fast | <R2fast> R2fast | <h2> h2 | <R2mgmt> R2mgmt } | PC }",
 	    pos="9,0!",
-	    kind="controller",
+	    requires="controller",
 	];
 
-	PC:R1mgmt -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:R2mgmt -- R2:mgmt [kind=mgmt, color="lightgray"]
+	PC:R1mgmt -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:R2mgmt -- R2:mgmt [requires="mgmt", color="lightgray"]
 
 	PC:h1 -- R1:h1
 	PC:h2 -- R2:h2

--- a/test/case/ietf_routing/ospf_default_route_advertise/topology.dot
+++ b/test/case/ietf_routing/ospf_default_route_advertise/topology.dot
@@ -10,23 +10,24 @@ graph "2x2" {
 	PC [
 	    label="PC | { <mgmt1> mgmt1 | <data1> data1 | <data2> data2 |  <mgmt2> mgmt2 }",
 	    pos="20,80!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         R1 [
 	    label="{ <mgmt> mgmt | <data> data  | <link> link } | R1 \n 192.168.100.1/32 \n 10.10.10.10/32\n(lo)",
 	    pos="250,85!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	R2 [
 	    label="{ <link> link  | <data> data | <mgmt> mgmt } | R2 \n 192.168.200.1/32 \n(lo)",
 	    pos="250,30!",
 
-	    kind="infix",
+	    requires="infix",
 	];
-	PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
+	
+	PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
 	PC:data1  -- R1:data  [color="black", headlabel="192.168.10.1/24", taillabel="192.168.10.2/24", fontcolor="black"]
 	PC:data2  -- R2:data  [color="black", headlabel="192.168.20.1/24", taillabel="192.168.20.2/24", fontcolor="black"]
 	R1:link  -- R2:link  [headlabel="192.168.50.2/24", taillabel="192.168.50.1/24", labeldistance=1, fontcolor="black", color="black"]

--- a/test/case/ietf_routing/ospf_multiarea/topology.dot
+++ b/test/case/ietf_routing/ospf_multiarea/topology.dot
@@ -11,38 +11,38 @@ graph "ring-4-duts" {
     PC [
         label=" { PC | { <mgmt4> mgmt4 | <data4> data4 | <mgmt1> mgmt1 | &#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160; | <mgmt2> mgmt2 | <data3> data3 | <mgmt3> mgmt3 } }",
         pos="150,200!"
-        kind="controller",
+        requires="controller",
     ];
 
     R1 [
         label="{ { <mgmt> mgmt } | R1 \n 10.0.0.1/32 \n(lo) } | { <ring1> ring1 | <cross> cross | <ring2> ring2 }",
         pos="50,150!",
-        kind="infix",
+        requires="infix",
     ];
 
     R4 [
         label="{ { <mgmt> mgmt | <data> data } | R4 \n 10.0.0.4/32 \n(lo) } | { <ring1> ring1 | <cross> cross | <ring2> ring2 }",
         pos="50,50!"
-        kind="infix",
+        requires="infix",
     ];
 
     R2 [
         label="{ <ring2> ring2 | <cross> cross | <ring1> ring1 } | { { <mgmt> mgmt } | R2 \n10.0.0.2/32 \n(lo) }",
         pos="250,150!"
-        kind="infix",
+        requires="infix",
     ];
 
     R3 [
         label="{ <ring2> ring2 | <cross> cross | <ring1> ring1 } | { { <data> data | <mgmt> mgmt } | R3 \n10.0.0.3/32 \n(lo) }",
         pos="250,50!"
-        kind="infix",
+        requires="infix",
     ];
 
     # Management Connections
-    PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-    PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
-    PC:mgmt3 -- R3:mgmt [kind=mgmt, color="lightgray", overlap=false, weight=0.1]
-    PC:mgmt4 -- R4:mgmt [kind=mgmt, color="lightgray", overlap=false, weight=0.1]
+    PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+    PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
+    PC:mgmt3 -- R3:mgmt [requires="mgmt", color="lightgray", overlap=false, weight=0.1]
+    PC:mgmt4 -- R4:mgmt [requires="mgmt", color="lightgray", overlap=false, weight=0.1]
 
     # PC-Dut links
     PC:data3 -- R3:data [color="purple", headlabel=".1", label="192.168.3.0/24\n(Area 1)", taillabel=".2", labeldistance=2, fontcolor="purple"]

--- a/test/case/ietf_routing/ospf_unnumbered_interface/topology.dot
+++ b/test/case/ietf_routing/ospf_unnumbered_interface/topology.dot
@@ -10,23 +10,24 @@ graph "2x2" {
 	PC [
 	    label="PC | { <mgmt1> mgmt1 | <data> data | <mgmt2> mgmt2 }",
 	    pos="20,80!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         R1 [
 	    label="{ <mgmt> mgmt | <data> data | <link> link} | R1 \n 192.168.100.1/32 \n(lo)",
 	    pos="250,80!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	R2 [
 	    label="{ <link> link |<mgmt> mgmt | <data> data  } | R2 \n 192.168.200.1/32 \n(lo)",
 	    pos="250,30!",
 
-	    kind="infix",
+	    requires="infix",
 	];
-	PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
+	
+	PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
 	PC:data  -- R1:data [color="black", headlabel="192.168.10.1/24", taillabel="192.168.10.2/24", fontcolor="black"]
 	R1:link  -- R2:link [headlabel="10.0.0.2/32", taillabel="10.0.0.1/32", labeldistance=1, fontcolor="black", color="black"]
 }

--- a/test/case/ietf_routing/route_pref_255/topology.dot
+++ b/test/case/ietf_routing/route_pref_255/topology.dot
@@ -11,25 +11,25 @@ graph "route-preference" {
 	[
 		label="PC | { <mgmt1> mgmt1 | <data1> data1 |  <data2> data2 | <mgmt2> mgmt2 }",
 	    	pos="20,58!",
-	    	kind="controller",
+	    	requires="controller",
 	];
 
         R1 
 	[
 		label="{ <mgmt> mgmt | <data> data | <link> link } | R1",
 		pos="80,60!",
-		kind="infix",
+		requires="infix",
 	];
 	
 	R2 
 	[
 	    	label="{ <link> link | <data> data | <mgmt> mgmt } | R2",
 	    	pos="80,42!",
-	    	kind="infix",
+	    	requires="infix",
 	];
 	
-	PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
+	PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
 	
 	PC:data1 -- R1:data  [color="black", headlabel="192.168.10.1/24", taillabel="192.168.10.11/24", fontcolor="black"]
 	PC:data2 -- R2:data  [color="black", headlabel="192.168.20.2/24", taillabel="192.168.20.22/24", fontcolor="black"]

--- a/test/case/ietf_routing/route_pref_dhcp/topology.dot
+++ b/test/case/ietf_routing/route_pref_dhcp/topology.dot
@@ -11,25 +11,25 @@ graph "route-preference" {
 	[
 		label="PC | { <mgmt1> mgmt1 | <data11> data11 | <data12> data12 | <> \n |<data2> data2 | <mgmt2> mgmt2 }",
 	    	pos="20,50!",
-	    	kind="controller",
+	    	requires="controller",
 	];
 
         R1 
 	[
 		label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 | <link> link } | R1 \n 192.168.100.1/32 \n(lo)",
 		pos="60,51.8!",
-		kind="infix",
+		requires="infix",
 	];
 	
 	R2 
 	[
 	    	label="{ <link> link | <data> data | <mgmt> mgmt } | R2 \n 192.168.200.1/32 \n(lo)",
 	    	pos="60,42!",
-	    	kind="infix",
+	    	requires="infix",
 	];
 	
-	PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
+	PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
 	
 	PC:data11 -- R1:data1  [color="black", headlabel="192.168.10.1/24", taillabel="192.168.10.3/24", fontcolor="black"]
 	PC:data12 -- R1:data2  [color="black", headlabel="192.168.30.1/24", taillabel="192.168.30.3/24", fontcolor="black"]

--- a/test/case/ietf_routing/route_pref_ospf/topology.dot
+++ b/test/case/ietf_routing/route_pref_ospf/topology.dot
@@ -11,25 +11,25 @@ graph "route-preference" {
 	[
 		label="PC | { <mgmt1> mgmt1 | <data1> data1 | <> \n\n | <R1_ospf> R1_ospf | <R2_ospf> R2_ospf | <> \n\n |  <data2> data2 | <mgmt2> mgmt2 }",
 	    	pos="20,50!",
-	    	kind="controller",
+	    	requires="controller",
 	];
 
         R1 
 	[
 		label="{ <mgmt> mgmt | <data> data | <ospf> ospf | <link> link } | R1",
 		pos="70,58!",
-		kind="infix",
+		requires="infix",
 	];
 	
 	R2 
 	[
 	    	label="{ <link> link | <ospf> ospf | <data> data | <mgmt> mgmt } | R2",
 	    	pos="70,42!",
-	    	kind="infix",
+	    	requires="infix",
 	];
 	
-	PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
+	PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
 	
 	PC:data1 -- R1:data  [color="black", headlabel="192.168.10.1/24", taillabel="192.168.10.11/24", fontcolor="black"]
 	PC:data2 -- R2:data  [color="black", headlabel="192.168.20.2/24", taillabel="192.168.20.22/24", fontcolor="black"]

--- a/test/case/ietf_routing/static_routing/topology.dot
+++ b/test/case/ietf_routing/static_routing/topology.dot
@@ -10,23 +10,23 @@ graph "2x2" {
 	PC [
 	    label="PC | { <mgmt1> mgmt1 | <data> data | <mgmt2> mgmt2 }",
 	    pos="20,80!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         R1 [
 	    label="{ <mgmt> mgmt | <data> data | <link> link} | R1 \n 192.168.100.1/32 \n(lo)",
 	    pos="250,80!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	R2 [
 	    label="{ <link> link | <mgmt> mgmt  } | R2 \n 192.168.200.1/32 \n(lo)",
 	    pos="250,30!",
 
-	    kind="infix",
+	    requires="infix",
 	];
-	PC:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-        PC:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
+	PC:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	PC:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
 	PC:data  -- R1:data [headlabel=".1", taillabel=".2", label="192.168.10.0/24", fontcolor="black", color="black"]
 	R1:link  -- R2:link [headlabel=".2", taillabel=".1", label="192.168.50.0/24", labeldistance=1, fontcolor="black", color="black"]
 }

--- a/test/case/ietf_syslog/remote/topology.dot
+++ b/test/case/ietf_syslog/remote/topology.dot
@@ -9,22 +9,23 @@ graph "2x2" {
 	host [
 	    label="host | { <mgmt1> mgmt1 | <mgmt2> mgmt2 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         client [
 	    label="{ <mgmt> mgmt | <link> link} | client",
 	    pos="15,18!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	server [
 	    label="{ <link> link | <mgmt> mgmt  } | server",
 	    pos="15,6!",
 
-	    kind="infix",
+	    requires="infix",
 	];
-	host:mgmt1 -- client:mgmt [kind=mgmt, color=lightgrey]
-        host:mgmt2 -- server:mgmt [kind=mgmt, color=lightgrey]
+	
+	host:mgmt1 -- client:mgmt [requires="mgmt", color=lightgrey]
+	host:mgmt2 -- server:mgmt [requires="mgmt", color=lightgrey]
 	client:link -- server:link [color=black, fontcolor=black, taillabel="10.0.0.2/24", headlabel="10.0.0.1/24"]
 }

--- a/test/case/infix_containers/container_bridge/topology.dot
+++ b/test/case/infix_containers/container_bridge/topology.dot
@@ -9,16 +9,16 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data> data } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- target:mgmt [requires="mgmt", color=lightgrey]
 	host:data -- target:data [color=black, fontcolor=black, fontsize=12, taillabel="10.0.0.1/24", headlabel="10.0.0.2/24"]
 }

--- a/test/case/infix_containers/container_firewall_basic/topology.dot
+++ b/test/case/infix_containers/container_firewall_basic/topology.dot
@@ -9,16 +9,16 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <ext0> ext0 } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- target:mgmt [requires="mgmt", color=lightgrey]
 	host:data -- target:ext0 [color=black, headlabel=".1 ", taillabel=" .2", label="\n     192.168.0.1/24     "]
 }

--- a/test/case/infix_dhcp/dhcp_basic/topology.dot
+++ b/test/case/infix_dhcp/dhcp_basic/topology.dot
@@ -9,15 +9,15 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,20!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         client [
 	    label="{ <mgmt> mgmt | <data> data } | client",
 	    pos="200,20!",
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- client:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- client:mgmt [requires="mgmt", color=lightgrey]
 	host:data -- client:data [color=black, taillabel="10.0.0.1/24", headlabel="10.0.0.42/24"]
 }

--- a/test/case/infix_dhcp/dhcp_router/topology.dot
+++ b/test/case/infix_dhcp/dhcp_router/topology.dot
@@ -9,15 +9,15 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,20!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         client [
 	    label="{ <mgmt> mgmt | <data> data } | client",
 	    pos="200,20!",
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- client:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- client:mgmt [requires="mgmt", color=lightgrey]
 	host:data -- client:data [color=black, taillabel="192.168.0.1/24"]
 }

--- a/test/case/infix_dhcp/dhcp_routes/topology.dot
+++ b/test/case/infix_dhcp/dhcp_routes/topology.dot
@@ -9,15 +9,15 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,20!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         client [
 	    label="{ <mgmt> mgmt | <data> data } | client",
 	    pos="200,20!",
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- client:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- client:mgmt [requires="mgmt", color=lightgrey]
 	host:data -- client:data [color=black, taillabel="192.168.0.1/24"]
 }

--- a/test/case/infix_services/mdns_allow_deny/topology.dot
+++ b/test/case/infix_services/mdns_allow_deny/topology.dot
@@ -9,17 +9,17 @@ graph "1x4" {
 	host [
 	    label="host | { <mgmt> mgmt | <eth1> eth1 | <eth2>  eth2 | <eth3>  eth3 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         dut [
 	    label="{ <mgmt> mgmt | <p1> p1 | <p2> p2 | <p3> p3 } | dut \n\n(br0)\n10.0.p.1/24",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- dut:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt -- dut:mgmt [requires="mgmt", color="lightgray"]
 	host:eth1 -- dut:p1 [color=black, fontcolor=black, taillabel="10.0.1.2/24"]
 	host:eth2 -- dut:p2 [color=black, fontcolor=black, taillabel="10.0.2.2/24"]
 	host:eth3 -- dut:p3 [color=black, fontcolor=black, taillabel="10.0.3.2/24"]

--- a/test/case/infix_services/services_basic/topology.dot
+++ b/test/case/infix_services/services_basic/topology.dot
@@ -9,16 +9,15 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data> data } | target",
 	    pos="10,12!",
-
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
 	host:data -- target:data [color=black, fontcolor=black, fontsize=12, taillabel="10.0.0.1/24", headlabel="10.0.0.10/24"]
+	host:mgmt -- target:mgmt [requires="mgmt", color="lightgrey"]
 }

--- a/test/case/infix_services/ssh_server_config/topology.dot
+++ b/test/case/infix_services/ssh_server_config/topology.dot
@@ -9,16 +9,16 @@ graph "1x3" {
 	host [
 	    	label="host | { <mgmt> mgmt | <data1> data1 | <data2> data2 }",
 	    	pos="0,12!",
-	    	kind="controller",
+	    	requires="controller",
 	];
 
         target [
 		label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 } | target",
 	    	pos="10,12!",
-	    	kind="infix",
+	    	requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt -- target:mgmt [requires="mgmt", color="lightgray"]
 	host:data1 -- target:data1 [color="black"]
 	host:data2 -- target:data2 [color="black"]
 }

--- a/test/case/use_case/ospf_container/topology.dot
+++ b/test/case/use_case/ospf_container/topology.dot
@@ -11,37 +11,37 @@ graph "ospf_containers" {
 	host [
 		label=" { {  <R1ring1> R1ring1 | <R1ring2> R1ring2 |  <data1> data1  | <mgmt1> mgmt1 |  <mgmt2> mgmt2 | <data2> data2 | <R2ring1> R2ring1 | <R2ring2> R2ring2 | <data3> data3  | <mgmt3> mgmt3 |  <R3ring1> R3ring1 | <R3ring2> R3ring2 |  <mgmt4> mgmt4 | <data4> data4 } | host } ",
 		pos="0,5!"
-		kind="controller",
+		requires="controller",
 	];
 
    	R1 [
 		label="{{ <link> link } | R1 | {<ring1> ring1 | <ring2> ring2 | <data> data | <mgmt> mgmt }}"
 		pos="-1,6!"
-		kind="infix",
+		requires="infix",
 	];
 
 	R2 [
 		label="{{ <link> link } | R2 | { <mgmt> mgmt | <data> data | <ring1> ring1 |  <ring2> ring2 }}"
 		pos="0,6!",
-		kind="infix",
+		requires="infix",
 	];
 	R3 [
 		label="{ <link> link | R3 | { <data> data | <mgmt> mgmt | <ring1> ring1 | <ring2> ring2 }}"
 		pos="1,6!"
-		kind="infix",
+		requires="infix",
 	];
 
 
 	ABR [
 		label="{ ABR | {<link1> link1 |  <link2> link2 |<link3> link3 | <mgmt> mgmt | <data> data }}"
 		pos="2,6.5!"
-		kind="infix",
+		requires="infix",
 	];
 
-	host:mgmt1 -- R1:mgmt [kind=mgmt, color="lightgray"]
-	host:mgmt2 -- R2:mgmt [kind=mgmt, color="lightgray"]
-	host:mgmt3 -- R3:mgmt  [kind=mgmt, color="lightgray"]
-	host:mgmt4 -- ABR:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt1 -- R1:mgmt [requires="mgmt", color="lightgray"]
+	host:mgmt2 -- R2:mgmt [requires="mgmt", color="lightgray"]
+	host:mgmt3 -- R3:mgmt  [requires="mgmt", color="lightgray"]
+	host:mgmt4 -- ABR:mgmt [requires="mgmt", color="lightgray"]
 
 	# host-Dut links
 	host:data1 -- R1:data

--- a/test/infamy/topologies/1x1.dot
+++ b/test/infamy/topologies/1x1.dot
@@ -9,15 +9,15 @@ graph "1x1" {
 	host [
 	    label="host | { <mgmt> mgmt }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color="lightgray"]
+	host:mgmt -- target:mgmt [requires="mgmt", color="lightgray"]
 }

--- a/test/infamy/topologies/1x2.dot
+++ b/test/infamy/topologies/1x2.dot
@@ -9,16 +9,16 @@ graph "1x2" {
 	host [
 	    label="host | { <mgmt> mgmt | <data> data }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data> data } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt -- target:mgmt [kind=mgmt, color=lightgrey]
+	host:mgmt -- target:mgmt [requires="mgmt", color=lightgrey]
 	host:data -- target:data [color=black]
 }

--- a/test/infamy/topologies/1x3.dot
+++ b/test/infamy/topologies/1x3.dot
@@ -9,17 +9,17 @@ graph "1x3" {
 	host [
 	    label="host | { <tgt> tgt | <data0> data0 | <data1>  data1 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:tgt -- target:mgmt [kind=mgmt]
+	host:tgt -- target:mgmt [requires="mgmt"]
 	host:data0 -- target:data0 [color=black]
 	host:data1 -- target:data1 [color=black]
 }

--- a/test/infamy/topologies/1x4.dot
+++ b/test/infamy/topologies/1x4.dot
@@ -9,17 +9,17 @@ graph "1x4" {
 	host [
 	    label="host | { <mgmt> mgmt | <data1> data1 | <data2>  data2 | <data3>  data3 }",
 	    pos="0,12!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target [
 	    label="{ <mgmt> mgmt | <data1> data1 | <data2> data2 | <data3> data3 } | target",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt  -- target:mgmt [kind=mgmt]
+	host:mgmt  -- target:mgmt [requires="mgmt"]
 	host:data1 -- target:data1 [color=black]
 	host:data2 -- target:data2 [color=black]
 	host:data3 -- target:data3 [color=black]

--- a/test/infamy/topologies/2x2.dot
+++ b/test/infamy/topologies/2x2.dot
@@ -9,23 +9,23 @@ graph "2x2" {
 	host [
 	    label="host | { <mgmt1> mgmt1 | <data1> data1 | <mgmt2> mgmt2 | <data2> data2 }",
 	    pos="0,15.7!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         target1 [
 	    label="{ <mgmt> mgmt | <data> data | <target2> target2} | target1",
 	    pos="10,16!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 	target2 [
 	    label="{ <target1> target1 |<mgmt> mgmt | <data> data  } | target2",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
-	host:mgmt1 -- target1:mgmt [kind=mgmt]
-        host:mgmt2 -- target2:mgmt [kind=mgmt]
+	host:mgmt1 -- target1:mgmt [requires="mgmt"]
+        host:mgmt2 -- target2:mgmt [requires="mgmt"]
 	host:data1 -- target1:data [color=black]
 	host:data2 -- target2:data [color=black]
 	target1:target2 -- target2:target1 [color=black]

--- a/test/infamy/topologies/2x4.dot
+++ b/test/infamy/topologies/2x4.dot
@@ -9,28 +9,28 @@ graph "2x4" {
 	host [
 	    label="host | { <mgmt1> mgmt1 | <data10> data10 | <data11>  data11 | <> \n\n\n\n\n\n | <mgmt2> mgmt2 | <data20> data20 | <data21>  data21 }",
 	    pos="0,15!",
-	    kind="controller",
+	    requires="controller",
 	];
 
         dut1 [
 	    label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 } | { \n dut1 \n\n |  <data2> data2 }",
 	    pos="10,18!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
         dut2 [
 		label="{ <mgmt> mgmt | <data0> data0 | <data1> data1 } | { <data2> data2 | \n dut2 \n\n }",
 	    pos="10,12!",
 
-	    kind="infix",
+	    requires="infix",
 	];
 
-	host:mgmt1 -- dut1:mgmt [kind=mgmt]
+	host:mgmt1 -- dut1:mgmt [requires="mgmt"]
 	host:data10 -- dut1:data0 [color=black]
 	host:data11 -- dut1:data1 [color=black]
 
-	host:mgmt2 -- dut2:mgmt [kind=mgmt]
+	host:mgmt2 -- dut2:mgmt [requires="mgmt"]
 	host:data20 -- dut2:data0 [color=black]
 	host:data21 -- dut2:data1 [color=black]
 

--- a/test/virt/quad/topology.dot.in
+++ b/test/virt/quad/topology.dot.in
@@ -15,13 +15,13 @@ graph "quad" {
         host [
 	    label="host | { <d1a> d1a | <d1b> d1b | <d1c> d1c | <d1c> d1d | <d2a> d2a | <d2b> d2b | <d2c> d2c | <d2d> d2d | <d2a> d3a | <d3b> d3b | <d3c> d3c | <d3c> d3d |  <d4a> d4a | <d4b> d4b | <d4c> d4c | <d4c> d4d }",
 	    color="grey",fontcolor="grey",pos="0,15!",
-	    kind="controller",
+	    provides="controller",
 	];
 
         dut1 [
 	    label="{ <e1> e1 | <e2> e2 | <e3> e3 } | dut1 | { <e4> e4 | <e5> e5 | <e6> e6 | <e7> e7 | <e8> e8}",
 	    pos="10,18!",
-	    kind="infix",
+	    provides="infix",
 	    qn_console=9001,
 	    qn_mem="384M",
 	    qn_usb="dut1.usb"
@@ -29,7 +29,7 @@ graph "quad" {
         dut2 [
 	    label="{ <e1> e1 | <e2> e2 | <e3> e3 } | dut2 | { <e4> e4 | <e5> e5 | <e6> e6  | <e7> e7 | <e8> e8}",
 	    pos="10,12!",
-	    kind="infix",
+	    provides="infix",
 	    qn_console=9002,
 	    qn_mem="384M",
 	    qn_usb="dut2.usb"
@@ -37,7 +37,7 @@ graph "quad" {
 	dut3 [
 	    label="{ <e1> e1 | <e2> e2 | <e3> e3 } | dut2 | { <e4> e4 | <e5> e5 | <e6> e6  | <e7> e7 | <e8> e8}",
 	    pos="10,12!",
-	    kind="infix",
+	    provides="infix",
 	    qn_console=9003,
 	    qn_mem="384M",
 	    qn_usb="dut3.usb"
@@ -46,31 +46,31 @@ graph "quad" {
 	dut4 [
 	    label="{ <e1> e1 | <e2> e2 | <e3> e3 } | dut2 | { <e4> e4 | <e5> e5 | <e6> e6  | <e7> e7 | <e8> e8}",
 	    pos="10,12!",
-	    kind="infix",
+	    provides="infix",
 	    qn_console=9004,
 	    qn_mem="384M",
 	    qn_usb="dut4.usb"
 	];
 
-	host:d1a -- dut1:e1 [kind=mgmt]
-	host:d1b -- dut1:e2
-	host:d1c -- dut1:e3
-	host:d1d -- dut1:e4
+	host:d1a -- dut1:e1 [provides="mgmt"]
+	host:d1b -- dut1:e2 [provides="ieee-mc"]
+	host:d1c -- dut1:e3 [provides="ieee-mc"]
+	host:d1d -- dut1:e4 [provides="ieee-mc"]
 
-	host:d2a -- dut2:e1 [kind=mgmt]
-	host:d2b -- dut2:e2
-	host:d2c -- dut2:e3
-	host:d2d -- dut2:e4
+	host:d2a -- dut2:e1 [provides="mgmt"]
+	host:d2b -- dut2:e2 [provides="ieee-mc"]
+	host:d2c -- dut2:e3 [provides="ieee-mc"]
+	host:d2d -- dut2:e4 [provides="ieee-mc"]
 
-	host:d3a -- dut3:e1 [kind=mgmt]
-	host:d3b -- dut3:e2
-	host:d3c -- dut3:e3
-	host:d3d -- dut3:e4
+	host:d3a -- dut3:e1 [provides="mgmt"]
+	host:d3b -- dut3:e2 [provides="ieee-mc"]
+	host:d3c -- dut3:e3 [provides="ieee-mc"]
+	host:d3d -- dut3:e4 [provides="ieee-mc"]
 
-	host:d4a -- dut4:e1 [kind=mgmt]
-	host:d4b -- dut4:e2
-	host:d4c -- dut4:e3
-	host:d4d -- dut4:e4
+	host:d4a -- dut4:e1 [provides="mgmt"]
+	host:d4b -- dut4:e2 [provides="ieee-mc"]
+	host:d4c -- dut4:e3 [provides="ieee-mc"]
+	host:d4d -- dut4:e4 [provides="ieee-mc"]
 
 	# Ring
 	dut1:e5 -- dut2:e6


### PR DESCRIPTION
Implemented logic to check if the system supports required services. Logical edges with 'requires' fields are mapped only if physical edges provide corresponding services. If not, the test is skipped. This ensures that tests only run when the required services are available in the test system configuration.

Fixes #654

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
