### PR TITLE
confd/board: nanopi-r2s: add gencert keystore entry to factory config

### DIFF
--- a/board/aarch64/acer-connect-vero-w6m/rootfs/usr/share/product/acer,connect-vero-w/etc/factory-config.cfg
+++ b/board/aarch64/acer-connect-vero-w6m/rootfs/usr/share/product/acer,connect-vero-w/etc/factory-config.cfg
@@ -214,6 +214,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -475,6 +483,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/bananapi-bpi-r3/rootfs/usr/share/product/bananapi,bpi-r3/etc/factory-config.cfg
+++ b/board/aarch64/bananapi-bpi-r3/rootfs/usr/share/product/bananapi,bpi-r3/etc/factory-config.cfg
@@ -206,6 +206,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -467,6 +475,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/bananapi-bpi-r3/rootfs/usr/share/product/bananapi,bpi-r3mini/etc/factory-config.cfg
+++ b/board/aarch64/bananapi-bpi-r3/rootfs/usr/share/product/bananapi,bpi-r3mini/etc/factory-config.cfg
@@ -172,6 +172,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -433,6 +441,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/bananapi-bpi-r4/rootfs/usr/share/product/bananapi,bpi-r4-2g5/etc/factory-config.cfg
+++ b/board/aarch64/bananapi-bpi-r4/rootfs/usr/share/product/bananapi,bpi-r4-2g5/etc/factory-config.cfg
@@ -139,6 +139,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -391,6 +399,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/bananapi-bpi-r4/rootfs/usr/share/product/bananapi,bpi-r4/etc/factory-config.cfg
+++ b/board/aarch64/bananapi-bpi-r4/rootfs/usr/share/product/bananapi,bpi-r4/etc/factory-config.cfg
@@ -131,6 +131,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -383,6 +391,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/bananapi-bpi-r64/rootfs/usr/share/product/bananapi,bpi-r64/etc/factory-config.cfg
+++ b/board/aarch64/bananapi-bpi-r64/rootfs/usr/share/product/bananapi,bpi-r64/etc/factory-config.cfg
@@ -164,6 +164,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -425,6 +433,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/factory-config.cfg
+++ b/board/aarch64/friendlyarm-nanopi-r2s/rootfs/usr/share/product/friendlyarm,nanopi-r2s/etc/factory-config.cfg
@@ -115,6 +115,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -367,6 +375,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/raspberrypi-rpi64/rootfs/usr/share/product/raspberrypi,4-model-b/etc/factory-config.cfg
+++ b/board/aarch64/raspberrypi-rpi64/rootfs/usr/share/product/raspberrypi,4-model-b/etc/factory-config.cfg
@@ -92,6 +92,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -268,6 +276,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/aarch64/raspberrypi-rpi64/rootfs/usr/share/product/raspberrypi,400/etc/factory-config.cfg
+++ b/board/aarch64/raspberrypi-rpi64/rootfs/usr/share/product/raspberrypi,400/etc/factory-config.cfg
@@ -106,6 +106,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -282,6 +290,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },

--- a/board/arm/raspberrypi-rpi2/rootfs/usr/share/product/raspberrypi,2-model-b/etc/factory-config.cfg
+++ b/board/arm/raspberrypi-rpi2/rootfs/usr/share/product/raspberrypi,2-model-b/etc/factory-config.cfg
@@ -77,6 +77,14 @@
     "asymmetric-keys": {
       "asymmetric-key": [
         {
+          "name": "gencert",
+          "public-key-format": "infix-crypto-types:x509-public-key-format",
+          "public-key": "",
+          "private-key-format": "infix-crypto-types:rsa-private-key-format",
+          "cleartext-private-key": "",
+          "certificates": {}
+        },
+        {
           "name": "genkey",
           "public-key-format": "infix-crypto-types:ssh-public-key-format",
           "public-key": "",
@@ -253,6 +261,7 @@
   },
   "infix-services:web": {
     "enabled": true,
+    "certificate": "gencert",
     "console": {
       "enabled": true
     },


### PR DESCRIPTION
Since the HTTPS certificate moved into the ietf-keystore, the Web UI (nginx) is broken on fresh installs: no factory config ships the "gencert" entry, so confd never generates the self-signed certificate, /etc/ssl/certs/self-signed.crt is missing and nginx refuses to start. Add the entry (empty keys, generated on first boot) and reference it from infix-services:web.certificate.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
