### PR TITLE
Bump FRR to 9.1.3

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -23,6 +23,7 @@ All notable changes to the project are documented in this file.
  - Support for VXLAN tunnels
  - Add documentation on management via SSH, Web (RESTCONF, Web
    Console), and Console Port, issue #787
+ - Upgrade FRR from 9.1.2 to 9.1.3
 
 ### Fixes
 


### PR DESCRIPTION
This is a bugfix release, mostly regarding bgp, but was also some intresting fixes in zebra:
<pre>
Add missing new line for help string
Add missing proto translations
Correctly report metrics
Fix crash during reconnect
Fix snmp walk of zebra rib
Let's use memset instead of walking bytes and setting to 0
Separate zebra ZAPI server open and accept
Unlock node only after operation in zebra_free_rnh()
</pre>

Full changelog: https://github.com/FRRouting/frr/releases/tag/frr-9.1.3
## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
