### PR TITLE
Skip CAN interfaces in operational data

### DIFF
--- a/src/statd/python/yanger/ietf_interfaces/link.py
+++ b/src/statd/python/yanger/ietf_interfaces/link.py
@@ -162,6 +162,10 @@ def interfaces(ifname=None):
         if iplink.get("group") == "internal":
             continue
 
+        link_type = iplink.get("link_type")
+        if link_type in ("can", "vcan"):
+            continue
+
         ipaddr = addrs.get(ifname, {})
 
         interfaces.append(interface(iplink, ipaddr))


### PR DESCRIPTION
## Description

Skip CAN interfaces that don't fit the IETF interface model.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
