### PR TITLE
kernel: nanopi-r2s: add rk3328-nanopi-r2s-plus device tree (eMMC support)

### DIFF
--- a/board/aarch64/friendlyarm-nanopi-r2s/dts/Makefile
+++ b/board/aarch64/friendlyarm-nanopi-r2s/dts/Makefile
@@ -1,1 +1,1 @@
-dtb-y += rockchip/rk3328-nanopi-r2s.dtb
+dtb-y += rockchip/rk3328-nanopi-r2s.dtb rockchip/rk3328-nanopi-r2s-plus.dtb

--- a/board/aarch64/friendlyarm-nanopi-r2s/dts/rockchip/rk3328-nanopi-r2s-plus.dts
+++ b/board/aarch64/friendlyarm-nanopi-r2s/dts/rockchip/rk3328-nanopi-r2s-plus.dts
@@ -1,0 +1,20 @@
+#include <arm64/rockchip/rk3328-nanopi-r2s-plus.dts>
+
+#include "infix.dtsi"
+
+/ {
+	compatible = "friendlyarm,nanopi-r2s", "rockchip,rk3328";
+};
+
+&rtl8153 {
+	/*
+	 * Fix port number: device is on port 1, not port 2.
+	 */
+	reg = <1>;
+};
+
+&{/chosen/infix} {
+	/* Expose only the external USB 2.0 port for user management */
+	usb-ports = <&usb_host0_ehci>;
+	usb-port-names = "USB";
+};

--- a/board/aarch64/friendlyarm-nanopi-r2s/uboot/r2s-env.dtsi
+++ b/board/aarch64/friendlyarm-nanopi-r2s/uboot/r2s-env.dtsi
@@ -4,6 +4,11 @@
 			boot_targets = "mmc1";
 			ethprime = "eth0";
 
+			/* The R2S Plus has an on-board eMMC (mmc0); the plain R2S does
+			 * not.  Pick the matching kernel DT so the eMMC controller is
+			 * enabled only when the hardware is present. */
+			ixvariant = "if mmc dev 0; then setenv fdtfile rockchip/rk3328-nanopi-r2s-plus.dtb; else setenv fdtfile rockchip/rk3328-nanopi-r2s.dtb; fi";
+
 			/* This is a development platform, hard code developer mode */
 			ixbtn-devmode = "setenv dev_mode yes; echo Enabled";
 

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -15,6 +15,11 @@ All notable changes to the project are documented in this file.
 - Build RPi64 SD card images in release builds
 - Include .pkg files in release builds
 
+### Added
+
+- Add NanoPi R2S Plus support (on-board 32 GB eMMC), including U-Boot
+  device tree selection so the eMMC is enabled when present
+
 ### Fixes
 
 - Fix annoying "cannot deselect all services" or reset to YANG default in the


### PR DESCRIPTION
## Description

Add support for the NanoPi R2S Plus, which adds an on-board 32 GB eMMC
to the plain R2S. The SoC, DRAM and network layout are identical to the
R2S — the only difference is the eMMC, so this is a superset variant
rather than a separate board.

Changes:

- **Device tree:** add `rk3328-nanopi-r2s-plus.dts`, wrapping the
  kernel's `rk3328-nanopi-r2s-plus` (which builds on the shared
  `rk3328-nanopi-r2s.dtsi`), and list both `.dtbs` in `dts/Makefile`,
  following the bpi-r3 pattern. The wrapper overrides the top-level
  compatible to `friendlyarm,nanopi-r2s`, so the Plus shares the R2S
  product configuration — no separate product directory is needed.

- **U-Boot DT selection:** the R2S had no `fdtfile`/`ixvariant`
  mechanism, so U-Boot always loaded the plain r2s DT and the kernel
  never saw the eMMC. Add `ixvariant` (bpi-r4 pattern) that selects
  the plus DT when `mmc0` (eMMC) is present, falling back to the r2s
  DT otherwise.

- **ChangeLog:** entry under v26.08.0.

## Regression Testing (Infamy, physical hardware)

Ran against the NanoPi R2S Plus in test mode
(`touch /mnt/aux/test-mode && reboot`), using the official Infamy
test suite with a single-DUT topology (controller host + target):

- `case/hardware/watchdog`: **6/6 pass** — watchdog tripped on an
  injected hard lockup (all cores, IRQs disabled) and rebooted the
  system back to a working state
- `case/system` (hostname, add/delete user, admin user, NACM,
  timezone x2, schedule reboot): **7/7 pass**
- `case/system/factory_config`: skipped in test mode by design (test
  mode always boots the test config, never the factory config)
- `case/system/upgrade`: not run (requires a data port not wired in
  this lab setup)

Found and worked around an upstream bug in the test harness while
running these tests (`Topology.get_password()` `qstrip` NameError) —
fixed in a separate PR (#1588).

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [x] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [x] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):

Disclaimer: Author: Peter Woxblom. Drafting and implementation assisted
by Jarvis, an AI agent (Hermes on DeepSeek V4 Flash backend). Reviewed
and tested on hardware by the author.