### PR TITLE
Set INFIX_RELEASE when running release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,12 @@ jobs:
       use_cache: true
 
   test:
-    needs: build
+    needs: [build, set-version]
     uses: ./.github/workflows/test.yml
     with:
       target: x86_64
       name: infix
+      release: ${{ needs.set-version.outputs.version }}
 
   release:
     name: Release Infix ${{ github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,11 @@ on:
         type: string
         default: ''
         description: 'Optional script to run after checkout (for spin customization)'
+      release:
+        required: false
+        type: string
+        default: ''
+        description: 'Release version (e.g. v26.04.0), sets INFIX_RELEASE so make test finds versioned artifacts'
     secrets:
       CHECKOUT_TOKEN:
         required: false
@@ -112,6 +117,8 @@ jobs:
           ln -s "${tarfile%.tar.gz}" images
 
       - name: Regression Test ${{ env.TARGET }}
+        env:
+          INFIX_RELEASE: ${{ inputs.release }}
         run: |
           if [ -n "$NINEPM_CONF" ]; then
             export NINEPM_PROJ_CONFIG="${GITHUB_WORKSPACE}/$NINEPM_CONF"


### PR DESCRIPTION
## Description

Without INFIX_RELEASE, make test resolves INFIX_ARTIFACT to the unversioned infix-x86_64, but release builds produce versioned artifacts (infix-x86_64-v26.04.0-rc1.qcow2 etc.), causing the test environment to fail with "No such file or directory".

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): releng
