### PR TITLE
YANG: infix-routing: Fix YANG schema validation

### DIFF
--- a/src/confd/yang/confd/infix-routing.yang
+++ b/src/confd/yang/confd/infix-routing.yang
@@ -791,7 +791,7 @@ module infix-routing {
    */
   augment "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/"
         + "ospf:ospf/ospf:local-rib/ospf:route" {
-    when "derived-from-or-self(../../rt:type, 'infix-routing:ospfv2')" {
+    when "derived-from-or-self(../../../rt:type, 'infix-routing:ospfv2')" {
       description
         "This augmentation is only valid for OSPFv2.";
     }


### PR DESCRIPTION
Schema node "type" for parent "/ietf-routing:routing/control-plane-protocols/control-plane-protocol/ietf-ospf:ospf" not found;
  in expr "derived-from-or-self(../../rt:type"

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
