### PR TITLE
Fix issue with storing authorized SSH key to startup

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -27,6 +27,7 @@ All notable changes to the project are documented in this file.
 ### Fixes
 
  - Fix #861: Fix error when running 251+ reconfigurations in test-mode
+ - Fix #777: Authorized SSH key not applied to startup config
  - Minor cleanup of Networking Guide
  - Fix memory leaks in confd
 

--- a/src/confd/src/ietf-system.c
+++ b/src/confd/src/ietf-system.c
@@ -1761,7 +1761,7 @@ int ietf_system_init(struct confd *confd)
 
 	os_init();
 
-	REGISTER_CHANGE(confd->session, "ietf-system", XPATH_AUTH_, SR_SUBSCR_UPDATE, change_auth, confd, &confd->sub);
+	REGISTER_CHANGE(confd->session, "ietf-system", XPATH_AUTH_, 0, change_auth, confd, &confd->sub);
 	REGISTER_OPER(confd->session, "ietf-system", PASSWORD_PATH, auth_cb, confd, 0, &confd->sub);
 	REGISTER_MONITOR(confd->session, "ietf-netconf-acm", "/ietf-netconf-acm:nacm//.",
 			 0, change_nacm, confd, &confd->sub);


### PR DESCRIPTION
The problem was that the sysrepo callback was never called, except on update (not availible on startup)

This fix #777

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
