### PR TITLE
Revert statd fix that cause massive test regressions

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -19,14 +19,6 @@ All notable changes to the project are documented in this file.
 
 - Fix annoying "cannot deselect all services" or reset to YANG default in the
   web interface's firewall configuration page
-- Fix `statd` timeout warnings in the log.  Updates to the mDNS neighbor
-  table, and status snapshots, could fail with:
-
-        statd[3658]: mdns: sr_apply_changes: Timeout expired
-        statd[3658]: Error, getting operational data: User callback failed
-
-  Such operations are now allowed up to 60 seconds to complete, same as for
-  other services in the system
 
 [v26.06.0][] - 2026-07-01
 -------------------------

--- a/src/statd/avahi.c
+++ b/src/statd/avahi.c
@@ -441,7 +441,7 @@ static void ds_push_resolver(struct mdns_ctx *ctx, struct avahi_service *svc,
 		return;
 	}
 
-	err = sr_apply_changes(ctx->sr_ses, SYSREPO_TIMEOUT);
+	err = sr_apply_changes(ctx->sr_ses, 0);
 	if (err)
 		ERROR("mdns: sr_apply_changes: %s", sr_strerror(err));
 }
@@ -470,7 +470,7 @@ static void ds_delete_neighbor(struct mdns_ctx *ctx, const char *hostname)
 static void ds_clear_all(struct mdns_ctx *ctx)
 {
 	sr_delete_item(ctx->sr_ses, XPATH_BASE, 0);
-	sr_apply_changes(ctx->sr_ses, SYSREPO_TIMEOUT);
+	sr_apply_changes(ctx->sr_ses, 0);
 }
 
 /* --------------------------------------------------------------------------
@@ -641,7 +641,7 @@ static void service_browser_cb(AvahiServiceBrowser *b,
 			}
 		}
 
-		sr_apply_changes(ctx->sr_ses, SYSREPO_TIMEOUT);
+		sr_apply_changes(ctx->sr_ses, 0);
 		break;
 	}
 

--- a/src/statd/journal.c
+++ b/src/statd/journal.c
@@ -133,7 +133,7 @@ static void journal_timer_cb(struct ev_loop *, struct ev_timer *w, int)
 	 * This triggers our own operational callbacks running in main thread
 	 */
 	DEBUG("Calling sr_get_data on session %p", jctx->sr_query_ses);
-	err = sr_get_data(jctx->sr_query_ses, "/*", 0, SYSREPO_TIMEOUT, 0, &sr_data);
+	err = sr_get_data(jctx->sr_query_ses, "/*", 0, 0, 0, &sr_data);
 	if (err != SR_ERR_OK) {
 		ERROR("Error, getting operational data: %s", sr_strerror(err));
 		sr_release_context(con);


### PR DESCRIPTION
## Description

The statd mDNS neighbor collector sometimes locks up and times out with:

Aug  2 07:11:53 test-00-01-00 statd[3558]: mdns: sr_apply_changes: Timeout expired
Aug  2 07:11:53 test-00-01-00 statd[3558]: Error, getting operational data: User callback failed

With the extended sysrepo API timeout introduced in c70a699, PR #1572, this causes massive test regressions, hence this revert.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [x] Other (please describe): revert for massive regressions
