### PR TITLE
Use fast pointer authentication emulation for aarch64

### DIFF
--- a/board/common/qemu/Config.in.in
+++ b/board/common/qemu/Config.in.in
@@ -66,7 +66,7 @@ endchoice
 
 config QEMU_MACHINE
 	string "Select emulated machine"
-	default "qemu-system-aarch64 -M virt,accel=kvm:tcg -cpu max" if QEMU_aarch64
+	default "qemu-system-aarch64 -M virt,accel=kvm:tcg -cpu max,pauth-impdef=on" if QEMU_aarch64
 	default "qemu-system-x86_64  -M pc,accel=kvm:tcg   -cpu max" if QEMU_x86_64
 	help
 	  You should not have to change this setting, although you may


### PR DESCRIPTION
## Description

Pointer authentication emulation is expensive.  By default, QEMU use the standard cryptographic algorithm (QARMA5), which is very time consuming.  This PR switches to the fast implementation.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [X] Other (please describe): `make run`
