### PR TITLE
Fix error when running 251+ reconfigurations (in test-mode)

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -24,6 +24,7 @@ All notable changes to the project are documented in this file.
 
 ### Fixes
 
+ - Fix #861: Fix error when running 251+ reconfigurations in test-mode
  - Minor cleanup of Networking Guide
 
 


### PR DESCRIPTION
The context was aquired but never released, this caused a lockup in sysrepo.

This fix #861

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
