### PR TITLE
Add top level makefile target to build cyclonedx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ $(config):
 legal-info: | buildroot/Makefile
 	$(call bmake,legal-info LINUX_LICENSE_FILES=COPYING)
 
+cyclonedx: | buildroot/Makefile
+	@echo "Generating package information..."
+	@$(MAKE) --no-print-directory -C buildroot O=$(O) show-info | ./buildroot/utils/generate-cyclonedx > $(O)/cyclonedx-sbom.json
+	@echo "CycloneDX SBOM generated: $(O)/cyclonedx-sbom.json"
+
 # Workaround, see board/x86_64/board.mk
 test:
 	@+$(call bmake,$@)
@@ -39,4 +44,4 @@ test:
 buildroot/Makefile:
 	@git submodule update --init
 
-.PHONY: all check coverity dep test
+.PHONY: all check coverity dep test cyclonedx


### PR DESCRIPTION
## Description

Create a top level make target that builds a cyclonedx based on show-info from buildroot.
This file can be used by CVE trackers, such as Dependency Track.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [x] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
