### PR TITLE
statd: yanger: Do not fail if rauc or /run/system.json is not found

### DIFF
--- a/src/statd/python/yanger/ietf_hardware.py
+++ b/src/statd/python/yanger/ietf_hardware.py
@@ -78,13 +78,18 @@ def usb_port_components(systemjson):
 
 
 def operational():
-    systemjson = HOST.read_json("/run/system.json")
+    try:
+        systemjson = HOST.read_json("/run/system.json")
+        vpd_components(systemjson)
+        usb_port_components(systemjson)
+        components = vpd_component + usb_port_components + []
+
+    except:
+        components = []
 
     return {
         "ietf-hardware:hardware": {
             "component":
-            vpd_components(systemjson) +
-            usb_port_components(systemjson) +
-            [],
+            components
         },
     }

--- a/src/statd/python/yanger/ietf_system.py
+++ b/src/statd/python/yanger/ietf_system.py
@@ -171,19 +171,25 @@ def add_software(out):
     except subprocess.CalledProcessError:
         pass    # Maybe an upgrade i progress, then rauc does not respond
 
-    installer_status = HOST.run_json(["rauc-installation-status"])
-    installer = {}
-    if installer_status.get("operation"):
-        installer["operation"] = installer_status["operation"]
-    if "progress" in installer_status:
-        progress = {}
+    except FileNotFoundError:
+        pass
 
-        if installer_status["progress"].get("percentage"):
-            progress["percentage"] = int(installer_status["progress"]["percentage"])
-        if installer_status["progress"].get("message"):
-            progress["message"] = installer_status["progress"]["message"]
-        installer["progress"] = progress
-    software["installer"] = installer
+    installer = {}
+    try:
+        installer_status = HOST.run_json(["rauc-installation-status"])
+        if installer_status.get("operation"):
+            installer["operation"] = installer_status["operation"]
+        if "progress" in installer_status:
+            progress = {}
+
+            if installer_status["progress"].get("percentage"):
+                progress["percentage"] = int(installer_status["progress"]["percentage"])
+            if installer_status["progress"].get("message"):
+                progress["message"] = installer_status["progress"]["message"]
+            installer["progress"] = progress
+        software["installer"] = installer
+    except FileNotFoundError:
+        pass
 
     insert(out, "infix-system:software", software)
 


### PR DESCRIPTION
This to be able to run statd outside infix.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
