### PR TITLE
Upgrade Buildroot to 2025.02.13 (LTS)

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -9,6 +9,7 @@ All notable changes to the project are documented in this file.
 ### Changes
 
 - Upgrade Linux kernel to 6.18.24 (LTS)
+- Upgrade Buildroot to 2025.02.13 (LTS)
 - Add support for [Banana Pi BPI-R4][BPI-R4], quad-core Cortex-A73 router with
   4x 2.5 GbE switching, dual 10 GbE SFP+.  Variants BPI-R4-2g5 and BPI-R4P have
   one SFP+ replaced by a 2.5 GbE RJ45, with optional PoE on the R4P

--- a/patches/gpsd/0001-Always-log-to-syslog.patch
+++ b/patches/gpsd/0001-Always-log-to-syslog.patch
@@ -1,23 +1,8 @@
-From 9ba3bc688c45a0c9e761c6c8bd0be83d6570c9dc Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Mattias=20Walstr=C3=B6m?= <lazzer@gmail.com>
-Date: Fri, 27 Feb 2026 16:58:12 +0100
-Subject: [PATCH] Always log to syslog
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
-Organization: Wires
-
-Signed-off-by: Mattias Walström <lazzer@gmail.com>
----
- gpsd/libgpsd_core.c | 13 ++-----------
- 1 file changed, 2 insertions(+), 11 deletions(-)
-
-diff --git a/gpsd/libgpsd_core.c b/gpsd/libgpsd_core.c
-index 982f822b8..c53c64838 100644
---- a/gpsd/libgpsd_core.c
-+++ b/gpsd/libgpsd_core.c
-@@ -180,17 +180,8 @@ static void gpsd_vlog(const int errlevel,
-     // this was crazy expensive, just fix the bad log calls
+diff -urN gpsd-3.25.orig/gpsd/libgpsd_core.c gpsd-3.25/gpsd/libgpsd_core.c
+--- gpsd-3.25.orig/gpsd/libgpsd_core.c	2023-01-10 23:38:26.000000000 +0100
++++ gpsd-3.25/gpsd/libgpsd_core.c	2026-04-22 14:06:09.498017456 +0200
+@@ -180,17 +180,8 @@
+     // this was carzy expensive, just fix the bad log calls
      // gps_visibilize(outbuf, outlen, buf, strlen(buf));
  
 -    if (getpid() == getsid(getpid())) {
@@ -36,6 +21,3 @@ index 982f822b8..c53c64838 100644
      gpsd_release_reporting_lock();
  #endif  // !SQUELCH_ENABLE
  }
--- 
-2.43.0
-


### PR DESCRIPTION
A lot of CVEs fixed.

Full changelog: https://github.com/buildroot/buildroot/blob/2025.02.x/CHANGES

Also revert gpsd upgrade, since buildroot has backported fixes, it is better to depend on them for continues CVE fixes.
## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [x] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe):
