### PR TITLE
Fix operational get-data crash on containers with shell chars

### DIFF
--- a/src/statd/python/yanger/infix_containers.py
+++ b/src/statd/python/yanger/infix_containers.py
@@ -234,10 +234,6 @@ def container(ps):
     if path:
         out["cmdline"] = " ".join([path] + args)
 
-    cmd = inspect.get("Config", {}).get("Cmd", [])
-    if cmd:
-        out["command"] = " ".join(cmd)
-
     net = network(ps, inspect)
     if net:
         out["network"] = net

--- a/test/case/statd/containers/infix-containers.json
+++ b/test/case/statd/containers/infix-containers.json
@@ -9,7 +9,6 @@
         "running": true,
         "status": "Up About a minute",
         "cmdline": "/usr/bin/tini -- /usr/sbin/httpd -f -v",
-        "command": "/usr/sbin/httpd -f -v",
         "network": {
           "interface": [
             {
@@ -30,7 +29,6 @@
         "running": true,
         "status": "Up About a minute",
         "cmdline": "/usr/bin/tini -- /usr/sbin/httpd -f -v -p 91",
-        "command": "/usr/sbin/httpd -f -v -p 91",
         "network": {
           "interface": [
             {
@@ -53,7 +51,6 @@
         "running": true,
         "status": "Up About a minute",
         "cmdline": "/usr/bin/tini -- /usr/sbin/nft-helper /etc/nftables.conf",
-        "command": "/usr/sbin/nft-helper /etc/nftables.conf",
         "network": {
           "host": true
         }

--- a/test/case/statd/containers/operational.json
+++ b/test/case/statd/containers/operational.json
@@ -1188,7 +1188,6 @@
     "container": [
       {
         "cmdline": "/usr/bin/tini -- /usr/sbin/httpd -f -v",
-        "command": "/usr/sbin/httpd -f -v",
         "id": "78d28082c2e5d494c82aa181c95118ce498e25930ad9e288ba010257ca336378",
         "image": "localhost/curios-httpd-oci-amd64-v24.11.0:latest",
         "image-id": "d6930d60a73be9980f8e19b4b4f63586a6d3492178e20bea962e4e9b8c654033",
@@ -1209,7 +1208,6 @@
       },
       {
         "cmdline": "/usr/bin/tini -- /usr/sbin/httpd -f -v -p 91",
-        "command": "/usr/sbin/httpd -f -v -p 91",
         "id": "3451cfceca4eee1091c1dfedece2faee99bc8a729e781799d9c0b4368a31d86d",
         "image": "localhost/curios-httpd-oci-amd64-v24.11.0:latest",
         "image-id": "d6930d60a73be9980f8e19b4b4f63586a6d3492178e20bea962e4e9b8c654033",
@@ -1232,7 +1230,6 @@
       },
       {
         "cmdline": "/usr/bin/tini -- /usr/sbin/nft-helper /etc/nftables.conf",
-        "command": "/usr/sbin/nft-helper /etc/nftables.conf",
         "id": "4e7c3daeba15546e7640014b9ee46e389737ed36583e5cb2f8b75a07a82e8523",
         "image": "localhost/curios-nftables-oci-amd64-v24.11.0:latest",
         "image-id": "7a3cc502436250357a6664100a600f306334b4d7203890b85b7ea9b8da6b5665",


### PR DESCRIPTION
## Description

Yanger was populating a strict-pattern config leaf from podman's full entrypoint, breaking every operational read of containers whose command contained characters disallowed by the pattern. To fix this, we simply remove "command" from the data as "command" is config not operational.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [x] Checked in changed Readme.adoc (make test-spec)
  - [x] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
