### PR TITLE
Drop doc build on PR, only main and doc branch triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,12 +11,6 @@ on:
       - 'doc/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    paths:
-      - 'doc/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/docs.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

The new `docs.yml` workflow mistakenly triggered on any PR.  What we want, for now, is for it to only trigger on pushes to `main` and the `doc` branch.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): doc generator workflow
