### PR TITLE
statd: reduce log warning to debug

### DIFF
--- a/src/statd/python/yanger/infix_firewall.py
+++ b/src/statd/python/yanger/infix_firewall.py
@@ -19,7 +19,8 @@ def get_interface(interface="org.fedoraproject.FirewallD1"):
         return dbus.Interface(obj, dbus_interface=interface)
 
     except dbus.exceptions.DBusException as e:
-        common.LOG.warning("Failed to connect to firewalld D-Bus: %s", e)
+        # Firewall service may not be running, this is not an error
+        common.LOG.debug("Firewalld not available: %s", e)
         return None
 
 


### PR DESCRIPTION
## Description

This fixes the following log message on systems w/o firewall enabled dumping operational data:

Dec  2 09:24:57 test-00-02-00 yanger[5352]: Failed to connect to firewalld D-Bus: org.freedesktop.DBus.Error.ServiceUnknown: The name org.fedoraproject.FirewallD1 was not provided by any .service files

[skip ci]

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): logging adjustment
