### PR TITLE
Restore missing CLI commands moved to show context

### DIFF
--- a/src/klish-plugin-infix/xml/infix.xml
+++ b/src/klish-plugin-infix/xml/infix.xml
@@ -492,6 +492,7 @@
   <COMMAND name="startup-config" help="Show startup-config">
     <ACTION sym="script" in="tty" out="tty" interrupt="true">jq -C . /cfg/startup-config.cfg |pager</ACTION>
   </COMMAND>
+</COMMAND>
 
   <COMMAND name="factory-reset" help="Restore the system to factory default state">
     <ACTION sym="script" in="tty" out="tty" interrupt="true">
@@ -586,8 +587,6 @@
       rauc install $force $KLISH_PARAM_URI
     </ACTION>
   </COMMAND>
-
-</COMMAND>
 </VIEW>
 
 <VIEW name="config">


### PR DESCRIPTION
Some CLI commands where inadvertently moved from the global CLI context into the show context.

For example the upgrade command.

As a result, commands like upgrade were unavailable at the top-level prompt:admin@ix-00-00-00:/> upgrade ?
Error: Command not found, or incomplete.

However, these commands remained accessible under the "show" context as a temporary workaround:

admin@ix-00-00-00:/> show upgrade ?
URI  [(ftp|tftp|http|https|ftp)://(dns.name | ip.address)/path/to/]upgrade-bundle.pkg

This patch restores the affected commands to the global CLI context so that commands like upgrade function as intended at the root prompt.

Fixes: 9c0a8e39 klish-plugin-infix: fix indentation in infix.xml

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
