### PR TITLE
nanopi-r2s: add R2S Plus support (eMMC) and link/activity port LEDs

### DIFF
--- a/board/aarch64/friendlyarm-nanopi-r2s/dts/rockchip/rk3328-nanopi-r2s.dts
+++ b/board/aarch64/friendlyarm-nanopi-r2s/dts/rockchip/rk3328-nanopi-r2s.dts
@@ -1,4 +1,9 @@
-#include <arm64/rockchip/rk3328-nanopi-r2s.dts>
+#include <arm64/rockchip/rk3328-nanopi-r2s-plus.dts>
+/*
+ * The Plus variant adds an on-board 32 GB eMMC. The same image
+ * works on both variants; on the plain R2S the eMMC controller
+ * simply finds no media and the SD card is used as before.
+ */
 #include "infix.dtsi"
 
 &rtl8153 {

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/factory-config.cfg
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/factory-config.cfg
@@ -1,0 +1,389 @@
+{
+  "ieee802-dot1ab-lldp:lldp": {
+    "infix-lldp:enabled": true
+  },
+  "ietf-hardware:hardware": {
+    "component": [
+      {
+        "class": "infix-hardware:usb",
+        "name": "USB",
+        "state": {
+          "admin-state": "unlocked"
+        }
+      }
+    ]
+  },
+  "ietf-interfaces:interfaces": {
+    "interface": [
+      {
+        "name": "br0",
+        "type": "infix-if-type:bridge",
+        "ietf-ip:ipv4": {
+          "address": [
+            {
+              "ip": "192.168.0.1",
+              "prefix-length": 24
+            }
+          ]
+        }
+      },
+      {
+        "name": "lan",
+        "type": "infix-if-type:ethernet",
+        "ietf-ip:ipv6": {},
+        "infix-interfaces:bridge-port": {
+          "bridge": "br0"
+        }
+      },
+      {
+        "name": "lo",
+        "type": "infix-if-type:loopback",
+        "ietf-ip:ipv4": {
+          "address": [
+            {
+              "ip": "127.0.0.1",
+              "prefix-length": 8
+            }
+          ]
+        },
+        "ietf-ip:ipv6": {
+          "address": [
+            {
+              "ip": "::1",
+              "prefix-length": 128
+            }
+          ]
+        }
+      },
+      {
+        "name": "wan",
+        "type": "infix-if-type:ethernet",
+        "ietf-ip:ipv4": {
+          "infix-dhcp-client:dhcp": {
+            "option": [
+              {
+                "id": "ntp-server"
+              },
+              {
+                "id": "broadcast"
+              },
+              {
+                "id": "domain"
+              },
+              {
+                "id": "hostname",
+                "value": "auto"
+              },
+              {
+                "id": "dns-server"
+              },
+              {
+                "id": "router"
+              },
+              {
+                "id": "netmask"
+              },
+              {
+                "id": "vendor-class",
+                "value": "NanoPi R2S"
+              }
+            ]
+          }
+        },
+        "ietf-ip:ipv6": {
+          "infix-dhcpv6-client:dhcp": {
+            "option": [
+              {
+                "id": "ntp-server"
+              },
+              {
+                "id": "client-fqdn"
+              },
+              {
+                "id": "domain-search"
+              },
+              {
+                "id": "dns-server"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "ietf-keystore:keystore": {
+    "asymmetric-keys": {
+      "asymmetric-key": [
+        {
+          "name": "genkey",
+          "public-key-format": "infix-crypto-types:ssh-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        }
+      ]
+    }
+  },
+  "ietf-netconf-acm:nacm": {
+    "enable-nacm": true,
+    "read-default": "permit",
+    "write-default": "permit",
+    "exec-default": "permit",
+    "groups": {
+      "group": [
+        {
+          "name": "admin",
+          "user-name": [
+            "admin"
+          ]
+        },
+        {
+          "name": "operator",
+          "user-name": []
+        },
+        {
+          "name": "guest",
+          "user-name": []
+        }
+      ]
+    },
+    "rule-list": [
+      {
+        "name": "admin-acl",
+        "group": [
+          "admin"
+        ],
+        "rule": [
+          {
+            "name": "permit-all",
+            "module-name": "*",
+            "access-operations": "*",
+            "action": "permit",
+            "comment": "Allow 'admin' group complete access to all operations and data."
+          }
+        ]
+      },
+      {
+        "name": "operator-acl",
+        "group": [
+          "operator"
+        ],
+        "rule": [
+          {
+            "name": "permit-system-rpcs",
+            "module-name": "ietf-system",
+            "rpc-name": "*",
+            "access-operations": "exec",
+            "action": "permit",
+            "comment": "Operators can reboot, shutdown, and set system time."
+          }
+        ]
+      },
+      {
+        "name": "guest-acl",
+        "group": [
+          "guest"
+        ],
+        "rule": [
+          {
+            "name": "deny-all-write+exec",
+            "module-name": "*",
+            "access-operations": "create update delete exec",
+            "action": "deny",
+            "comment": "Guests cannot change anything or exec rpcs."
+          }
+        ]
+      },
+      {
+        "name": "default-deny-all",
+        "group": [
+          "*"
+        ],
+        "rule": [
+          {
+            "name": "deny-password-access",
+            "path": "/ietf-system:system/authentication/user/password",
+            "access-operations": "*",
+            "action": "deny",
+            "comment": "No user except admins can access password hashes."
+          },
+          {
+            "name": "deny-keystore-access",
+            "module-name": "ietf-keystore",
+            "access-operations": "*",
+            "action": "deny",
+            "comment": "No user except admins can access cryptographic keys."
+          },
+          {
+            "name": "deny-truststore-access",
+            "module-name": "ietf-truststore",
+            "access-operations": "*",
+            "action": "deny",
+            "comment": "No user except admins can access trust store."
+          }
+        ]
+      }
+    ]
+  },
+  "ietf-netconf-server:netconf-server": {
+    "listen": {
+      "endpoints": {
+        "endpoint": [
+          {
+            "name": "default-ssh",
+            "ssh": {
+              "tcp-server-parameters": {
+                "local-bind": [
+                  {
+                    "local-address": "::"
+                  }
+                ]
+              },
+              "ssh-server-parameters": {
+                "server-identity": {
+                  "host-key": [
+                    {
+                      "name": "default-key",
+                      "public-key": {
+                        "central-keystore-reference": "genkey"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "ietf-system:system": {
+    "hostname": "r2s-%m",
+    "ntp": {
+      "server": [
+        {
+          "name": "default",
+          "udp": {
+            "address": "pool.ntp.org"
+          }
+        }
+      ]
+    },
+    "authentication": {
+      "user": [
+        {
+          "name": "admin",
+          "password": "$factory$",
+          "infix-system:shell": "bash"
+        }
+      ]
+    },
+    "infix-system:motd-banner": "Li0tLS0tLS0uCnwgIC4gLiAgfCBJbmZpeCBPUyDigJQgSW1tdXRhYmxlLkZyaWVuZGx5LlNlY3VyZQp8LS4gdiAuLXwgaHR0cHM6Ly9rZXJuZWxraXQub3JnCictJy0tLSctJwo="
+  },
+  "infix-dhcp-server:dhcp-server": {
+    "option": [
+      {
+        "id": "ntp-server",
+        "address": "auto"
+      },
+      {
+        "id": "dns-server",
+        "address": "auto"
+      },
+      {
+        "id": "router",
+        "address": "auto"
+      }
+    ],
+    "subnet": [
+      {
+        "subnet": "192.168.0.0/24",
+        "pool": {
+          "start-address": "192.168.0.100",
+          "end-address": "192.168.0.250"
+        }
+      }
+    ]
+  },
+  "infix-firewall:firewall": {
+    "default": "wan",
+    "zone": [
+      {
+        "name": "lan",
+        "action": "accept",
+        "interface": [
+          "br0"
+        ]
+      },
+      {
+        "name": "wan",
+        "action": "drop",
+        "interface": [
+          "wan"
+        ],
+        "service": [
+          "dhcpv6-client"
+        ]
+      }
+    ],
+    "policy": [
+      {
+        "name": "lan-to-wan",
+        "action": "accept",
+        "ingress": [
+          "lan"
+        ],
+        "egress": [
+          "wan"
+        ],
+        "masquerade": true
+      }
+    ]
+  },
+  "infix-meta:meta": {
+    "version": "1.7"
+  },
+  "infix-services:mdns": {
+    "enabled": true
+  },
+  "infix-services:ssh": {
+    "enabled": true,
+    "hostkey": [
+      "genkey"
+    ],
+    "listen": [
+      {
+        "name": "ipv4",
+        "address": "0.0.0.0",
+        "port": 22
+      },
+      {
+        "name": "ipv6",
+        "address": "::",
+        "port": 22
+      }
+    ]
+  },
+  "infix-services:web": {
+    "enabled": true,
+    "console": {
+      "enabled": true
+    },
+    "netbrowse": {
+      "enabled": true
+    },
+    "restconf": {
+      "enabled": true
+    },
+    "certificate": "gencert"
+  }
+}

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/finit.d/enabled/input-event-daemon.conf
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/finit.d/enabled/input-event-daemon.conf
@@ -1,0 +1,1 @@
+../available/input-event-daemon.conf

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/finit.d/startup.conf
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/finit.d/startup.conf
@@ -1,0 +1,1 @@
+service [2345] <service/confd/ready> startup-led.sh -- System ready (LED trigger)

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/finit.d/wan-monitor.conf
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/finit.d/wan-monitor.conf
@@ -1,0 +1,1 @@
+service [12345789] log wan-monitor.sh -- WAN Health monitor

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/iitod.json
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/iitod.json
@@ -1,0 +1,91 @@
+{
+    "input": {
+	"path": {
+	    "locate":       { "path": "/run/led/locate" },
+
+	    "status-prime": { "path": "/run/led/status-prime" },
+	    "status-ok":    { "path": "/run/led/status-ok" },
+	    "status-err":   { "path": "/run/led/status-err" },
+	    "status-crit":  { "path": "/run/led/status-crit" },
+
+	    "fault-prime":  { "path": "/run/led/fault-prime" },
+	    "fault-ok":     { "path": "/run/led/fault-ok" },
+	    "fault-err":    { "path": "/run/led/fault-err" },
+	    "fault-crit":   { "path": "/run/led/fault-crit" },
+
+	    "wan-up":       { "path": "/run/led/wan-up" },
+
+	    "startup":   { "path": "/run/finit/cond/run/startup/success" },
+	    "fail-safe": { "path": "/run/finit/cond/run/failure/success" },
+	    "panic":     { "path": "/run/finit/cond/run/failure/failure" }
+	},
+	"udev": {
+	    "power-a": { "subsystem": "power_supply" },
+	    "power-b": { "subsystem": "power_supply" }
+	}
+    },
+
+    "output": {
+	"led-group": {
+	    "port-link-act": {
+		"match": ["*:green:tp", "*:green:sfp", "*:green:port" ],
+
+		"rules": [
+		    { "if": "true", "then": { "trigger": "netdev", "link": 1, "rx": 1, "tx": 1 } }
+		]
+	    },
+	    "port-alarm": {
+		"match": ["*:yellow:tp", "*:yellow:sfp", "*:yellow:port" ],
+
+		"rules": [
+		]
+	    }
+	},
+	"led": {
+	    "nanopi-r2s:red:sys": {
+		"rules": [
+		    { "if": "locate",    "then": "@blink-1hz" },
+		    { "if": "panic",     "then": "@blink-5hz" },
+		    { "if": "fail-safe", "then": "@blink-5hz" },
+		    { "if": "startup",   "then": "@off" },
+		    { "if": "true",      "then": "@blink-1hz" }
+		]
+	    },
+
+	    "nanopi-r2s:green:lan": {
+		"rules": [
+		    { "if": "locate",  "then": "@blink-1hz" },
+		    { "if": "panic",   "then": "@blink-5hz" },
+		    { "if": "startup", "then": "@on" }
+		]
+	    },
+
+	    "nanopi-r2s:green:wan": {
+		"rules": [
+		    { "if": "locate", "then": "@blink-1hz" },
+		    { "if": "panic",  "then": "@blink-5hz" },
+		    { "if": "wan-up", "then": "@on" }
+		]
+	    }
+	}
+    },
+
+    "aliases": {
+	"on": {
+	    "brightness": true
+	},
+	"off": {
+	    "brightness": false
+	},
+	"blink-1hz": {
+	    "trigger": "timer",
+	    "delay_on": 500,
+	    "delay_off": 500
+	},
+	"blink-5hz": {
+	    "trigger": "timer",
+	    "delay_on": 100,
+	    "delay_off": 100
+	}
+    }
+}

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/iitod.json
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/iitod.json
@@ -52,19 +52,15 @@
 		]
 	    },
 
+
 	    "nanopi-r2s:green:lan": {
 		"rules": [
-		    { "if": "locate",  "then": "@blink-1hz" },
-		    { "if": "panic",   "then": "@blink-5hz" },
-		    { "if": "startup", "then": "@on" }
+		    { "if": "true", "then": { "trigger": "netdev", "device_name": "lan", "link": 1, "rx": 1, "tx": 1 } }
 		]
 	    },
-
 	    "nanopi-r2s:green:wan": {
 		"rules": [
-		    { "if": "locate", "then": "@blink-1hz" },
-		    { "if": "panic",  "then": "@blink-5hz" },
-		    { "if": "wan-up", "then": "@on" }
+		    { "if": "true", "then": { "trigger": "netdev", "device_name": "wan", "link": 1, "rx": 1, "tx": 1 } }
 		]
 	    }
 	}

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/input-event-daemon.conf
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/input-event-daemon.conf
@@ -1,0 +1,5 @@
+[Global]
+listen = /dev/input/event1
+
+[Keys]
+RESTART = reboot

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/udev/rules.d/90-persistent-net.rules
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s-plus/etc/udev/rules.d/90-persistent-net.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="net", DEVPATH=="/devices/platform/ff540000.ethernet/net/eth0", NAME="wan"
+ACTION=="add", SUBSYSTEM=="net", DEVPATH=="/devices/platform/ff600000.usb/xhci-hcd.0.auto/usb5/5-1/5-1:1.0/net/*", NAME="lan"

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/finit.d/startup.conf
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/finit.d/startup.conf
@@ -1,0 +1,1 @@
+service [2345] <service/confd/ready> startup-led.sh -- System ready (LED trigger)

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/iitod.json
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/iitod.json
@@ -52,19 +52,15 @@
 		]
 	    },
 
+
 	    "nanopi-r2s:green:lan": {
 		"rules": [
-		    { "if": "locate",  "then": "@blink-1hz" },
-		    { "if": "panic",   "then": "@blink-5hz" },
-		    { "if": "startup", "then": "@on" }
+		    { "if": "true", "then": { "trigger": "netdev", "device_name": "lan", "link": 1, "rx": 1, "tx": 1 } }
 		]
 	    },
-
 	    "nanopi-r2s:green:wan": {
 		"rules": [
-		    { "if": "locate", "then": "@blink-1hz" },
-		    { "if": "panic",  "then": "@blink-5hz" },
-		    { "if": "wan-up", "then": "@on" }
+		    { "if": "true", "then": { "trigger": "netdev", "device_name": "wan", "link": 1, "rx": 1, "tx": 1 } }
 		]
 	    }
 	}

--- a/board/aarch64/rootfs/usr/sbin/startup-led.sh
+++ b/board/aarch64/rootfs/usr/sbin/startup-led.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Set the iitod "startup" condition once confd is ready, so the LAN and
+# status LEDs light up per the product iitod.json rules.  /run is tmpfs,
+# so this must run on every boot.
+mkdir -p /run/finit/cond/run/startup
+touch /run/finit/cond/run/startup/success


### PR DESCRIPTION
## Description

1. Use the rk3328-nanopi-r2s-plus device tree so the on-board 32 GB
   eMMC is detected (the Plus DT is a superset; the same image still
   works on the plain R2S, which simply uses the SD card).
2. Add a product config for the friendlyarm,nanopi-r2s-plus compatible
   string (without it factory config is empty and there is no
   networking). Includes the gencert keystore entry so the Web UI works
   on fresh installs.
3. LED fixes: iitod expects /run/finit/cond/run/startup/success to
   control the status LED, but nothing ever creates it; add a finit
   service that sets the condition once confd is ready. Both port LEDs
   now track link/activity via the netdev trigger (lan/wan interfaces)
   instead of static rules.

Verified on hardware (NanoPi R2S Plus): fresh install with networking,
Web UI reachable, LAN/WAN LEDs follow cable presence, SYS LED off in
normal operation. A/B update via RAUC .pkg verified.

Disclaimer: Author: Peter Woxblom. Drafting and implementation assisted
by Jarvis, an AI agent (Hermes on DeepSeek V4 Flash backend). Reviewed
and tested on hardware by the author.

<!--

  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [X ] Other (please describe): Device support
