### PR TITLE
infamy: route: Make more robust, check if the route is installed

### DIFF
--- a/test/case/routing/ospf_default_route_advertise/test.adoc
+++ b/test/case/routing/ospf_default_route_advertise/test.adoc
@@ -39,6 +39,8 @@ image::topology.svg[OSPF Default Route Advertise topology, align=center, scaledw
 
 . Set up topology and attach to target DUTs
 . Configure targets
+. Verify R1 has an active static default route
+. Wait for all neighbors to peer
 . Verify R2 has a default route and 192.168.100.1/32 from OSPF
 . Verify connectivity from PC:data2 to 10.10.10.10
 . Disable link PC:data1 <--> R1:data (take default gateway down)

--- a/test/case/routing/ospf_default_route_advertise/test.py
+++ b/test/case/routing/ospf_default_route_advertise/test.py
@@ -271,12 +271,20 @@ with infamy.Test() as test:
 
         parallel(lambda: config_target1(R1, R1data, R1link),
                  lambda: config_target2(R2, R2data, R2link))
+
+    with test.step("Verify R1 has an active static default route"):
+        until(lambda: route.ipv4_route_exist(R1, "0.0.0.0/0", proto="ietf-routing:static", active_check=True), attempts=60)
+
+    with test.step("Wait for all neighbors to peer"):
+        until(lambda: route.ospf_get_neighbor(R1, "0.0.0.0", R1link, "2.2.2.2"), attempts=200)
+        until(lambda: route.ospf_get_neighbor(R2, "0.0.0.0", R2link, "1.1.1.1"), attempts=200)
+
     with test.step("Verify R2 has a default route and 192.168.100.1/32 from OSPF"):
         print("Waiting for OSPF routes...")
-        until(lambda: route.ipv4_route_exist(R2, "0.0.0.0/0", proto="ietf-ospf:ospfv2"), attempts=200)
-        until(lambda: route.ipv4_route_exist(R2, "192.168.100.1/32", proto="ietf-ospf:ospfv2"), attempts=200)
-        until(lambda: route.ipv4_route_exist(R1, "192.168.200.1/32", proto="ietf-ospf:ospfv2"), attempts=200)
-        until(lambda: route.ipv4_route_exist(R1, "192.168.20.0/24", proto="ietf-ospf:ospfv2"), attempts=200)
+        until(lambda: route.ipv4_route_exist(R2, "0.0.0.0/0", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
+        until(lambda: route.ipv4_route_exist(R2, "192.168.100.1/32", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.200.1/32", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.20.0/24", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
 
     with test.step("Verify connectivity from PC:data2 to 10.10.10.10"):
         _, hport0 = env.ltop.xlate("PC", "data2")
@@ -289,8 +297,8 @@ with infamy.Test() as test:
         disable_interface(R1, R1data)
 
     with test.step("Verify R2 does not have a default route but a 192.168.100.1/32 from OSPF"):
-        until(lambda: route.ipv4_route_exist(R2, "192.168.100.1/32", proto="ietf-ospf:ospfv2"), attempts=200)
-        until(lambda: route.ipv4_route_exist(R1, "192.168.200.1/32", proto="ietf-ospf:ospfv2"), attempts=200)
+        until(lambda: route.ipv4_route_exist(R2, "192.168.100.1/32", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.200.1/32", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
         until(lambda: route.ipv4_route_exist(R2, "0.0.0.0/0", proto="ietf-ospf:ospfv2") == False, attempts=200)
 
     with test.step("Verify no connectivity from PC:data2 to 10.10.10.10"):
@@ -309,10 +317,10 @@ with infamy.Test() as test:
 
     with test.step("Verify R2 has a default route and 192.168.100.1/32 from OSPF"):
         print("Waiting for OSPF routes...")
-        until(lambda: route.ipv4_route_exist(R2, "192.168.100.1/32", proto="ietf-ospf:ospfv2"), attempts=200)
-        until(lambda: route.ipv4_route_exist(R1, "192.168.200.1/32", proto="ietf-ospf:ospfv2"), attempts=200)
-        until(lambda: route.ipv4_route_exist(R1, "192.168.20.0/24", proto="ietf-ospf:ospfv2"), attempts=200)
-        until(lambda: route.ipv4_route_exist(R2, "0.0.0.0/0", proto="ietf-ospf:ospfv2"), attempts=200)
+        until(lambda: route.ipv4_route_exist(R2, "192.168.100.1/32", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.200.1/32", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.20.0/24", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
+        until(lambda: route.ipv4_route_exist(R2, "0.0.0.0/0", proto="ietf-ospf:ospfv2", active_check=True), attempts=200)
 
     with test.step("Verify connectivity from PC:data2 to 10.10.10.10"):
         _, hport0 = env.ltop.xlate("PC", "data2")

--- a/test/case/routing/rip_multihop/test.py
+++ b/test/case/routing/rip_multihop/test.py
@@ -253,21 +253,21 @@ with infamy.Test() as test:
     with test.step("Wait for RIP routes to be exchanged"):
         print("Waiting for RIP routes to propagate...")
         # R1 should learn R2's loopback
-        until(lambda: route.ipv4_route_exist(R1, "192.168.22.1/32", proto="ietf-rip:rip"), attempts=40)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.22.1/32", proto="ietf-rip:rip", active_check=True), attempts=40)
         # R1 should learn R3's loopback (via R2)
-        until(lambda: route.ipv4_route_exist(R1, "192.168.33.1/32", proto="ietf-rip:rip"), attempts=40)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.33.1/32", proto="ietf-rip:rip", active_check=True), attempts=40)
         # R2 should learn R1's loopback
-        until(lambda: route.ipv4_route_exist(R2, "192.168.11.1/32", proto="ietf-rip:rip"), attempts=40)
+        until(lambda: route.ipv4_route_exist(R2, "192.168.11.1/32", proto="ietf-rip:rip", active_check=True), attempts=40)
         # R2 should learn R3's loopback
-        until(lambda: route.ipv4_route_exist(R2, "192.168.33.1/32", proto="ietf-rip:rip"), attempts=40)
+        until(lambda: route.ipv4_route_exist(R2, "192.168.33.1/32", proto="ietf-rip:rip", active_check=True), attempts=40)
         # R3 should learn R2's loopback
-        until(lambda: route.ipv4_route_exist(R3, "192.168.22.1/32", proto="ietf-rip:rip"), attempts=40)
+        until(lambda: route.ipv4_route_exist(R3, "192.168.22.1/32", proto="ietf-rip:rip", active_check=True), attempts=40)
         # R3 should learn R1's loopback (via R2)
-        until(lambda: route.ipv4_route_exist(R3, "192.168.11.1/32", proto="ietf-rip:rip"), attempts=40)
-        until(lambda: route.ipv4_route_exist(R2, "192.168.10.0/24", proto="ietf-rip:rip"), attempts=40)
-        until(lambda: route.ipv4_route_exist(R3, "192.168.10.0/24", proto="ietf-rip:rip"), attempts=40)
-        until(lambda: route.ipv4_route_exist(R2, "192.168.70.0/24", proto="ietf-rip:rip"), attempts=40)
-        until(lambda: route.ipv4_route_exist(R1, "192.168.70.0/24", proto="ietf-rip:rip"), attempts=40)
+        until(lambda: route.ipv4_route_exist(R3, "192.168.11.1/32", proto="ietf-rip:rip", active_check=True), attempts=40)
+        until(lambda: route.ipv4_route_exist(R2, "192.168.10.0/24", proto="ietf-rip:rip", active_check=True), attempts=40)
+        until(lambda: route.ipv4_route_exist(R3, "192.168.10.0/24", proto="ietf-rip:rip", active_check=True), attempts=40)
+        until(lambda: route.ipv4_route_exist(R2, "192.168.70.0/24", proto="ietf-rip:rip", active_check=True), attempts=40)
+        until(lambda: route.ipv4_route_exist(R1, "192.168.70.0/24", proto="ietf-rip:rip", active_check=True), attempts=40)
 
     with test.step("Verify R2 has two RIP neighbors"):
         print("Checking R2 has two RIP neighbors...")

--- a/test/infamy/route.py
+++ b/test/infamy/route.py
@@ -12,6 +12,13 @@ def _get_routes(target, protocol):
         return r.get("routes", {}).get("route", {})
     return {}
 
+def _installed(route):
+    """True if at least one next-hop of the route is installed in the FIB"""
+    nh = route.get("next-hop", {})
+    hops = nh.get("next-hop-list", {}).get("next-hop", [nh])
+    return any("installed" in h or "infix-routing:installed" in h for h in hops)
+
+
 def _exist_route(target, dest, nexthop=None, ip=None, proto=None, pref=None, active_check=False):
     routes = _get_routes(target, ip)
     for r in routes:
@@ -41,7 +48,7 @@ def _exist_route(target, dest, nexthop=None, ip=None, proto=None, pref=None, act
                 if nh_addr != nexthop:
                     continue
 
-        if active_check and "active" not in r:
+        if active_check and ("active" not in r or not _installed(r)):
             continue
 
         return True


### PR DESCRIPTION
If the user set `active_check=True` to route_exist() it just checked if it was selected in zebra, not if it was installed in kernel. If this happens it is an indication of a FRR bug.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
