### PR TITLE
generate-defconfig: handle missing trailing newline

### DIFF
--- a/utils/generate-defconfig.sh
+++ b/utils/generate-defconfig.sh
@@ -79,7 +79,11 @@ for change in $changes; do
 done
 
 TMPDIR=`mktemp -d`
-$MERGE_CONFIG -O "$TMPDIR" "$base" "$changes"
+
+# Concatenate the changes with awk. This terminates every line, so a file
+# without a trailing newline won't glue its last line to the next file's first.
+awk '{print}' $changes > "$TMPDIR/changes.conf"
+$MERGE_CONFIG -O "$TMPDIR" "$base" "$TMPDIR/changes.conf"
 
 O="$TMPDIR" make savedefconfig
 mv "$TMPDIR"/defconfig "$output"


### PR DESCRIPTION
## Description

merge_config.sh appends each file with cat, which inserts nothing between files. A file that does not end with a newline therefore sticks its last line to the first line of the next. Like:

BR2_PACKAGE_FOO=yBR2_ROOTFS_OVERLAY="..."

Kconfig cannot parse that, so both settings are silently dropped and the generated defconfig keeps the base value instead.

This commit concatenate the fragments with awk. This terminates every line, so the result no longer depends on how the input files ends.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
