### PR TITLE
Fix Coverity Scan build target

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Build applications for Coverity
         run: |
           export PATH=`pwd`/coverity/bin:$PATH
-          cov-build --dir cov-int make coverity-build
+          cov-build --dir cov-int make coverity
 
       - name: Submit results to Coverity Scan
         env:

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ bmake   = $(MAKE) -C buildroot O=$(O) $1
 all: $(config) buildroot/Makefile
 	@+$(call bmake,$@)
 
-check dep:
-	@echo "Starting local check, stage $@ ..."
+check dep coverity:
 	@make -C src $@
 
 $(config):
@@ -40,4 +39,4 @@ test:
 buildroot/Makefile:
 	@git submodule update --init
 
-.PHONY: all check test
+.PHONY: all check coverity dep test

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,117 +1,58 @@
 # Host build of critical components, for static analysis
 #
 # Available targets:
-#   build        - Build all components (no static analysis)
-#   check        - Run static analysis (auto-detects scan-build or cppcheck)
-#   scan-build   - Run clang static analyzer (preferred)
-#   cppcheck     - Run cppcheck static analyzer (fallback)
-#   coverity     - Show Coverity Scan usage
-#   coverity-build - Build for Coverity Scan (used by CI)
-#   dep          - Build dependencies only
+#   build          - Build all components (no static analysis)
+#   check          - Run static analysis (auto-detects scan-build or cppcheck)
+#   coverity       - Build for Coverity Scan (used by CI)
+#   dep            - Build dependencies only
 #
-APPS = bin confd factory keyack statd
-
-# Detect available static analysis tools
+# Installation (for 'make check'):
+#   scan-build (recommended):
+#     Debian/Ubuntu: sudo apt-get install clang-tools
+#     Fedora/RHEL:   sudo dnf install clang-tools-extra
+#     Alpine:        sudo apk add clang-extra-tools
+#
+#   cppcheck (fallback):
+#     Debian/Ubuntu: sudo apt-get install cppcheck
+#     Fedora/RHEL:   sudo dnf install cppcheck
+#
+APPS            = bin confd factory keyack statd
 HAVE_SCANBUILD := $(shell command -v scan-build 2>/dev/null)
 HAVE_CPPCHECK  := $(shell command -v cppcheck 2>/dev/null)
 
-.PHONY: all
 all:
-	@echo "*** all not supported, only build/check/coverity possible ***"
+	@echo "Target 'all' not supported, use build/check/coverity instead"
 	@false
 
-.PHONY: dep
 dep:
 	(cd libsrx && make -f check.mk dep)
 
-# Main build target (renamed from check)
-.PHONY: build
 build: dep $(APPS)
 	rm -rf staging
 
 $(APPS): libsrx
 	(cd $@ && make -f check.mk)
 
-.PHONY: libsrx
 libsrx:
 	(cd $@ && make -f check.mk)
 
-# Static analysis target - auto-detects scan-build or cppcheck
-.PHONY: check
-check:
+# Static analysis - auto-detects scan-build or cppcheck
+check: dep
 ifdef HAVE_SCANBUILD
-	@echo "==> Running scan-build (clang static analyzer)"
-	$(MAKE) scan-build
-else ifdef HAVE_CPPCHECK
-	@echo "==> Running cppcheck (fallback - scan-build not found)"
-	@echo "    For better analysis, install scan-build:"
-	@echo "      Debian/Ubuntu: apt-get install clang-tools"
-	@echo "      Fedora/RHEL:   dnf install clang-tools-extra"
-	@echo ""
-	$(MAKE) cppcheck
-else
-	@echo "*** ERROR: No static analysis tool found ***"
-	@echo ""
-	@echo "Please install scan-build (recommended) or cppcheck:"
-	@echo "  Debian/Ubuntu: sudo apt-get install clang-tools"
-	@echo "  Fedora/RHEL:   sudo dnf install clang-tools-extra"
-	@echo "  Alpine:        apk add clang-extra-tools"
-	@echo ""
-	@echo "Or install cppcheck as fallback:"
-	@echo "  Debian/Ubuntu: sudo apt-get install cppcheck"
-	@echo "  Fedora/RHEL:   sudo dnf install cppcheck"
-	@false
-endif
-
-# Clang static analyzer (preferred)
-.PHONY: scan-build
-scan-build: dep
-ifndef HAVE_SCANBUILD
-	@echo "*** ERROR: scan-build not found ***"
-	@echo ""
-	@echo "Install scan-build for better static analysis:"
-	@echo "  Debian/Ubuntu: sudo apt-get install clang-tools"
-	@echo "  Fedora/RHEL:   sudo dnf install clang-tools-extra"
-	@echo "  Alpine:        apk add clang-extra-tools"
-	@false
-endif
-	@echo "==> Running scan-build on all components"
 	@rm -rf scan-results
-	scan-build -o scan-results --status-bugs $(MAKE) _analyze
-	@echo "==> Scan complete. Results in scan-results/"
-
-# cppcheck static analyzer
-.PHONY: cppcheck
-cppcheck: dep
-ifndef HAVE_CPPCHECK
-	@echo "*** ERROR: cppcheck not found ***"
-	@echo ""
-	@echo "Install cppcheck:"
-	@echo "  Debian/Ubuntu: sudo apt-get install cppcheck"
-	@echo "  Fedora/RHEL:   sudo dnf install cppcheck"
-	@echo ""
-	@echo "Or use scan-build (recommended) instead:"
-	@echo "  Debian/Ubuntu: sudo apt-get install clang-tools"
+	@scan-build -o scan-results --status-bugs $(MAKE) build
+	@echo "Scan complete. Results in scan-results/"
+else ifdef HAVE_CPPCHECK
+	@for app in libsrx $(APPS); do							\
+		(cd $$app && cppcheck --enable=all --suppress=missingIncludeSystem	\
+			--quiet --template=gcc -I../staging/include . 2>&1) || true;	\
+	done
+else
+	@echo "Error: No static analysis tool found."
 	@false
 endif
-	@echo "==> Running cppcheck on all components"
-	@for app in libsrx $(APPS); do \
-		echo "  -> Checking $$app"; \
-		(cd $$app && cppcheck --enable=all --suppress=missingIncludeSystem \
-			--quiet --template=gcc -I../staging/include . 2>&1) || true; \
-	done
-	@echo "==> cppcheck complete"
 
-# Internal target for scan-build to analyze
-.PHONY: _analyze
-_analyze: libsrx $(APPS)
-	rm -rf staging
+# Coverity Scan (for CI)
+coverity: build
 
-# Coverity Scan target (for CI)
-.PHONY: coverity
-coverity:
-	@echo "==> Building for Coverity Scan"
-	@echo "Use: cov-build --dir cov-int make coverity-build"
-
-.PHONY: coverity-build
-coverity-build: build
+.PHONY: all dep build libsrx check coverity


### PR DESCRIPTION
## Description

Unb0rk regression from #1271, commit c34c8db4, and simplify `src/Makfile` for readability.

Reference: <https://github.com/kernelkit/infix/actions/runs/19588417931/job/56101973331>

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): static code analysis
