### PR TITLE
test/env: allow extra container runner args

### DIFF
--- a/test/env
+++ b/test/env
@@ -67,6 +67,13 @@ usage: test/env [-cDhiKr] -f <IMAGE> -q <QENETH-DIR> <COMMAND> [<ARGS>...]
       topology. If the command is containerized, it will be launched
       in the host's network namespace
 
+  Environment:
+
+    INFIX_RUNNER_ARGS
+      Extra arguments to the container runner (docker/podman).
+      For example "--name foo" or "--label key=val", to give the
+      caller a handle on the container.
+
 EOF
 }
 
@@ -248,6 +255,7 @@ if [ "$containerize" ]; then
 	 --tty \
 	 $volumes \
 	 $kvm \
+	 $INFIX_RUNNER_ARGS \
 	 $INFIX_TEST \
 	 "$0" -C "$@"
 else


### PR DESCRIPTION
## Description

Add INFIX_RUNNER_ARGS which is passed last to docker/podman run. So callers can set something like "--name" or "--label" to keep a handle on the container.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
