### PR TITLE
klish: followup 8a638fa26 allow `when` expression to depend on defaults

### DIFF
--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.hash
@@ -1,3 +1,3 @@
 # Locally calculated
 sha256  9d9d33b873917ca5d0bdcc47a36d2fd385971ab0c045d1472fcadf95ee5bcf5b  LICENCE
-sha256  9f88c21f7c7e96558c9e2f3b485f6420259cea9548e26876cd9bc37f46664e5a  klish-plugin-sysrepo-d3751b91cb858ece9be138f0175502e43e3fdad1-git4.tar.gz
+sha256  db6317f2dbe68fea22e83b32fa1a7b05b13257f6e750233f3d40de2240ae191b  klish-plugin-sysrepo-a1156954447ac663409b143dc67da7c15cf649ff-git4.tar.gz

--- a/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
+++ b/package/klish-plugin-sysrepo/klish-plugin-sysrepo.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KLISH_PLUGIN_SYSREPO_VERSION = d3751b91cb858ece9be138f0175502e43e3fdad1
+KLISH_PLUGIN_SYSREPO_VERSION = a1156954447ac663409b143dc67da7c15cf649ff
 KLISH_PLUGIN_SYSREPO_SITE = https://github.com/kernelkit/klish-plugin-sysrepo.git
 #KLISH_PLUGIN_SYSREPO_VERSION = cdd3eb51a7f7ee0ed5bd925fa636061d3b1b85fb
 #KLISH_PLUGIN_SYSREPO_SITE = https://src.libcode.org/pkun/klish-plugin-sysrepo.git


### PR DESCRIPTION
If a when expssion depended on a default value it always got evaulated to false.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
