### PR TITLE
infamy: fix NameError in Topology.get_password (qstrip -> _qstrip)

### DIFF
--- a/test/infamy/topology.py
+++ b/test/infamy/topology.py
@@ -129,7 +129,7 @@ class Topology:
         b = n[0] if n else {}
         password = b.get("password")
 
-        return qstrip(password) if password is not None else "admin"
+        return _qstrip(password) if password is not None else "admin"
 
     def get_expected_boot(self, node):
         n = self.dotg.get_node(node)


### PR DESCRIPTION
## Description

Fix a `NameError` in the Infamy test harness. `Topology.get_password()`
called `qstrip()` but the helper is defined as `_qstrip()` — so any
physical topology that sets a per-node `password` attribute (or any
value needing quote-stripping) crashed during `env.attach()`.

Found while running the hardware regression suite against a physical
device. Worked around locally, this is the proper upstream fix.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [x] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):

Disclaimer: Author: Peter Woxblom. Drafting and implementation assisted
by Jarvis, an AI agent (Hermes on DeepSeek V4 Flash backend). Reviewed
and tested on hardware by the author.