### PR TITLE
Generate test report via 9pm

### DIFF
--- a/test/test.mk
+++ b/test/test.mk
@@ -57,10 +57,11 @@ test-spec:
 	 	-o $(test-specification) $(spec-dir)/Readme.adoc
 
 test-report:
-	asciidoctor-pdf --theme $(spec-dir)/theme.yml \
-		-a logo="image:$(LOGO)" \
-		-a pdf-fontsdir=$(spec-dir)/fonts \
-		-o $(test-report) $(test-dir)/.log/last/report.adoc
+	$(ninepm_report) pdf $(test-dir)/.log/last/result.json \
+		--theme $(spec-dir)/theme.yml \
+		--fontsdir $(spec-dir)/fonts \
+		--logo "$(LOGO)" \
+		-o $(test-report)
 
 # Unit tests run with random (-r) hostname and container name to
 # prevent race conditions when running in CI environments.


### PR DESCRIPTION
## Description

The test-report target previously fed a pre-baked report.adoc to asciidoctor-pdf. This lets 9pm's report.py, the author of result.json,  both generate and render the report instead.

It's invoked with Infix's own theme, fonts, and logo, so the output is unchanged. Spin projects only need to override LOGO to rebrand it.

Also bumps the 9pm submodule to pick up the new --theme/--fontsdir/--logo options on the pdf format.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
