### PR TITLE
hostapd: Do not limit BSSID

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -18,6 +18,12 @@ All notable changes to the project are documented in this file.
 - Add `legacy-rates` option to re-enable 802.11b rates on 2.4 GHz for
   old IoT devices (disabled by default)
 
+### Fixes
+
+- Firewall masquerade no longer enables the global IPv4/IPv6 forwarding
+  sysctls.  You must now enable IP forwarding explicitly on the interfaces
+  that should route traffic; enabling NAT alone is no longer enough
+
 [wifi]: wifi.md
 
 [v26.05.0][] - 2026-05-29

--- a/patches/hostapd/0003-more-limit-bssid-mask.patch
+++ b/patches/hostapd/0003-more-limit-bssid-mask.patch
@@ -1,0 +1,17 @@
+diff --git a/src/ap/hostapd.c b/src/ap/hostapd.c
+index 72a0bf503..9bdc2b41d 100644
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -916,12 +916,6 @@ static int hostapd_validate_bssid_configuration(struct hostapd_iface *iface)
+ 	if (bits < j)
+ 		bits = j;
+ 
+-	if (bits > 40) {
+-		wpa_printf(MSG_ERROR, "Too many bits in the BSSID mask (%u)",
+-			   bits);
+-		return -1;
+-	}
+-
+ 	os_memset(mask, 0xff, ETH_ALEN);
+ 	j = bits / 8;
+ 	for (i = 5; i > 5 - j; i--)


### PR DESCRIPTION
## Description
hostapd limit hard what BSSID to use, this since hosatpd is desinged
to use radio-mac+n as default. We demand the user to select the MAC
address, if having multiple BSS.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
