### PR TITLE
fix: flaky dhcp option 121 test

### DIFF
--- a/test/case/dhcp/client_routes/test.py
+++ b/test/case/dhcp/client_routes/test.py
@@ -81,7 +81,7 @@ with infamy.Test() as test:
         with infamy.dhcp.Server(netns, prefix=PREFIX, router=ROUTER):
             with test.step("Verify client has route 10.0.0.0/24 via 192.168.0.254 (option 121)"):
                 print("Verify client use classless routes, option 121")
-                until(lambda: route.ipv4_route_exist(client, PREFIX, ROUTER))
+                until(lambda: route.ipv4_route_exist(client, PREFIX, ROUTER), attempts=60)
 
             with test.step("Verify client has default route via 192.168.0.254 (not use option 3)"):
                 print("Verify client did *not* use option 3")
@@ -90,6 +90,6 @@ with infamy.Test() as test:
 
             with test.step("Verify client still has canary route to 20.0.0.0/24 via 192.168.0.2"):
                 until(lambda: route.ipv4_route_exist(client, CANARY,
-                                                CANHOP, pref=250))
+                                                CANHOP, pref=250), attempts=60)
 
     test.succeed()


### PR DESCRIPTION
## Description

This commit increases attempts on checks in this particular test from default 10 to 60. This has been introduced to match worst case scenario where after 3 retries(5s) each dhcp waits 30 seconds before next 3 retries. Commits yields to much more stable test behaviour.

Results on Alder test system before fix:
--- PASS: 98  FAIL: 2  TOTAL: 100 results written to run-repeat-results.csv 

After fix:
--- PASS: 1000  FAIL: 0  TOTAL: 1000 results written to run-repeat-results.csv 




<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
