### PR TITLE
confd: fix meta version key in generated configs

### DIFF
--- a/src/confd/bin/gen-version.in
+++ b/src/confd/bin/gen-version.in
@@ -3,7 +3,7 @@
 cat <<EOF
 {
   "infix-meta:meta": {
-    "infix-meta:version": "@VERSION@"
+    "version": "@VERSION@"
   }
 }
 EOF


### PR DESCRIPTION
## Description

The generated factory, failure, and test configs are always detected as version 0.0, so confd runs the migrate script on every boot in test mode and on every failure-config fallback.

Root cause: the gen-version script emits the version leaf with a namespace prefix:

    "infix-meta:meta": { "infix-meta:version": "1.9" }

While confd's maybe_migrate() and the migrate script both look up the bare "version" key, which is also what migrate writes back and what all static factory-config.cfg files in the tree use.

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [x] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
