### PR TITLE
Run migrate script locally

### DIFF
--- a/src/confd/bin/migrate
+++ b/src/confd/bin/migrate
@@ -27,7 +27,7 @@ cleanup()
 note()
 {
     if [ -n "$quiet" ]; then
-       return
+        return
     fi
     logger -I $$ -k -p user.notice -t "$ident" "$1"
 }
@@ -46,11 +46,11 @@ atoi()
 file_version()
 {
     jq -r '
-        if .["infix-meta:meta"] | has("version") then
-            .["infix-meta:meta"]["version"]
-        else
-            "0.0"
-        end
+    if .["infix-meta:meta"] | has("version") then
+        .["infix-meta:meta"]["version"]
+    else
+        "0.0"
+    end
     ' "$1"
 }
 
@@ -58,16 +58,16 @@ file_version()
 confd_version()
 {
     find "$scripts" -mindepth 1 -maxdepth 1 -type d \
-	| sort -V | tail -n1 | xargs -n1 basename
-}
+        | sort -V | tail -n1 | xargs -n1 basename
+    }
 
 # Update meta data with the latest version
 meta_version()
 {
     if jq --arg version "$sys_version" '.["infix-meta:meta"] = {"infix-meta:version": $version}' "$2" \
-       > "${2}.tmp" && mv "${2}.tmp" "$2"; then
-	note "$1: configuration updated to version $sys_version."
-	return 0
+        > "${2}.tmp" && mv "${2}.tmp" "$2"; then
+            note "$1: configuration updated to version $sys_version."
+            return 0
     fi
 
     err "$1: failed updating configuration to version $sys_version!"
@@ -80,23 +80,23 @@ migrate()
     note "$1: migrating from version $cfg_version"
 
     for version_dir in $(find "$scripts" -mindepth 1 -maxdepth 1 -type d | sort -V); do
-	dir=$(basename "$version_dir")
-	version=$(atoi "$dir")
+        dir=$(basename "$version_dir")
+        version=$(atoi "$dir")
 
-	# Step by step upgrade file to latest version
-	if [ "$cfg_level" -lt "$version" ]; then
-	    note "Applying migrations for version $dir ..."
+    # Step by step upgrade file to latest version
+    if [ "$cfg_level" -lt "$version" ]; then
+        note "Applying migrations for version $dir ..."
 
-	    # Apply all scripts in the version directory in order
-	    for script in $(find "$version_dir" -type f -name '*.sh' | sort -V); do
-		note "$1: calling $script ..."
-		sh "$script" "$2"
-	    done
+        # Apply all scripts in the version directory in order
+        for script in $(find "$version_dir" -type f -name '*.sh' | sort -V); do
+            note "$1: calling $script ..."
+            sh "$script" "$2"
+        done
 
-	    # File now at $version ...
-	    cfg_level="$version"
-	fi
-    done
+        # File now at $version ...
+        cfg_level="$version"
+    fi
+done
 }
 
 # Try migrating a copy, then diff the files, for factory-config check
@@ -126,31 +126,31 @@ eval set -- "$OPTS"
 
 while [ -n "$1" ]; do
     case $1 in
-	-b)
-	    bak=$2
-	    shift
-	    ;;
-	-c)
-	    check=1
-	    ;;
-	-h)
-	    usage
-	    exit 0
-	    ;;
-	-i)
-	    inplace=1
-	    ;;
-	-q)
-	    quiet=1
-	    ;;
-	--)
-	    shift
-	    break
-	    ;;
-	*)
-	    # Likely file argument
-	    break
-	    ;;
+        -b)
+            bak=$2
+            shift
+            ;;
+        -c)
+            check=1
+            ;;
+        -h)
+            usage
+            exit 0
+            ;;
+        -i)
+            inplace=1
+            ;;
+        -q)
+            quiet=1
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            # Likely file argument
+            break
+            ;;
     esac
     shift
 done
@@ -190,22 +190,22 @@ if [ "$cfg_level" -eq "$sys_level" ]; then
     exit 0
 else
     if [ -n "$check" ]; then
-	# We may be called to check a file without meta:version (factory)
-	if [ "$cfg_version" = "0.0" ]; then
-	    if diff "$tmp"; then
-		# File is OK, despite lacking meta:version
-		exit 0
-	    fi
-	    msg="$orig: has syntax error, requires migrating."
-	else
-	    msg="$orig: version $cfg_version, requires migrating."
-	fi
-	if [ -t 0 ]; then
-	    echo "$msg"
-	else
-	    note "$msg"
-	fi
-	exit 1
+        # We may be called to check a file without meta:version (factory)
+        if [ "$cfg_version" = "0.0" ]; then
+            if diff "$tmp"; then
+                # File is OK, despite lacking meta:version
+                exit 0
+            fi
+            msg="$orig: has syntax error, requires migrating."
+        else
+            msg="$orig: version $cfg_version, requires migrating."
+        fi
+        if [ -t 0 ]; then
+            echo "$msg"
+        else
+            note "$msg"
+        fi
+        exit 1
     fi
 fi
 
@@ -214,10 +214,10 @@ if [ -n "$bak" ]; then
     ext="${bak##*.}"
     bak="${fil}-${cfg_version}.${ext}"
     if cp -p "$tmp" "$bak" 2>/dev/null; then
-	note "$orig: backup created: $bak"
+        note "$orig: backup created: $bak"
     else
-	err "$orig: failed creating backup: $bak"
-	exit 1
+        err "$orig: failed creating backup: $bak"
+        exit 1
     fi
 fi
 

--- a/src/confd/bin/migrate
+++ b/src/confd/bin/migrate
@@ -9,6 +9,7 @@ usage()
     echo
     echo "options:"
     echo "  -b FILE  Create backup FILE, appends detected version before .ext"
+    echo "  -e       Print all messages on stderr instead of syslog"
     echo "  -c       Check only, returns false when migration is not needed"
     echo "  -h       This help text"
     echo "  -i       Edit file in-place instead of sending to stdout, like sed"
@@ -30,12 +31,21 @@ note()
     if [ -n "$quiet" ]; then
         return
     fi
-    logger -I $$ -k -p user.notice -t "$ident" "$1"
+
+    if [ -n "$nolog" ]; then
+        echo "$1" >&2
+    else
+        logger -I $$ -k -p user.notice -t "$ident" "$1"
+    fi
 }
 
 err()
 {
-    logger -I $$ -k -p user.err -t "$ident" "$1"
+    if [ -n "$nolog" ]; then
+        echo "Error: $1" >&2
+    else
+        logger -I $$ -k -p user.err -t "$ident" "$1"
+    fi
 }
 
 # Convert human-readable version to integer level
@@ -122,7 +132,7 @@ chmod 600 "$tmp"
 
 trap cleanup INT HUP TERM EXIT
 
-OPTS=$(getopt -o b:chiqs: -- "$@")
+OPTS=$(getopt -o b:echiqs: -- "$@")
 eval set -- "$OPTS"
 
 while [ -n "$1" ]; do
@@ -130,6 +140,9 @@ while [ -n "$1" ]; do
         -b)
             bak=$2
             shift
+            ;;
+        -e)
+            nolog=1
             ;;
         -c)
             check=1

--- a/src/confd/bin/migrate
+++ b/src/confd/bin/migrate
@@ -13,6 +13,7 @@ usage()
     echo "  -h       This help text"
     echo "  -i       Edit file in-place instead of sending to stdout, like sed"
     echo "  -q       Quiet, skip normal log messages, only errors are logged"
+    echo "  -s PATH  Specify custom script path"
     echo
     echo "By default, this script reads a .cfg file on stdin, or as the first"
     echo "non-option argument, then migrates it to a new syntax on stdout."
@@ -121,7 +122,7 @@ chmod 600 "$tmp"
 
 trap cleanup INT HUP TERM EXIT
 
-OPTS=$(getopt -o b:chiq -- "$@")
+OPTS=$(getopt -o b:chiqs: -- "$@")
 eval set -- "$OPTS"
 
 while [ -n "$1" ]; do
@@ -142,6 +143,10 @@ while [ -n "$1" ]; do
             ;;
         -q)
             quiet=1
+            ;;
+        -s)
+            scripts=$2
+            shift
             ;;
         --)
             shift


### PR DESCRIPTION
## Description
Allows a user to run the migrate script off-target.

Example of running it locally:
`./migrate -e -s ../share/migrate/ ~/old-factory-config.cfg` 

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
