### PR TITLE
Fix dependabot moderate CVE warning in Infamy container

### DIFF
--- a/test/.env
+++ b/test/.env
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034,SC2154
 
 # Current container image
-INFIX_TEST=ghcr.io/kernelkit/infix-test:2.3
+INFIX_TEST=ghcr.io/kernelkit/infix-test:2.4
 
 ixdir=$(readlink -f "$testdir/..")
 logdir=$(readlink -f "$testdir/.log")

--- a/test/docker/pip-requirements.txt
+++ b/test/docker/pip-requirements.txt
@@ -5,5 +5,5 @@ networkx==3.1
 pydot==1.4.2
 pyyaml==6.0.1
 passlib==1.7.4
-requests==2.32.0
+requests~=2.32.4
 scapy==2.6.1


### PR DESCRIPTION
## Description

Fix dependabot CVE-2024-47081 Moderate severity warning in Infamy container.

| Dependency |  Version | Upgrade to |
|-----|--|--|
| requests  |    < 2.32.4 | ~> 2.32.4 |

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): infamy container image dep.
