### PR TITLE
test: avoid infamy0 race in CI by using random container names

### DIFF
--- a/test/env
+++ b/test/env
@@ -122,7 +122,7 @@ name()
     nm=infamy
     id=0
 
-    if [ -n "$random" ]; then
+    if [ -n "$random" ] || [ -n "$CI" ]; then
 	# Let podman/docker allocate random hostname and container name
 	return
     fi


### PR DESCRIPTION
## Description

Prior to this PR, two CI jobs that starts at the same time, could both get ID 0 and grab `infamy0`. This resulted in one crashing. This usually happened when there was much to test, typically during a release....

In this PR we use the CI variable that GitHub Actions sets. We treat it like -r so parallel jobs don't all try to claim "infamy0" and clobber each other.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
