### PR TITLE
Redesign CI to use workflow calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,12 @@ on:
         required: false
         default: true
         type: boolean
+      infix_repo:
+        description: 'Repo to checkout (for spin overrides)'
+        required: false
+        default: kernelkit/infix
+        type: string
+
 
   workflow_call:
     inputs:
@@ -26,9 +32,14 @@ on:
         required: false
         type: boolean
         default: true
+      infix_repo:
+        required: false
+        type: string
+        default: kernelkit/infix
 
 env:
   MINIMAL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.minimal || inputs.minimal }}
+  INFIX_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_repo || inputs.infix_repo }}
 
 
 jobs:
@@ -47,8 +58,11 @@ jobs:
           rm -rf ./.??* || true
           ls -la ./
 
-      - uses: actions/checkout@v4
+      - name: Checkout infix repo
+        uses: actions/checkout@v4
         with:
+          repository: ${{ env.INFIX_REPO }}
+          ref: ${{ github.ref }}
           clean: true
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: ''
         type: string
-      parallell:
+      parallel:
         description: 'Massive parallel build of each image'
         required: false
         default: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,15 @@ on:
       name:
         required: true
         type: string
+      minimal:
+        required: false
+        type: boolean
+        default: true
+
+env:
+  MINIMAL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.minimal || inputs.minimal }}
+
+
 jobs:
   build:
     name: Build ${{ inputs.name }} ${{ inputs.target }}
@@ -57,21 +66,13 @@ jobs:
                   "${{ github.event.number }}" "${{ github.event.pull_request.head.sha }}" \
                   | tee -a $GITHUB_OUTPUT $GITHUB_ENV
           fi
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-              if [ "${{ github.event.inputs.minimal }}" == "true" ]; then
-                  flavor="_minimal"
-              fi
-          else
-              # Ensure 'release' job get the proper image when building main
-              if [ "$GITHUB_REF_NAME" != "main" ]; then
-                  flavor="_minimal"
+
+          if [ "${MINIMAL}" == "true" ]; then
+              flavor="_minimal"
               else
-                  flavor=""
-              fi
-              if ${{ contains(github.event.pull_request.labels.*.name, 'ci:main') }}; then
-                  flavor=""
-              fi
+              flavor=""
           fi
+
           target=${{ inputs.target }}
           name=${{ inputs.name }}
           echo "dir=${name}-${target}"        >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Infix
+name: Build
 
 on:
   workflow_dispatch:
@@ -19,9 +19,12 @@ on:
       target:
         required: true
         type: string
+      name:
+        required: true
+        type: string
 jobs:
   build:
-    name: Build Infix ${{ inputs.target }}
+    name: Build ${{ inputs.name }} ${{ inputs.target }}
     runs-on: [ self-hosted, latest ]
     strategy:
       fail-fast: false
@@ -70,8 +73,9 @@ jobs:
               fi
           fi
           target=${{ inputs.target }}
-          echo "dir=infix-$target"        >> $GITHUB_OUTPUT
-          echo "tgz=infix-$target.tar.gz" >> $GITHUB_OUTPUT
+          name=${{ inputs.name }}
+          echo "dir=${name}-${target}"        >> $GITHUB_OUTPUT
+          echo "tgz=${name}-${target}.tar.gz" >> $GITHUB_OUTPUT
           echo "flv=$flavor"              >> $GITHUB_OUTPUT
           echo "Building target ${target}${flavor}_defconfig"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
-name: Bob the Builder
+name: Build Infix
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       minimal:
@@ -18,13 +13,17 @@ on:
         required: false
         default: true
         type: boolean
+
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
 jobs:
   build:
-    name: Build Infix ${{ matrix.target }}
+    name: Build Infix ${{ inputs.target }}
     runs-on: [ self-hosted, latest ]
     strategy:
-      matrix:
-        target: [aarch64, x86_64]
       fail-fast: false
     outputs:
       build_id: ${{ steps.vars.outputs.INFIX_BUILD_ID }}
@@ -70,7 +69,7 @@ jobs:
                   flavor=""
               fi
           fi
-          target=${{ matrix.target }}
+          target=${{ inputs.target }}
           echo "dir=infix-$target"        >> $GITHUB_OUTPUT
           echo "tgz=infix-$target.tar.gz" >> $GITHUB_OUTPUT
           echo "flv=$flavor"              >> $GITHUB_OUTPUT
@@ -88,16 +87,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache/
-          key: ccache-${{ matrix.target }}-${{ hashFiles('.git/modules/buildroot/HEAD', 'package/*/*.hash') }}
+          key: ccache-${{ inputs.target }}-${{ hashFiles('.git/modules/buildroot/HEAD', 'package/*/*.hash') }}
           restore-keys: |
-            ccache-${{ matrix.target }}-
+            ccache-${{ inputs.target }}-
             ccache-
 
-      - name: Configure ${{ matrix.target }}${{ steps.vars.outputs.flv }}
+      - name: Configure ${{ inputs.target }}${{ steps.vars.outputs.flv }}
         run: |
-          make ${{ matrix.target }}${{ steps.vars.outputs.flv }}_defconfig
+          make ${{ inputs.target }}${{ steps.vars.outputs.flv }}_defconfig
 
-      - name: Unit Test ${{ matrix.target }}
+      - name: Unit Test ${{ inputs.target }}
         run: |
           make test-unit
 
@@ -115,9 +114,9 @@ jobs:
           fi
           echo "MAKE=$MAKE" >> $GITHUB_OUTPUT
 
-      - name: Build ${{ matrix.target }}${{ steps.vars.outputs.flv }}
+      - name: Build ${{ inputs.target }}${{ steps.vars.outputs.flv }}
         run: |
-          echo "Building ${{ matrix.target }}${{ steps.vars.outputs.flv }}_defconfig ..."
+          echo "Building ${{ inputs.target }}${{ steps.vars.outputs.flv }}_defconfig ..."
           eval "${{ steps.parallel.outputs.MAKE }}"
 
       - name:  Check SBOM from Build
@@ -139,7 +138,7 @@ jobs:
           printf "Size of output/images/: "
           ls -l output/images/
 
-      - name: Prepare ${{ matrix.target }} Artifact
+      - name: Prepare ${{ inputs.target }} Artifact
         run: |
           cd output/
           mv images ${{ steps.vars.outputs.dir }}
@@ -149,111 +148,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: output/${{ steps.vars.outputs.tgz }}
-          name: artifact-${{ matrix.target }}
-
-  test:
-    name: Regression Test of Infix x86_64
-    needs: build
-    runs-on: [ self-hosted, regression ]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          clean: true
-          submodules: recursive
-
-      - name: Set Build Variables
-        id: vars
-        run: |
-          if [ -n "${{ needs.build.outputs.build_id }}" ]; then
-              echo "INFIX_BUILD_ID=${{ needs.build.outputs.build_id }}" \
-                   >>$GITHUB_ENV
-          fi
-
-          if [ "$GITHUB_REF_NAME" != "main" ]; then
-              flavor="_minimal"
-          else
-              flavor=""
-          fi
-          echo "flv=$flavor"              >> $GITHUB_OUTPUT
-
-      - name: Configure x86_64${{ steps.vars.outputs.flv }}
-        run: |
-          make x86_64${{ steps.vars.outputs.flv }}_defconfig
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: "artifact-*"
-          merge-multiple: true
-
-      - name: Restore x86-64${{ steps.vars.outputs.flv }} output/
-        run: |
-          ls -l
-          mkdir -p output
-          mv infix-x86_64.tar.gz output/
-          cd output/
-          tar xf infix-x86_64.tar.gz
-          ln -s infix-x86_64 images
-
-      - name: Regression Test x86_64${{ steps.vars.outputs.flv }}
-        run: |
-          make test
-
-      - name: Publish Test Result for x86_64${{ steps.vars.outputs.flv }}
-        # Ensure this runs even if Regression Test fails
-        if: always()
-        run: cat test/.log/last/result-gh.md >> $GITHUB_STEP_SUMMARY
-
-      - name: Generate Test Report for x86_64${{ steps.vars.outputs.flv }}
-        # Ensure this runs even if Regression Test fails
-        if: always()
-        run: |
-          asciidoctor-pdf \
-          --theme test/9pm/report/theme.yml \
-          -a pdf-fontsdir=test/9pm/report/fonts \
-          test/.log/last/report.adoc \
-          -o test/.log/last/report.pdf
-
-      - name: Upload Test Report as Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-report
-          path: test/.log/last/report.pdf
-
-  release:
-    if: ${{github.repository_owner == 'kernelkit' && github.ref_name == 'main'}}
-    name: Upload Latest Build
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: "artifact-*"
-          merge-multiple: true
-
-      - name: Create checksums ...
-        run: |
-          for file in *.tar.gz; do
-              sha256sum $file > $file.sha256
-          done
-
-      - uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          omitName: true
-          omitBody: true
-          omitBodyDuringUpdate: true
-          prerelease: true
-          tag: "latest"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "*.tar.gz*"
-
-      - name: Summary
-        run: |
-          cat <<EOF >> $GITHUB_STEP_SUMMARY
-          # Latest Build Complete! :rocket:
-
-          For the public download links of these build artifacts, please see:
-           <https://github.com/kernelkit/infix/releases/tag/latest>
-          EOF
+          name: artifact-${{ inputs.target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,11 @@ name: Build
 on:
   workflow_dispatch:
     inputs:
-      minimal:
-        description: 'Build minimal defconfigs'
+      flavor:
+        description: 'Optional build flavor (e.g. _minimal)'
         required: false
-        default: true
-        type: boolean
+        default: ''
+        type: string
       parallell:
         description: 'Massive parallel build of each image'
         required: false
@@ -28,19 +28,18 @@ on:
       name:
         required: true
         type: string
-      minimal:
+      flavor:
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: ''
       infix_repo:
         required: false
         type: string
         default: kernelkit/infix
 
 env:
-  MINIMAL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.minimal || inputs.minimal }}
+  FLV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.flavor || inputs.flavor }}
   INFIX_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_repo || inputs.infix_repo }}
-
 
 jobs:
   build:
@@ -81,18 +80,12 @@ jobs:
                   | tee -a $GITHUB_OUTPUT $GITHUB_ENV
           fi
 
-          if [ "${MINIMAL}" == "true" ]; then
-              flavor="_minimal"
-              else
-              flavor=""
-          fi
-
           target=${{ inputs.target }}
           name=${{ inputs.name }}
           echo "dir=${name}-${target}"        >> $GITHUB_OUTPUT
           echo "tgz=${name}-${target}.tar.gz" >> $GITHUB_OUTPUT
-          echo "flv=$flavor"              >> $GITHUB_OUTPUT
-          echo "Building target ${target}${flavor}_defconfig"
+          echo "flv=$FLV"              >> $GITHUB_OUTPUT
+          echo "Building target ${target}${FLV}_defconfig"
 
       - name: Restore Cache of dl/
         uses: actions/cache@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish latest Infix
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  publish:
+    name: Upload Latest Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "artifact-*"
+          merge-multiple: true
+
+      - name: Create checksums ...
+        run: |
+          for file in *.tar.gz; do
+              sha256sum $file > $file.sha256
+          done
+
+      - uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          omitName: true
+          omitBody: true
+          omitBodyDuringUpdate: true
+          prerelease: true
+          tag: "latest"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "*.tar.gz*"
+
+      - name: Summary
+        run: |
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          # Latest Build Complete! :rocket:
+
+          For the public download links of these build artifacts, please see:
+           <https://github.com/kernelkit/infix/releases/tag/latest>
+          EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,15 @@ on:
         required: false
         type: string
         default: kernelkit/infix
+      ninepm-conf:
+        required: false
+        type: string
+        default: ''
 
 env:
   FLV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.flavor || inputs.flavor }}
   INFIX_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_repo || inputs.infix_repo }}
+  NINEPM_CONF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ninepm-conf || inputs.ninepm-conf }}
 
 jobs:
   test:
@@ -77,6 +82,10 @@ jobs:
 
       - name: Regression Test x86_64${{ steps.vars.outputs.flv }}
         run: |
+          if [ -n "$NINEPM_CONF" ]; then
+            export NINEPM_PROJ_CONFIG="${GITHUB_WORKSPACE}/$NINEPM_CONF"
+            echo "DEBUG: NINEPM_PROJ_CONFIG is '$NINEPM_PROJ_CONFIG'"
+          fi
           make test
 
       - name: Publish Test Result for x86_64${{ steps.vars.outputs.flv }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,16 @@ on:
         required: false
         type: string
         default: ''
+      test-path:
+        required: false
+        type: string
+        default: 'test'
 
 env:
   FLV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.flavor || inputs.flavor }}
   INFIX_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_repo || inputs.infix_repo }}
   NINEPM_CONF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ninepm-conf || inputs.ninepm-conf }}
+  TEST_PATH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test-path || inputs.test-path }}
 
 jobs:
   test:
@@ -91,21 +96,21 @@ jobs:
       - name: Publish Test Result for x86_64${{ steps.vars.outputs.flv }}
         # Ensure this runs even if Regression Test fails
         if: always()
-        run: cat test/.log/last/result-gh.md >> $GITHUB_STEP_SUMMARY
+        run: cat $TEST_PATH/.log/last/result-gh.md >> $GITHUB_STEP_SUMMARY
 
       - name: Generate Test Report for x86_64${{ steps.vars.outputs.flv }}
         # Ensure this runs even if Regression Test fails
         if: always()
         run: |
           asciidoctor-pdf \
-          --theme test/9pm/report/theme.yml \
-          -a pdf-fontsdir=test/9pm/report/fonts \
-          test/.log/last/report.adoc \
-          -o test/.log/last/report.pdf
+          --theme $TEST_PATH/9pm/report/theme.yml \
+          -a pdf-fontsdir=$TEST_PATH/9pm/report/fonts \
+          $TEST_PATH/.log/last/report.adoc \
+          -o $TEST_PATH/.log/last/report.pdf
 
       - name: Upload Test Report as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: test-report
-          path: test/.log/last/report.pdf
+          path: ${{ env.TEST_PATH }}/.log/last/report.pdf
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,20 +2,46 @@ name: Test Infix
 
 on:
   workflow_dispatch:
+    inputs:
+      infix_repo:
+        description: 'Repo to checkout (for spin overrides)'
+        required: false
+        default: kernelkit/infix
+        type: string
+
   workflow_call:
     inputs:
       target:
         required: true
         type: string
+      name:
+        required: true
+        type: string
+      flavor:
+        required: false
+        type: string
+        default: ''
+      infix_repo:
+        required: false
+        type: string
+        default: kernelkit/infix
+
+env:
+  FLV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.flavor || inputs.flavor }}
+  INFIX_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_repo || inputs.infix_repo }}
 
 jobs:
   test:
-    name: Regression Test of Infix x86_64
+    name: Regression Test ${{ inputs.name }} ${{ inputs.target }}
     runs-on: [ self-hosted, regression ]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout infix repo
+        uses: actions/checkout@v4
         with:
+          repository: ${{ env.INFIX_REPO }}
+          ref: ${{ github.ref }}
           clean: true
+          fetch-depth: 0
           submodules: recursive
 
       - name: Set Build Variables
@@ -26,16 +52,11 @@ jobs:
                    >>$GITHUB_ENV
           fi
 
-          if [ "$GITHUB_REF_NAME" != "main" ]; then
-              flavor="_minimal"
-          else
-              flavor=""
-          fi
-          echo "flv=$flavor"              >> $GITHUB_OUTPUT
+          echo "flv=$FLV" >> $GITHUB_OUTPUT
 
-      - name: Configure x86_64${{ steps.vars.outputs.flv }}
+      - name: Configure ${{ inputs.target }}${{ steps.vars.outputs.flv }}
         run: |
-          make x86_64${{ steps.vars.outputs.flv }}_defconfig
+          make ${{ inputs.target }}${{ steps.vars.outputs.flv }}_defconfig
 
       - uses: actions/download-artifact@v4
         with:
@@ -44,12 +65,15 @@ jobs:
 
       - name: Restore x86-64${{ steps.vars.outputs.flv }} output/
         run: |
+          target=${{ inputs.target }}
+          name=${{ inputs.name }}
+
           ls -l
           mkdir -p output
-          mv infix-x86_64.tar.gz output/
+          mv ${name}-${target}.tar.gz output/
           cd output/
-          tar xf infix-x86_64.tar.gz
-          ln -s infix-x86_64 images
+          tar xf ${name}-${target}.tar.gz
+          ln -s ${name}-${target} images
 
       - name: Regression Test x86_64${{ steps.vars.outputs.flv }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,78 @@
+name: Test Infix
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Regression Test of Infix x86_64
+    runs-on: [ self-hosted, regression ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          clean: true
+          submodules: recursive
+
+      - name: Set Build Variables
+        id: vars
+        run: |
+          if [ -n "${{ needs.build.outputs.build_id }}" ]; then
+              echo "INFIX_BUILD_ID=${{ needs.build.outputs.build_id }}" \
+                   >>$GITHUB_ENV
+          fi
+
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+              flavor="_minimal"
+          else
+              flavor=""
+          fi
+          echo "flv=$flavor"              >> $GITHUB_OUTPUT
+
+      - name: Configure x86_64${{ steps.vars.outputs.flv }}
+        run: |
+          make x86_64${{ steps.vars.outputs.flv }}_defconfig
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "artifact-*"
+          merge-multiple: true
+
+      - name: Restore x86-64${{ steps.vars.outputs.flv }} output/
+        run: |
+          ls -l
+          mkdir -p output
+          mv infix-x86_64.tar.gz output/
+          cd output/
+          tar xf infix-x86_64.tar.gz
+          ln -s infix-x86_64 images
+
+      - name: Regression Test x86_64${{ steps.vars.outputs.flv }}
+        run: |
+          make test
+
+      - name: Publish Test Result for x86_64${{ steps.vars.outputs.flv }}
+        # Ensure this runs even if Regression Test fails
+        if: always()
+        run: cat test/.log/last/result-gh.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Generate Test Report for x86_64${{ steps.vars.outputs.flv }}
+        # Ensure this runs even if Regression Test fails
+        if: always()
+        run: |
+          asciidoctor-pdf \
+          --theme test/9pm/report/theme.yml \
+          -a pdf-fontsdir=test/9pm/report/fonts \
+          test/.log/last/report.adoc \
+          -o test/.log/last/report.pdf
+
+      - name: Upload Test Report as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: test/.log/last/report.pdf
+

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       target: "x86_64"
+      name: "infix"
 
   test-publish-x86_64:
     needs: test-run-x86_64

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -13,22 +13,22 @@ jobs:
   build-x86_64:
     uses: ./.github/workflows/build.yml
     with:
-      target: x86_64 
-      name: infix
-      flavor: _minimal
+      target: "x86_64"
+      name: "infix"
+      flavor: "_minimal"
 
   build-aarch64:
     uses: ./.github/workflows/build.yml
     with:
-      target: aarch64 
-      name: infix
-      flavor: _minimal
+      target: "aarch64"
+      name: "infix"
+      flavor: "_minimal"
 
   test-run-x86_64:
     needs: build-x86_64
     uses: ./.github/workflows/test.yml
     with:
-      target: x86_64 
+      target: "x86_64"
 
   test-publish-x86_64:
     needs: test-run-x86_64

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -15,12 +15,14 @@ jobs:
     with:
       target: x86_64 
       name: infix
+      flavor: _minimal
 
   build-aarch64:
     uses: ./.github/workflows/build.yml
     with:
       target: aarch64 
       name: infix
+      flavor: _minimal
 
   test-run-x86_64:
     needs: build-x86_64

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,32 @@
+name: Self Trigger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  push:
+    branches:
+      - main
+      - ci-workflow-redesign
+  workflow_dispatch:
+
+jobs:
+  build-x86_64:
+    uses: ./.github/workflows/build.yml
+    with:
+      target: x86_64 
+
+  build-aarch64:
+    uses: ./.github/workflows/build.yml
+    with:
+      target: aarch64 
+
+  test-run-x86_64:
+    needs: build-x86_64
+    uses: ./.github/workflows/test.yml
+    with:
+      target: x86_64 
+
+  test-publish-x86_64:
+    needs: test-run-x86_64
+    uses: ./.github/workflows/publish.yml
+

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -14,11 +14,13 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       target: x86_64 
+      name: infix
 
   build-aarch64:
     uses: ./.github/workflows/build.yml
     with:
       target: aarch64 
+      name: infix
 
   test-run-x86_64:
     needs: build-x86_64


### PR DESCRIPTION
## Description

This PR redesigns the existing github build and test workflow to support workflow calls.

Main changes:
* Add workflow calls.
* Split build.yml into build.yml and test.yml.
* Add a self trigger to run build and test on push and PR.
* Increase parameterisation.

A Spin of Infix can now use workflow calls to run Infix build and test directly. This means an Infix Spin doesn't have to duplicate or create there own github workflow for building and testing.
Here's an example of how that might look  (pseudo):
```
name: Infix SpinX CI

on:
  pull_request:
    types: [opened, synchronize, reopened, labeled]
...
jobs:
  build-infix-x86_64:
    uses: kernelkit/infix/.github/workflows/build.yml@main
    with:
      name: "Infix-SpinX"
      target: "x86_64"
      infix_repo: "kernelkit/infix"

  test-infix-x86_64:
    needs: build-infix-x86_64
    uses: kernelkit/infix/.github/workflows/test.yml@main
    with:
      name: "Infix-SpinX"
      target: "x86_64"
      infix_repo: "kernelkit/infix"
      ninepm-conf: "test/9pm-proj.yaml"
      test-path: "infix/test"

  publish-infix:
    needs: test-infix-x86_64
    uses: kernelkit/infix/.github/workflows/publish.yml@main
    
   ```
  

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
