### PR TITLE
imx8mp-evk: Disable mqprio for eth1

### DIFF
--- a/board/common/rootfs/usr/libexec/infix/has-quirk
+++ b/board/common/rootfs/usr/libexec/infix/has-quirk
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [ $# -lt 2 ]; then
+        echo "usage: $0 <quirk-name> <ifname>"
+        exit 1
+fi
+quirk=$1
+ifname=$2
+if [ -f "/etc/product/interface-quirks.json" ]; then
+        echo "$(jq -r --arg iface "$ifname" --arg quirk "$quirk" '.[$iface][$quirk] // "false"' /etc/product/interface-quirks.json)"
+else
+        echo "false"
+fi

--- a/board/common/rootfs/usr/libexec/infix/init.d/25-mqprio
+++ b/board/common/rootfs/usr/libexec/infix/init.d/25-mqprio
@@ -43,6 +43,7 @@ while [ "$1" ]; do
     txqs="$2"
     shift 2
 
+    [ $(/usr/libexec/infix/has-quirk "broken-mqprio" "$iface") = "true" ] && echo "Skipping $iface, does not support mqprio" && continue
     [ $txqs -lt 2 ] && continue
     [ $txqs -gt 8 ] && txqs=8
 

--- a/src/board/freescale-imx8mp-evk/rootfs/usr/share/product/fsl,imx8mp-evk/etc/product/interface-quirks.json
+++ b/src/board/freescale-imx8mp-evk/rootfs/usr/share/product/fsl,imx8mp-evk/etc/product/interface-quirks.json
@@ -1,5 +1,8 @@
 {
     "eth0": {
 	"phy-detached-when-down": true
+    },
+    "eth1": {
+	"broken-mqprio": true
     }
 }


### PR DESCRIPTION
The kernel just hang, adding a quirk for it.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
