### PR TITLE
CI: Add workflow customization for upstream callers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ on:
         description: 'Repo to checkout (for spin overrides)'
         default: kernelkit/infix
         type: string
+      infix_branch:
+        description: 'Branch/tag/commit to checkout (for spin overrides)'
+        default: ''
+        type: string
 
   workflow_call:
     inputs:
@@ -32,6 +36,11 @@ on:
         required: false
         type: string
         default: kernelkit/infix
+      infix_branch:
+        required: false
+        type: string
+        default: ''
+        description: 'Branch/tag/commit to checkout (for spin overrides). Defaults to github.ref if not specified'
       parallel:
         required: false
         type: boolean
@@ -50,6 +59,7 @@ env:
   NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.name || inputs.name }}
   TARGET: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target || inputs.target }}
   INFIX_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_repo || inputs.infix_repo }}
+  INFIX_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_branch || inputs.infix_branch }}
 
 jobs:
   build:
@@ -82,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.INFIX_REPO }}
-          ref: ${{ github.ref }}
+          ref: ${{ env.INFIX_BRANCH != '' && env.INFIX_BRANCH || github.ref }}
           clean: true
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: kernelkit/infix
         type: string
+      infix_branch:
+        description: 'Branch/tag/commit to checkout (for spin overrides)'
+        default: ''
+        type: string
 
   workflow_call:
     inputs:
@@ -21,6 +25,11 @@ on:
         required: false
         type: string
         default: kernelkit/infix
+      infix_branch:
+        required: false
+        type: string
+        default: ''
+        description: 'Branch/tag/commit to checkout (for spin overrides). Defaults to github.ref if not specified'
       ninepm-conf:
         required: false
         type: string
@@ -42,6 +51,7 @@ on:
 env:
   TARGET: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target || inputs.target }}
   INFIX_REPO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_repo || inputs.infix_repo }}
+  INFIX_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.infix_branch || inputs.infix_branch }}
   NINEPM_CONF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ninepm-conf || inputs.ninepm-conf }}
   TEST_PATH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test-path || inputs.test-path }}
 
@@ -64,7 +74,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.INFIX_REPO }}
-          ref: ${{ github.ref }}
+          ref: ${{ env.INFIX_BRANCH != '' && env.INFIX_BRANCH || github.ref }}
           clean: true
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
## Description
Enhances workflows to support customization by upstream callers (Spin):

- Add `branch` input parameter to allow specifying a custom branch for build and test workflows
- Add `pre-test-script` input parameter to enable running arbitrary setup code before tests execute
 
These changes enable upstream projects to better integrate with and customize the CI pipeline for their specific needs.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
