### PR TITLE
Tune kernel memory settings

### DIFF
--- a/board/common/rootfs/etc/sysctl.d/vm.conf
+++ b/board/common/rootfs/etc/sysctl.d/vm.conf
@@ -1,0 +1,23 @@
+# Memory and OOM tuning for embedded network devices
+# Optimized for systems with 512MB-4GB RAM
+# Target: Fast and deterministic OOM behavior
+
+# OOM Behavior
+# Panic on OOM for fast system reset and recovery
+vm.panic_on_oom=1
+
+# Dirty Page Writeback
+# Limit dirty pages to 10% of RAM before blocking writers
+# Start background writeback at 5% to prevent accumulation
+vm.dirty_ratio=10
+vm.dirty_background_ratio=5
+
+# Writeback Timing
+# Expire dirty pages after 10 seconds (1000 centiseconds)
+# Ensures quick flushing on limited-memory systems
+vm.dirty_expire_centisecs=1000
+
+# Memory Watermarks
+# Increase distance between low/high watermarks for earlier reclaim
+# Maintains larger free memory buffer proactively (default: 10)
+vm.watermark_scale_factor=150

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -16,6 +16,8 @@ All notable changes to the project are documented in this file.
   production environments. See the documentation for usage examples
 - Add support for "routing interfaces", issue #647.  Lists interfaces with IP
   forwarding.  Inspect from CLI using `show interface`, look for `⇅` flag
+- Add memory tuning configuration for embedded network devices with aggressive
+  dirty page writeback and OOM panic for deterministic recovery
 
 ### Fixes
 

--- a/doc/system-tuning.md
+++ b/doc/system-tuning.md
@@ -1,0 +1,32 @@
+# System Tuning Guide
+
+## Memory
+
+Default memory tuning is defined in `/etc/sysctl.d/vm.conf`, optimized for embedded network devices with 512MB-4GB RAM.
+
+### For Systems with 4GB+ Memory
+
+Systems with more memory can afford to be less aggressive with cache reclaim.
+
+```conf
+# Allow more dirty pages before writeback
+vm.dirty_ratio=15
+vm.dirty_background_ratio=10
+
+# Less aggressive watermark (memory pressure less critical)
+vm.watermark_scale_factor=100
+```
+
+### For Systems with Heavy Filesystem Activity
+
+Unusual for network equipment, but may occur on systems with extensive logging or storage features.
+
+```conf
+# Allow more dirty pages for better write batching
+vm.dirty_ratio=20
+vm.dirty_background_ratio=10
+
+# Longer dirty page expiration for write coalescing
+vm.dirty_expire_centisecs=3000
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
       - Developing with Buildroot: override-package.md
       - Netboot HowTo: netboot.md
       - Regression Testing: testing.md
+      - System Tuning Guide: system-tuning.md
       - Test System Architecture: test-arch.md
       - Virtual Environments: virtual.md
       - Vital Product Data (VPD): vpd.md


### PR DESCRIPTION
## Description

Add vm.conf with sysctl parameters optimized for embedded network devices 512MB-8GB of memory.

Focus on fast recovery and determinism.
- Panic on OOM
- Aggressive dirty page writeback
- Increased watermark scale factor for proactive reclaim

Includes tuning guide documentation for alternative scenarios.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [x] ChangeLog updates (for next release)
  - [x] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [x] Documentation content changes
  - [x] ChangeLog updated (for major changes)
- [ ] Other (please describe):