### PR TITLE
 yanger: expand VLAN ranges from bridge global output

### DIFF
--- a/src/statd/python/yanger/ietf_interfaces/bridge.py
+++ b/src/statd/python/yanger/ietf_interfaces/bridge.py
@@ -275,8 +275,9 @@ def vlans_add_memberships(iplink, vlans):
             continue
 
         for brpvlan in brpvlans["vlans"]:
-            if not (vlan := vlans.get(brpvlan["vlan"])):
-                LOG.error(f"Unexpected vlan {brpvlans['vlan']} on {port}")
+            vid = brpvlan["vlan"]
+            if not (vlan := vlans.get(vid)):
+                LOG.error(f"Unexpected vlan {vid} on {port}")
                 continue
 
             if "Egress Untagged" in brpvlan.get("flags", []):
@@ -291,17 +292,18 @@ def vlans(iplink):
 
     mctldata = mctl_queriers()
 
-    vlans = {
-        v["vlan"]: {
-            "vid": v["vlan"],
-            "untagged": [],
-            "tagged": [],
-
-            "multicast": multicast(iplink, v, mctldata),
-            "multicast-filters": multicast_filters(iplink, v["vlan"]),
-        }
-        for v in brgvlans[0]["vlans"]
-    }
+    vlans = {}
+    for v in brgvlans[0]["vlans"]:
+        start = v["vlan"]
+        end = v.get("vlanEnd", start)
+        for vid in range(start, end + 1):
+            vlans[vid] = {
+                "vid": vid,
+                "untagged": [],
+                "tagged": [],
+                "multicast": multicast(iplink, v, mctldata),
+                "multicast-filters": multicast_filters(iplink, vid),
+            }
 
     vlans_add_memberships(iplink, vlans)
     return list(vlans.values())


### PR DESCRIPTION
bridge -j vlan global show can return VLAN ranges as {"vlan": 1, "vlanEnd": 3} instead of individual entries. The vlans dict was only keyed on the start value, causing port VLANs 2 and 3 to be reported as "Unexpected".

Also fix typo in error message (brpvlans -> brpvlan).

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
