### PR TITLE
confd: remove prefix from version leaf in migrate

### DIFF
--- a/src/confd/bin/migrate
+++ b/src/confd/bin/migrate
@@ -75,7 +75,7 @@ confd_version()
 # Update meta data with the latest version
 meta_version()
 {
-    if jq --arg version "$sys_version" '.["infix-meta:meta"] = {"infix-meta:version": $version}' "$2" \
+    if jq --arg version "$sys_version" '.["infix-meta:meta"] = {"version": $version}' "$2" \
         > "${2}.tmp" && mv "${2}.tmp" "$2"; then
             note "$1: configuration updated to version $sys_version."
             return 0


### PR DESCRIPTION
## Description

The version migrate looks for is "version" in:
```
 "infix-meta:meta": {
    "version": "1.5"
  },
```

Prior to this patch migrate actually wrote:

```
 "infix-meta:meta": {
    "infix-meta:version": "1.5"
  },
```


<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
