### PR TITLE
Upgrade Finit to v4.10

### DIFF
--- a/package/finit/finit.hash
+++ b/package/finit/finit.hash
@@ -1,5 +1,5 @@
 # From https://github.com/troglobit/finit/releases/
-sha256  40c8db203cb59381973146f7157bde6886f05de06f18f1bd567c70ee780cbe3f  finit-4.10-rc2.tar.gz
+sha256  da14f5f05f595e15abc73bbacabfb55e8e1a4c40fc6ca6ab294be34ea437cc82  finit-4.10.tar.gz
 
 # Locally calculated
 sha256  2fd62c0fe6ea6d1861669f4c87bda83a0b5ceca64f4baa4d16dd078fbd218c14  LICENSE

--- a/package/finit/finit.mk
+++ b/package/finit/finit.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-FINIT_VERSION = 4.10-rc2
+FINIT_VERSION = 4.10
 FINIT_SITE = https://github.com/troglobit/finit/releases/download/$(FINIT_VERSION)
 FINIT_LICENSE = MIT
 FINIT_LICENSE_FILES = LICENSE


### PR DESCRIPTION
## Description

Final bump from 4.10-rc2 -> 4.10 GA.  For the full ChangeLog, see https://github.com/troglobit/finit/releases/tag/4.10

Only change between rc2 and the GA is https://github.com/troglobit/finit/commit/1691ebb2925b985356d3ba03c672990f2cd8a4a1 which goes with the latest changes to [sysklogd v2.7.1](https://github.com/troglobit/sysklogd/releases/tag/v2.7.1), which will hopefully make it to Buildroot 2025.02.0.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [X] Other (please describe): critical infrastructure
