### PR TITLE
Only publish to latest release from main branch

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -70,5 +70,6 @@ jobs:
       name: "infix"
 
   test-publish-x86_64:
+    if: ${{ github.repository_owner == 'kernelkit' && github.ref_name == 'main' }}
     needs: test-run-x86_64
     uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
## Description

When building from a PR, potentially an older maintenance branch, we should not upload the built artifacts to the `latest` tag.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [x] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): releng
