### PR TITLE
test: imfamy: Allow broken images

### DIFF
--- a/test/infamy/netutil.py
+++ b/test/infamy/netutil.py
@@ -1,11 +1,8 @@
 import socket
 
-def tcp_port_is_open(host, port):
+def tcp_port_is_open(host, port, timeout=3):
     try:
-        ai = socket.getaddrinfo(host, port, 0, 0, socket.SOL_TCP)
-        sock = socket.socket(ai[0][0], ai[0][1], 0)
-        sock.connect(ai[0][4])
-        sock.close()
-        return True
-    except Exception:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except (socket.timeout, OSError):
         return False


### PR DESCRIPTION
If ping succeed but fail to check if netconf port is open, the testsystem will hang forever.

This will allow totally broken images to be loaded at the device.

The timeout can possibly be lower, but this should never fail. Before this check there is a
check for connectivity (ping)
## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
