### PR TITLE
test: ntp: revert netns server helper to BusyBox ntpd

### DIFF
--- a/test/case/ntp/client_stratum_selection/test.adoc
+++ b/test/case/ntp/client_stratum_selection/test.adoc
@@ -10,9 +10,8 @@ stratum level.
 This test validates NTP clock selection algorithm by configuring a client
 to sync from two servers with different stratum levels:
 
-- srv1: Test PC running chronyd, serving its local clock at stratum 5
-  with an honest root distance so clients tolerate startup transients
-- srv2: NTP server DUT syncing from srv1 (stratum 6)
+- srv1: Test PC running BusyBox ntpd, serving its local clock (-l)
+- srv2: NTP server DUT syncing from srv1 (one stratum higher)
 - client: NTP client DUT syncing from both servers
 
 Both servers sync to the same time source (srv2 syncs from srv1),

--- a/test/case/ntp/client_stratum_selection/test.py
+++ b/test/case/ntp/client_stratum_selection/test.py
@@ -7,9 +7,8 @@ stratum level.
 This test validates NTP clock selection algorithm by configuring a client
 to sync from two servers with different stratum levels:
 
-- srv1: Test PC running chronyd, serving its local clock at stratum 5
-  with an honest root distance so clients tolerate startup transients
-- srv2: NTP server DUT syncing from srv1 (stratum 6)
+- srv1: Test PC running BusyBox ntpd, serving its local clock (-l)
+- srv2: NTP server DUT syncing from srv1 (one stratum higher)
 - client: NTP client DUT syncing from both servers
 
 Both servers sync to the same time source (srv2 syncs from srv1),
@@ -32,7 +31,7 @@ import infamy.ntp_server as ntp_server
 
 # Network configuration
 ips = {
-    "srv1":   "192.168.1.1",   # chronyd on test PC
+    "srv1":   "192.168.1.1",   # BusyBox ntpd on test PC
     "srv2":   "192.168.1.2",   # Infix NTP server
     "client": "192.168.1.3"    # Infix NTP client
 }
@@ -172,7 +171,7 @@ with infamy.Test() as test:
                                 and srv1_stratum < srv2_stratum)
 
                 # srv2 synced before the client was configured, so the
-                # client's iburst samples already carry stratum 6
+                # client's iburst samples already carry the higher stratum
                 until(check_stratums, attempts=30)
                 print(f"srv1 and srv2 stratums verified as different")
 

--- a/test/infamy/ntp_server.py
+++ b/test/infamy/ntp_server.py
@@ -1,28 +1,15 @@
 """Start NTP server in the background"""
-import contextlib
-import os
-import tempfile
+import subprocess
 import time
 
 
 class Server:
-    """chronyd serving its local clock, never touching it (-x).
+    """BusyBox ntpd serving the local clock (-l), never touching it (-w)."""
 
-    stratum and distance control what is advertised to clients: the
-    stratum of the served time and the root distance (accuracy claim).
-    An honest, wide distance keeps clients from flagging the source as
-    unstable ('~') while their own clocks are still settling, which
-    BusyBox ntpd provoked by claiming near-zero dispersion.
-    """
-
-    def __init__(self, netns, stratum=5, distance=1.0):
+    def __init__(self, netns, iface="iface"):
+        self.iface = iface
         self.process = None
         self.netns = netns
-        self.stratum = stratum
-        self.distance = distance
-        self.rundir = None
-        self.logfile = None
-        self.pidfile = None
 
     def __enter__(self):
         self.start()
@@ -32,56 +19,19 @@ class Server:
         self.stop()
 
     def start(self):
-        # Instances in different netns share the filesystem, so the
-        # pidfile is per-instance.  It lives in /run/chrony because a
-        # host AppArmor profile for chronyd, present when the host runs
-        # chrony, attaches by binary path even inside the test container
-        # and allows no other pidfile location.  The command socket and
-        # port are disabled, nothing talks to chronyc here, and
-        # -f /dev/null keeps the image's default config out of it.
-        self.rundir = tempfile.TemporaryDirectory(prefix="chronyd-")
-        log = f"{self.rundir.name}/chronyd.log"
-        piddir = "/run/chrony"
-        try:
-            os.makedirs(piddir, exist_ok=True)
-        except OSError:
-            piddir = self.rundir.name
-        self.pidfile = f"{piddir}/{os.path.basename(self.rundir.name)}.pid"
-        cmd = [
-            "chronyd", "-d", "-x", "-f", "/dev/null", "-u", "root",
-            f"local stratum {self.stratum} distance {self.distance}",
-            "allow",
-            "cmdport 0",
-            "bindcmdaddress /",
-            f"pidfile {self.pidfile}",
-        ]
-        self.logfile = open(log, "w")
-        self.process = self.netns.popen(cmd, stderr=self.logfile)
+        cmd = ["ntpd", "-w", "-n", "-l", "-I", self.iface]
+        self.process = self.netns.popen(cmd, stderr=subprocess.DEVNULL)
 
-        # chronyd exits immediately on bad options or a missing binary
-        # behind an exec wrapper; fail loudly instead of serving nothing
+        # ntpd exits immediately on bad options or a missing interface;
+        # fail loudly instead of serving nothing
         time.sleep(1)
         if self.process.poll() is not None:
-            with open(log) as f:
-                output = f.read().strip()
             code = self.process.returncode
             self.stop()
-            raise RuntimeError(
-                f"chronyd failed to start (exit {code}): "
-                f"{output or 'no output; is chrony installed in the test environment?'}")
+            raise RuntimeError(f"ntpd failed to start (exit {code})")
 
     def stop(self):
         if self.process:
             self.process.terminate()
             self.process.wait()
             self.process = None
-        if self.logfile:
-            self.logfile.close()
-            self.logfile = None
-        if self.pidfile:
-            with contextlib.suppress(OSError):
-                os.unlink(self.pidfile)
-            self.pidfile = None
-        if self.rundir:
-            self.rundir.cleanup()
-            self.rundir = None


### PR DESCRIPTION
Commit 1d6017981 replaced BusyBox ntpd with chronyd in the netns server helper.  On some test PCs the test cannot stop chronyd, SIGTERM fails with EPERM, and the MACVLAN teardown times out.  Go back to ntpd, keep chrony in the container image.

## Description

<!--
  -- A description of changes, detailing *why* changes are made.
  -- Remember: assign a reviewer, or use @mentions if org. member.
  -->

## Checklist

Tick *relevant* boxes, this PR is-a or has-a:

- [ ] Bugfix
  - [ ] Regression tests
  - [ ] ChangeLog updates (for next release)
- [ ] Feature
  - [ ] YANG model change => revision updated?
  - [ ] Regression tests added?
  - [ ] ChangeLog updates (for next release)
  - [ ] Documentation added?
- [ ] Test changes
  - [ ] Checked in changed Readme.adoc (make test-spec)
  - [ ] Added new test to group Readme.adoc and yaml file
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (please detail in commit messages)
- [ ] Build related changes
- [ ] Documentation content changes
  - [ ] ChangeLog updated (for major changes)
- [ ] Other (please describe):
