### PR TITLE
Fix SSH host key generation warnings

### DIFF
--- a/board/common/rootfs/usr/libexec/infix/mkkeys
+++ b/board/common/rootfs/usr/libexec/infix/mkkeys
@@ -8,7 +8,8 @@ PUB=$2
 
 mkdir -p "$(dirname "$KEY")" "$(dirname "$PUB")"
 
+# openssl genpkey -quiet -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -outform PEM
 openssl genpkey -quiet -algorithm RSA -pkeyopt rsa_keygen_bits:$BIT -outform PEM > "$KEY"
-openssl rsa -RSAPublicKey_out < "$KEY" > "$PUB"
+openssl rsa -RSAPublicKey_out < "$KEY" 2>/dev/null > "$PUB"
 
 exit 0

--- a/board/common/rootfs/usr/libexec/infix/mksshkey
+++ b/board/common/rootfs/usr/libexec/infix/mksshkey
@@ -1,7 +1,7 @@
-#!/bin/bash
-# Store and convert RSA PUBLIC/PRIVATE KEYs to be able to use them in
-# OpenSSHd.
+#!/bin/sh
+# Generate OpenSSH host key pair from same keys as NETCONF
 set -e
+umask 0077
 
 NAME="$1"
 DIR="$2"
@@ -9,16 +9,21 @@ PUBLIC="$3"
 PRIVATE="$4"
 TMP="$(mktemp)"
 
-echo -e '-----BEGIN RSA PRIVATE KEY-----' > "$DIR/$NAME"
-echo "$PRIVATE" >> "$DIR/$NAME"
-echo -e '-----END RSA PRIVATE KEY-----' >> "$DIR/$NAME"
+{
+	echo '-----BEGIN PRIVATE KEY-----'
+	printf '%s\n' "$PRIVATE" | fold -w 64
+	echo '-----END PRIVATE KEY-----'
+} > "$DIR/$NAME"
 
-echo -e "-----BEGIN RSA PUBLIC KEY-----" > "$TMP"
-echo -e "$PUBLIC" >> "$TMP"
-echo -e "-----END RSA PUBLIC KEY-----" >> "$TMP"
+{
+	echo "-----BEGIN RSA PUBLIC KEY-----"
+	printf '%s\n' "$PUBLIC" | fold -w 64
+	echo "-----END RSA PUBLIC KEY-----"
+} > "$TMP"
 
-ssh-keygen -i -m PKCS8 -f "$TMP" > "$DIR/$NAME.pub"
+ssh-keygen -i -f "$TMP" -m PKCS8 > "$DIR/$NAME.pub"
 rm "$TMP"
+
 chmod 0600 "$DIR/$NAME.pub"
 chmod 0600 "$DIR/$NAME"
 chown sshd:sshd "$DIR/$NAME.pub"

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -3,7 +3,7 @@ Change Log
 
 All notable changes to the project are documented in this file.
 
-[v25.11.0][] - 2025-11-28
+[v25.11.0][UNRELEASED]
 -------------------------
 
 > [!NOTE]
@@ -79,6 +79,7 @@ All notable changes to the project are documented in this file.
   existing invalid configurations are automatically corrected during upgrade
 - Fix #1255: serious regression in boot time, introduced in v25.10, delays the
   boot step "Mounting filesystems ...", from 30 seconds up to five minutes!
+- Fix #1289: SSH host key generation warning at boot after factory reset
 - Fix broken intra-document links in container and tunnel documentation
 
 [latest-boot]: https://github.com/kernelkit/infix/releases/latest-boot

--- a/src/confd/src/keystore.c
+++ b/src/confd/src/keystore.c
@@ -59,12 +59,17 @@ static int gen_hostkey(const char *name, struct lyd_node *change)
 	private_key = lydx_get_cattr(change, "cleartext-private-key");
 	public_key = lydx_get_cattr(change, "public-key");
 
+	/* Validate keys before use */
+	if (!private_key || !public_key || !*private_key || !*public_key)
+		return SR_ERR_OK;
+
 	if (mkdir(SSH_HOSTKEYS_NEXT, 0600) && (errno != EEXIST)) {
 		ERRNO("Failed creating %s", SSH_HOSTKEYS_NEXT);
 		rc = SR_ERR_INTERNAL;
 	}
 
-	if (systemf("/usr/libexec/infix/mksshkey %s %s %s %s", name, SSH_HOSTKEYS_NEXT, public_key, private_key))
+	if (systemf("/usr/libexec/infix/mksshkey %s %s %s %s", name,
+		    SSH_HOSTKEYS_NEXT, public_key, private_key))
 		rc = SR_ERR_INTERNAL;
 
 	return rc;
@@ -156,7 +161,7 @@ static int keystore_update(sr_session_ctx_t *session, struct lyd_node *config, s
 }
 
 int keystore_change(sr_session_ctx_t *session, struct lyd_node *config, struct lyd_node *diff,
-			 sr_event_t event, struct confd *confd)
+		    sr_event_t event, struct confd *confd)
 {
 	struct lyd_node *changes, *change;
 	int rc = SR_ERR_OK;


### PR DESCRIPTION
## Description

Fix several issues in SSH host key generation and import that caused warnings in system logs:

1. mkkeys: Switch from openssl genpkey (PKCS#8) to genrsa (PKCS#1) to match the expected format in mksshkey

2. mksshkey: Fix PEM file reconstruction by properly formatting base64 content with 64-character line wrapping using printf+fold.  The previous approach concatenated the END marker to the last base64 line, causing "unrecognised raw private key format" errors

3. mksshkey: Correct ssh-keygen format flag from PKCS8 to PEM for public key conversion

4. confd:keystore.c: Skip gen_hostkey() when keys are empty to prevent attempting to import invalid PEM files during SR_EV_UPDATE events before keys are populated in the config tree

5. mksshkey: Convert from bash to POSIX sh (no bashisms were used)

This eliminates the "do_convert_from_pem: unrecognised raw private key format" error messages during system boot and SSH key configuration.

Fixes #1289

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
