### PR TITLE
Add migration script for confd: prevent IP addresses on bridge ports

### DIFF
--- a/src/confd/share/migrate/1.6/40-bridge-port-remove-ip.sh
+++ b/src/confd/share/migrate/1.6/40-bridge-port-remove-ip.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Remove ietf-ip:ipv4 and ietf-ip:ipv6 from bridge port interfaces.
+# Bridge ports should not have IP addresses; the IP address should
+# be configured on the bridge interface itself.
+file=$1
+temp=${file}.tmp
+
+jq '
+if .["ietf-interfaces:interfaces"]?.interface then
+  .["ietf-interfaces:interfaces"].interface |= map(
+    if .["infix-interfaces:bridge-port"] and .type != "infix-if-type:bridge" then
+      del(.["ietf-ip:ipv4"], .["ietf-ip:ipv6"])
+    else
+      .
+    end
+  )
+else
+  .
+end
+' "$file" > "$temp" && mv "$temp" "$file"

--- a/src/confd/share/migrate/1.6/Makefile.am
+++ b/src/confd/share/migrate/1.6/Makefile.am
@@ -1,4 +1,5 @@
 migratedir          = $(pkgdatadir)/migrate/1.6
 dist_migrate_DATA   = 10-dhcp-client-to-ipv4.sh \
                       20-autoconf-to-presence.sh \
-                      30-ospf-backbone-area-type.sh
+                      30-ospf-backbone-area-type.sh \
+                      40-bridge-port-remove-ip.sh


### PR DESCRIPTION
Unfortunatly the fix was entered in 25.10, but confd was not stepped up until 25.11, so this should be for 25.10 but now it is for confd version 1.6 (infix 25.11), as close as we can get.

this is a follwup for commit 7e37fc49a3004982d16baa5cd414eded06515077

confd: prevent IP addresses on bridge ports

Bridge ports should not have IP addresses configured. The IP address should be configured on the bridge interface itself, not its member ports.

Add YANG must expression to enforce this rule at configuration time.

Fixes #1122

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
