### PR TITLE
confd/board: nanopi-r2s: add gencert keystore entry to factory config

### DIFF
--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/factory-config.cfg
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/factory-config.cfg
@@ -121,6 +121,14 @@
           "private-key-format": "infix-crypto-types:rsa-private-key-format",
           "cleartext-private-key": "",
           "certificates": {}
+        },
+        {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
         }
       ]
     }
@@ -375,6 +383,7 @@
     },
     "restconf": {
       "enabled": true
-    }
+    },
+    "certificate": "gencert"
   }
 }


### PR DESCRIPTION
## Description
Since the HTTPS certificate moved into the ietf-keystore, the Web UI (nginx) is broken on fresh installs: no factory config ships the "gencert" entry, so confd never generates the self-signed certificate, /etc/ssl/certs/self-signed.crt is missing and nginx refuses to start. Add the entry (empty keys, generated on first boot) and reference it from infix-services:web.certificate.

<!--
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
