### PR TITLE
rpi-4: Remove product specific gen-interfaces file

### DIFF
--- a/board/aarch64/raspberrypi-rpi64/rootfs/usr/share/product/raspberrypi,4-model-b/usr/libexec/confd/product/gen-interfaces
+++ b/board/aarch64/raspberrypi-rpi64/rootfs/usr/share/product/raspberrypi,4-model-b/usr/libexec/confd/product/gen-interfaces
@@ -1,6 +1,0 @@
-cat <<EOF
-   {
-        "name": "wifi0",
-        "type": "infix-if-type:wifi",
-   }
-EOF


### PR DESCRIPTION
This could not have worked, it is a read-only filesystem and it should not be there since rpi-4 has it's own factory-config.
This fix #1191

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
