### PR TITLE
test: pass 9pm project conf to test environment

### DIFF
--- a/test/env
+++ b/test/env
@@ -227,6 +227,7 @@ if [ "$containerize" ]; then
 	 --env INFAMY_ARGS="$INFAMY_ARGS" \
 	 --env INFAMY_EXTRA_ARGS="$INFAMY_EXTRA_ARGS" \
 	 --env PROMPT_DIRTRIM="$ixdir" \
+	 --env NINEPM_PROJ_CONFIG="$NINEPM_PROJ_CONFIG" \
 	 --env PS1="$(build_ps1)" \
 	 $extra_env \
 	 --expose 9001-9010 --publish-all \


### PR DESCRIPTION
Make the NINEPM_PROJ_CONFIG environment variable available for 9pm inside the test env.

## Description

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
