### PR TITLE
containers: prune dangling images

### DIFF
--- a/board/common/rootfs/usr/sbin/container
+++ b/board/common/rootfs/usr/sbin/container
@@ -302,6 +302,9 @@ delete()
     log "$name: calling podman rm -vif ..."
     podman rm -vif "$name" >/dev/null 2>&1
     [ -n "$quiet" ] || log "Container $name has been removed."
+
+    cnt=$(podman image prune -f | wc -l)
+    log "Pruned $cnt image(s)"
 }
 
 waitfor()
@@ -757,6 +760,8 @@ case $cmd in
 	done
 
 	rm -f "$pidfile"
+	cnt=$(podman image prune -f | wc -l)
+	log "setup: pruned $cnt image(s)"
 	;;
     shell)
 	if [ -z "$name" ]; then

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -14,6 +14,8 @@ All notable changes to the project are documented in this file.
 
 
 ### Fixes
+- containers: prune dangling images to reclaim disk space (#1098)
+
 [v25.06.0][] - 2025-07-01
 -------------------------
 


### PR DESCRIPTION
## Description

Previously, upgrading Podman containers with the same tag left behind dangling images, causing overlay storage to grow and fill disk space.

This change ensures dangling images are cleaned up using podman image prune. The command is run without -a, so only unreferenced images are removed. This provides safe cleanup while preventing unnecessary overlay growth.

Fixes #1098

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
