### PR TITLE
test: fix image paths in test specifications (again)

### DIFF
--- a/test/case/ietf_interfaces/bridge_vlan/bridge_vlan.adoc
+++ b/test/case/ietf_interfaces/bridge_vlan/bridge_vlan.adoc
@@ -5,7 +5,7 @@ which in turn untags one VLAN outisde a non-VLAN filtering bridge.
 
 .Logical network setup
 ifdef::topdoc[]
-image::../../test/case/ietf_interfaces/bridge_vlan/bridge-vlan.svg[]
+image::{topdoc}../../test/case/ietf_interfaces/bridge_vlan/bridge-vlan.svg[]
 endif::topdoc[]
 ifndef::topdoc[]
 ifdef::testgroup[]

--- a/test/case/ietf_interfaces/lag_basic/lag_basic.adoc
+++ b/test/case/ietf_interfaces/lag_basic/lag_basic.adoc
@@ -5,7 +5,7 @@ modes during basic failure scenarios.
 
 .Internal network setup, PC verifies connectivity with dut2 via dut1
 ifdef::topdoc[]
-image::../../test/case/ietf_interfaces/lag_basic/lag-basic.svg[Internal networks]
+image::{topdoc}../../test/case/ietf_interfaces/lag_basic/lag-basic.svg[Internal networks]
 endif::topdoc[]
 ifndef::topdoc[]
 ifdef::testgroup[]

--- a/test/case/ietf_interfaces/lag_failure/lag_failure.adoc
+++ b/test/case/ietf_interfaces/lag_failure/lag_failure.adoc
@@ -5,7 +5,7 @@ links stop forwarding traffic, without carrier loss.
 
 .Logical network setup, link breakers (lb1 & lb2) here managed by host PC
 ifdef::topdoc[]
-image::../../test/case/ietf_interfaces/lag_failure/lag-failure.svg[]
+image::{topdoc}../../test/case/ietf_interfaces/lag_failure/lag-failure.svg[]
 endif::topdoc[]
 ifndef::topdoc[]
 ifdef::testgroup[]

--- a/test/case/infix_dhcp/server_subnets/server_subnets.adoc
+++ b/test/case/infix_dhcp/server_subnets/server_subnets.adoc
@@ -7,7 +7,7 @@ subnets.
 
 .Internal network setup, client2 and client3 are on the same LAN
 ifdef::topdoc[]
-image::../../test/case/infix_dhcp/server_subnets/dhcp-subnets.svg[Internal networks]
+image::{topdoc}../../test/case/infix_dhcp/server_subnets/dhcp-subnets.svg[Internal networks]
 endif::topdoc[]
 ifndef::topdoc[]
 ifdef::testgroup[]

--- a/test/case/use_case/ospf_container/ospf_container.adoc
+++ b/test/case/use_case/ospf_container/ospf_container.adoc
@@ -10,7 +10,7 @@ PC, which can act as a link breaker.
 .Use-case overview.
 [#img-overview]
 ifdef::topdoc[]
-image::../../test/case/use_case/ospf_container/overview.svg[]
+image::{topdoc}../../test/case/use_case/ospf_container/overview.svg[]
 endif::topdoc[]
 ifndef::topdoc[]
 ifdef::testgroup[]
@@ -51,7 +51,7 @@ second bridge, `br1`, only use IPv6 link-local addresses.
 .Internal network setup, here router R1 on subnet 10.1.1.1/24.
 [#img-setup]
 ifdef::topdoc[]
-image::../../test/case/use_case/ospf_container/internal-network.svg[Internal networks]
+image::{topdoc}../../test/case/use_case/ospf_container/internal-network.svg[Internal networks]
 endif::topdoc[]
 ifndef::topdoc[]
 ifdef::testgroup[]

--- a/test/spec/generate_spec.py
+++ b/test/spec/generate_spec.py
@@ -25,7 +25,7 @@ def replace_image_tag(text, test_dir):
         label = match.group("label")
 
         return f"""ifdef::topdoc[]
-image::../../{test_dir}/{image_name}[{label}]
+image::{{topdoc}}../../{test_dir}/{image_name}[{label}]
 endif::topdoc[]
 ifndef::topdoc[]
 ifdef::testgroup[]


### PR DESCRIPTION
{topdoc} is needed for asciidoctor to find the image during test report generation.

This is the same functional change as 02d8288863e2 but with the generation script actually updated. This was forgotten in the last commit.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
