### PR TITLE
Bump buildroot to 2025.02.14

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -9,6 +9,7 @@ All notable changes to the project are documented in this file.
 ### Changes
 
 - Upgrade Linux kernel to 6.18.33 (LTS)
+- Upgrade Buildroot to 2025.02.14 (LTS)
 - Upgrade FRR to 10.5.4
 - Add support for [Acer Connect Vero W6m][AcerConnectVero], a COTS home router,
   based upon the same hardware as [Banana Pi BPI-R3][BPI-R3], but


### PR DESCRIPTION
Just a lot of CVE fixes, full changelog:
https://github.com/buildroot/buildroot/blob/2025.02.x/CHANGES

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
