### PR TITLE
test: move sanity checks to a subsuite that aborts

### DIFF
--- a/test/case/all.yaml
+++ b/test/case/all.yaml
@@ -2,21 +2,9 @@
 - settings:
     test-spec: Readme.adoc
 
-- case: meta/reproducible.py
-  name: "Ensure Reproducible Env"
-  infamy:
-    specification: False
-
-- case: meta/bootorder.py
-  name: "Verify Bootorder"
-  infamy:
-    specification: False
-
-- case: meta/check-version.py
-  name: "Verify Software Version"
-  infamy:
-    specification: False
-
+- name: "Initial Sanity Checks"
+  suite: sanity.yaml
+  abort: true
 
 - name: "System"
   suite: system/all.yaml

--- a/test/case/sanity.yaml
+++ b/test/case/sanity.yaml
@@ -1,0 +1,15 @@
+---
+- case: meta/reproducible.py
+  name: "Ensure Reproducible Env"
+  infamy:
+    specification: False
+
+- case: meta/bootorder.py
+  name: "Verify Bootorder"
+  infamy:
+    specification: False
+
+- case: meta/check-version.py
+  name: "Verify Software Version"
+  infamy:
+    specification: False

--- a/test/case/sanity.yaml
+++ b/test/case/sanity.yaml
@@ -13,3 +13,7 @@
   name: "Verify Software Version"
   infamy:
     specification: False
+
+# This typically reveals problems triggered or caused by previous test runs.
+- case: misc/operational_all/test.py
+  name: "Get Operational Baseline"


### PR DESCRIPTION
## Description

Move all initial sanity checks to a new subsuite that has abort: true set. This means 9pm will abort the whole execution if any of the tests in the sanity suite fails. There's simply no point in running any other tests if the setup isn't sane.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [x] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
