### PR TITLE
Run regression tests as part of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,16 @@ jobs:
       version: ${{ needs.set-version.outputs.version }}
       use_cache: true
 
+  test:
+    needs: build
+    uses: ./.github/workflows/test.yml
+    with:
+      target: x86_64
+      name: infix
+
   release:
     name: Release Infix ${{ github.ref_name }}
-    needs: build
+    needs: [build, test]
     runs-on: [self-hosted, release]
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,10 +105,11 @@ jobs:
 
           ls -l
           mkdir -p output
-          mv ${name}-${target}.tar.gz output/
+          tarfile=$(ls ${name}-${target}*.tar.gz | head -1)
+          mv "$tarfile" output/
           cd output/
-          tar xf ${name}-${target}.tar.gz
-          ln -s ${name}-${target} images
+          tar xf "$tarfile"
+          ln -s "${tarfile%.tar.gz}" images
 
       - name: Regression Test ${{ env.TARGET }}
         run: |


### PR DESCRIPTION
## Description

Add an x86_64 regression test job to release.yml that runs after the build and gates publishing — the release job now requires both build and test to succeed.

Fixes #1392

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): releng
