### PR TITLE
OSPF: skip interfaces without OSPF enabled

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -29,6 +29,7 @@ All notable changes to the project are documented in this file.
 - Fix #1155: `show ospf` commands regression
 - Fix #1150: `show-legacy` wrapper permissions
 - Fix #1161: error in log during boot about unsupported command
+- Fix #1169: Expected neighbors not shown in sysrepocfg
 - Fixes for unicode translation in log and pager outputs as well as `syslogd`
 
 [BPI-R3]: https://wiki.banana-pi.org/Banana_Pi_BPI-R3

--- a/src/statd/python/ospf_status/ospf_status.py
+++ b/src/statd/python/ospf_status/ospf_status.py
@@ -40,6 +40,11 @@ def main():
     for ifname, iface in interfaces["interfaces"].items():
         iface["name"] = ifname
         iface["neighbors"] = []
+
+        # Skip interfaces that don't have OSPF enabled or area configured
+        if not iface.get("ospfEnabled", False) or not iface.get("area"):
+            continue
+
         for area_id in ospf["areas"]:
             area_type=""
 


### PR DESCRIPTION
Fix a bug where systems with OSPF enabled on some, but not all, interfaces would cause the OSPF iterator to fail when accessing iface['area'], which was missing. This caused the ospf_status.py tool to return {}, resulting in empty OSPF data in sysrepo.

Fixes #1169 Expected neighbors not shown in sysrepocfg

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
