### PR TITLE
Fix Coverity Scan issues in copy command

### DIFF
--- a/src/bin/copy.c
+++ b/src/bin/copy.c
@@ -316,7 +316,7 @@ static int copy(const char *src, const char *dst, const char *remote_user)
 			else {
 				snprintf(adjust, sizeof(adjust), "/tmp/%s.cfg", srcds->name);
 				fn = tmpfn = adjust;
-				remove(tmpfn);
+				(void)remove(tmpfn);
 				rc = systemf("sysrepocfg -d %s -X%s -f json", srcds->sysrepocfg, fn);
 			}
 
@@ -378,7 +378,7 @@ static int copy(const char *src, const char *dst, const char *remote_user)
 			}
 			snprintf(adjust, sizeof(adjust), "/tmp/%s", fn);
 			fn = tmpfn = adjust;
-			remove(tmpfn);
+			(void)remove(tmpfn);
 		} else {
 			fn = cfg_adjust(src, NULL, adjust, sizeof(adjust), sanitize);
 			if (!fn) {

--- a/src/bin/util.c
+++ b/src/bin/util.c
@@ -128,7 +128,7 @@ char *cfg_adjust(const char *fn, const char *tmpl, char *buf, size_t len, int sa
 		}
 
 		/* If file exists, resolve symlinks and verify still in whitelist */
-		if (!access(fn, F_OK) && realpath(fn, resolved)) {
+		if (realpath(fn, resolved)) {
 			if (!path_allowed(resolved))
 				return NULL;
 			fn = resolved;


### PR DESCRIPTION
## Description

Address two issues identified by Coverity Scan:

1. CID 550484 (TOCTOU): Remove access() check before realpath()
   - realpath() already fails if file doesn't exist, making the access() check redundant and introducing a TOCTOU race
   - Simplifies code while improving security

2. CID 550483 (CHECKED_RETURN): Mark unchecked remove() calls
   - Add (void) cast to two remove() calls to explicitly indicate we don't care about the return value
   - These are cleanup operations for temp files where failure is acceptable, even expected

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
