### PR TITLE
qemu: fix /cfg mount failure due to missing mkfs.ext4 in PATH

### DIFF
--- a/board/common/qemu/run.sh
+++ b/board/common/qemu/run.sh
@@ -19,6 +19,9 @@
 #
 # shellcheck disable=SC3037
 
+# Add /sbin to PATH for mkfs.ext4 and such (not default in debian)
+export PATH="/sbin:/usr/sbin:$PATH"
+
 qdir=$(dirname "$(readlink -f "$0")")
 imgdir=$(readlink -f "${qdir}/..")
 prognm=$(basename "$0")
@@ -173,6 +176,8 @@ usb_args()
 rw_args()
 {
     [ "$CONFIG_QEMU_RW" ] ||  return
+
+    command -v mkfs.ext4 >/dev/null || die "$prognm: cannot find mkfs.ext4"
 
     if ! [ -f "aux.ext4" ]; then
 	dd if=/dev/zero of="aux.ext4" bs=1M count=1 >/dev/null 2>&1


### PR DESCRIPTION
## Description
The cfg.ext4 disk image was created but not formatted because mkfs.ext4 wasn't found. As sbin is not in PATH for an unprivileged user in Debian.

This caused the VM boot to fail with "No persistent storage found for /cfg".

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
