### PR TITLE
klish: Do not autocomplete nodes that do not pass a when expression

### DIFF
--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
@@ -1,3 +1,3 @@
 # Locally calculated
 sha256  9d9d33b873917ca5d0bdcc47a36d2fd385971ab0c045d1472fcadf95ee5bcf5b  LICENCE
-sha256  71802708c96521a8bf43e38d6e5ac36de5481e087eaabdbebbc282ec0e29b8d3  klish-plugin-sysrepo-0846fa6b8d5d665eebfc7b1664542646915a79f7-git4.tar.gz
+sha256  9f88c21f7c7e96558c9e2f3b485f6420259cea9548e26876cd9bc37f46664e5a  klish-plugin-sysrepo-d3751b91cb858ece9be138f0175502e43e3fdad1-git4.tar.gz

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KLISH_PLUGIN_SYSREPO_VERSION = 0846fa6b8d5d665eebfc7b1664542646915a79f7
+KLISH_PLUGIN_SYSREPO_VERSION = d3751b91cb858ece9be138f0175502e43e3fdad1
 KLISH_PLUGIN_SYSREPO_SITE = https://github.com/kernelkit/klish-plugin-sysrepo.git
 #KLISH_PLUGIN_SYSREPO_VERSION = cdd3eb51a7f7ee0ed5bd925fa636061d3b1b85fb
 #KLISH_PLUGIN_SYSREPO_SITE = https://src.libcode.org/pkun/klish-plugin-sysrepo.git


### PR DESCRIPTION
This is most noticeable in interface context

<pre>
admin@infix-00-00-00:/config/interface/e1/> set type wifi
admin@infix-00-00-00:/config/interface/e1/> set <kbd>Tab</kbd>
bind-ni-name         bridge-port   container-network custom-phys-address         
description          enabled       ethernet
</pre>

where you previously got **all** containers for all interface-types, now just `wifi` and `ethernet` (since it has configuration)

Big contributor for this: claude.ai ❤️

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
