### PR TITLE
Rauc integration fixes

### DIFF
--- a/board/aarch64/rootfs/etc/rauc/system.conf
+++ b/board/aarch64/rootfs/etc/rauc/system.conf
@@ -6,6 +6,12 @@ mountprefix=/var/lib/rauc/mnt
 bundle-formats=-plain
 max-bundle-download-size=1073741824
 
+[log.event-log]
+filename=/var/log/upgrade-json.log
+format=json-pretty
+max-size=1M
+max-files=5
+
 [keyring]
 directory=/etc/rauc/keys
 

--- a/board/common/rootfs/etc/finit.d/available/rauc.conf
+++ b/board/common/rootfs/etc/finit.d/available/rauc.conf
@@ -1,5 +1,5 @@
 set G_MESSAGES_DEBUG=nocolor
 service [2345] <service/dbus/running> \
-	env:-/etc/default/rauc log:prio:user.notice \
+	env:-/etc/default/rauc  \
 	rauc service $RAUC_ARGS -- Software update service
 

--- a/board/riscv64/rootfs/etc/rauc/system.conf
+++ b/board/riscv64/rootfs/etc/rauc/system.conf
@@ -6,6 +6,12 @@ mountprefix=/var/lib/rauc/mnt
 bundle-formats=-plain
 max-bundle-download-size=1073741824
 
+[log.event-log]
+filename=/var/log/upgrade-json.log
+format=json-pretty
+max-size=1M
+max-files=5
+
 [keyring]
 directory=/etc/rauc/keys
 

--- a/board/x86_64/rootfs/etc/rauc/system.conf
+++ b/board/x86_64/rootfs/etc/rauc/system.conf
@@ -7,6 +7,12 @@ mountprefix=/var/lib/rauc/mnt
 bundle-formats=-plain
 max-bundle-download-size=1073741824
 
+[log.event-log]
+filename=/var/log/upgrade-json.log
+format=json-pretty
+max-size=1M
+max-files=5
+
 [keyring]
 directory=/etc/rauc/keys
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -20,6 +20,7 @@ All notable changes to the project are documented in this file.
 - cli: new `terminal reset` and `terminal resize` convenience commands
 
 ### Fixes
+- Fix #1080: Error message in log from rauc, deprecated 'Install' D-Bus method
 - Fix #1100: Reduce DHCP client logging verbosity by 70% and include interface
   names in log messages for easier troubleshooting
 - Fix #1119: CLI UX regression, restore proper behavior for `no enabled` command

--- a/src/confd/src/infix-system-software.c
+++ b/src/confd/src/infix-system-software.c
@@ -31,6 +31,7 @@ static int infix_system_sw_install(sr_session_ctx_t *session, uint32_t sub_id,
 	sr_error_t srerr = SR_ERR_OK;
 	GError *raucerr = NULL;
 	RaucInstaller *rauc;
+	GVariant *args;
 
 	DEBUG("url:%s", url);
 
@@ -38,7 +39,10 @@ static int infix_system_sw_install(sr_session_ctx_t *session, uint32_t sub_id,
 	if (!rauc)
 		return SR_ERR_INTERNAL;
 
-	rauc_installer_call_install_sync(rauc, url, NULL, &raucerr);
+	/* Empty args dictionary for InstallBundle method, for now. */
+	args = g_variant_new("a{sv}", NULL);
+
+	rauc_installer_call_install_bundle_sync(rauc, url, args, NULL, &raucerr);
 	if (raucerr) {
 		sr_session_set_netconf_error(session, "application", "operation-failed",
 					     NULL, NULL, raucerr->message, 0);


### PR DESCRIPTION
## Description

 - #1080 
 - Two new optional arguments to `install-bundle` RPC
   - `verify-certificate` — weather to verify bundle certificate at install, default: `True`
   - `verify-compatible` — weather to verify if bundle is compatible, default: `True`
 - Drop redirect of rauc console events (ANSI color coded) in favor of dedicated JSON event log

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
