### PR TITLE
test: bump support collect timeout to 300s

### DIFF
--- a/test/case/misc/support_collect/test.py
+++ b/test/case/misc/support_collect/test.py
@@ -42,7 +42,7 @@ with infamy.Test() as test:
             result = tgtssh.run("sudo support --work-dir /tmp collect --log-sec 2",
                                 stdout=f,
                                 stderr=subprocess.PIPE,
-                                timeout=120)
+                                timeout=300)
 
         if result.returncode != 0:
             stderr_output = result.stderr.decode('utf-8') if result.stderr else ""
@@ -120,7 +120,7 @@ with infamy.Test() as test:
                 result = tgtssh.run(f"sudo support --work-dir /tmp collect --log-sec 2 --password {test_password}",
                                     stdout=f,
                                     stderr=subprocess.PIPE,
-                                    timeout=120)
+                                    timeout=300)
 
             if result.returncode != 0:
                 stderr_output = result.stderr.decode('utf-8') if result.stderr else ""

--- a/test/infamy/ptp.py
+++ b/test/infamy/ptp.py
@@ -84,11 +84,19 @@ def is_own_gm(target, inst_idx=0):
 
 
 def has_converged(target, threshold_ns=100_000, inst_idx=0):
-    """True when |offset-from-time-transmitter| < threshold_ns."""
+    """True when |offset-from-time-transmitter| < threshold_ns.
+
+    Prints the offset while unconverged, so a failed until() wait
+    shows the offset trend in the test log.
+    """
     off = offset_ns(target, inst_idx)
     if off is None:
+        print(f"{target.name}: no offset-from-time-transmitter")
         return False
-    return abs(off) < threshold_ns
+    if abs(off) < threshold_ns:
+        return True
+    print(f"{target.name}: offset {off} ns, threshold {threshold_ns} ns")
+    return False
 
 
 def port_state_dbg(target, port_idx=1, inst_idx=0):


### PR DESCRIPTION
This will most likely fix the `support collect` test, that is flaky on hardware with a lot of ports.


## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
